### PR TITLE
Fixes for backtraces with poorly specified PHP behavior

### DIFF
--- a/ratchetio.php
+++ b/ratchetio.php
@@ -383,7 +383,16 @@ class RatchetioNotifier {
 
     private function build_exception_frames($exc) {
         $frames = array();
-        foreach ($exc->getTrace() as $frame) {
+        
+        $trace = $exc->getTrace();
+        $topframe = array_shift($trace);
+        $frames[] = array(
+            'filename' => $exc->getFile(),
+            'lineno' => $exc->getLine(),
+            'method' => $topframe['function']
+        );
+
+        foreach ($trace as $frame) {
             $frames[] = array(
                 'filename' => $frame['file'],
                 'lineno' => $frame['line'],
@@ -392,12 +401,6 @@ class RatchetioNotifier {
             );
         }
         
-        // add top-level file and line
-        $frames[] = array(
-            'filename' => $exc->getFile(),
-            'lineno' => $exc->getLine()
-        );
-
         return $frames;
     }
 
@@ -417,18 +420,14 @@ class RatchetioNotifier {
                 }
                 
                 $frames[] = array(
-                    'filename' => $frame['file'],
-                    'lineno' => $frame['line'],
+                    // Sometimes, file and line are not set and we must use a fake value. See:
+                    // http://stackoverflow.com/questions/4581969/why-is-debug-backtrace-not-including-line-number-sometimes
+                    'filename' => isset($frame['file']) ? $frame['file'] : "<internal>",
+                    'lineno' =>  isset($frame['line']) ? $frame['line'] : 0,
                     'method' => $frame['function']
                 );
             }
         }
-
-        // add top-level file and line
-        $frames[] = array(
-            'filename' => $errfile, 
-            'lineno' => $errline
-        );
 
         return $frames;
     }


### PR DESCRIPTION
Sometimes, PHP does not provide a line number and filename in a
debug_backtrace(), including cases where call_user_function() is used.
We must supply fake values, since the function name is still useful to log.

Also, in an Exception's getTrace(), the first frame does not include
a line and filename, but that information can be retrieved from the Exception's
getFile() and getLine() methods.

Lastly, since debug_backtrace() will always include the erroring line,
don't force include it, to avoid an inaccurate and misleading stack trace.
