### PR TITLE
Fixing max_errno comparison operator to match docs

### DIFF
--- a/ratchetio.php
+++ b/ratchetio.php
@@ -175,7 +175,7 @@ class RatchetioNotifier {
             return;
         }
         
-        if ($this->max_errno != -1 && $errno > $this->max_errno) {
+        if ($this->max_errno != -1 && $errno >= $this->max_errno) {
             // ignore
             return;
         }


### PR DESCRIPTION
The docs define the max_errno variable as "Max PHP error number to report. e.g. 1024 will ignore all errors E_USER_NOTICE or higher."
This fix ensures that a setting of 1024 will ignore all errors of type E_USER_NOTICE. Previously a setting of 1024 would ignore only errors with a higher increment than specified.
The documented behavior is more clear, therefore, the operator has been changed to match.
