### PR TITLE
Adding "pass" to the list of terms to scrub.

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -89,7 +89,7 @@ class RollbarNotifier {
     public $person = null;
     public $person_fn = null;
     public $root = '';
-    public $scrub_fields = array('passwd', 'password', 'secret', 'confirm_password', 
+    public $scrub_fields = array('passwd', 'pass', 'password', 'secret', 'confirm_password', 
         'password_confirmation', 'auth_token', 'csrf_token');
     public $shift_function = true;
     public $timeout = 3;


### PR DESCRIPTION
This is sent by Drupal's login page- and I can imagine is used by many other frameworks/CMSes, too.

Ps. I don't know if I'm okay to do any pull requests on this project, but I thought it was quite a bit of a security issue.
