### PR TITLE
Check if constant exists before defining

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -78,7 +78,9 @@ class Rollbar {
 }
 
 // Send errors that have these levels
-define('ROLLBAR_INCLUDED_ERRNO_BITMASK', E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
+if (!defined('ROLLBAR_INCLUDED_ERRNO_BITMASK')) {
+        define('ROLLBAR_INCLUDED_ERRNO_BITMASK', E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR);
+}
 
 class RollbarNotifier {
     const VERSION = "0.9.4";


### PR DESCRIPTION
We are getting a lot of errors after upgrading to the latest version. The problem is that PHP cannot redefine a constant, so I added a check to see if it already exists before defining again.

Example error:
 [exec] 5) ApiControllerTest::testFeedbackSpecialChars
     [exec] PHPUnit_Framework_Exception: PHP Notice:  Constant ROLLBAR_INCLUDED_ERRNO_BITMASK already defined in /var/lib/jenkins/jobs/ci_development/workspace/protected/vendors/rollbar/rollbar.php on line 81
     [exec] PHP Stack trace:
