### PR TITLE
Improved the composer package definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Monitors errors and exceptions and reports them to Rollbar",
   "type": "library",
   "keywords": ["logging", "debugging", "monitoring", "errors", "exceptions"],
-  "version": "0.6.3",
   "license": "MIT",
   "homepage": "http://github.com/rollbar/rollbar-php",
   "authors": [
@@ -17,6 +16,6 @@
     "email": "support@rollbar.com"
   },
   "autoload": {
-    "files": ["rollbar.php"]
+    "classmap": ["rollbar.php"]
   }
 }


### PR DESCRIPTION
- changed the autoload from files to classmap to really use autoloading (files is not autoloading, it is eagerloading needed for files defining functions rather than classes)
- removed the explicit version in the file, as this causes more harm than good for packages stored in VCS repos: Composer ignores it for branches, and will consider tags as invalid if the explicit version does not match the version generated based on the tag name.
