### PR TITLE
remove error level check when reporting arbitrary messages

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -376,11 +376,6 @@ class RollbarNotifier {
             return;
         }
 
-        if (error_reporting() === 0 && !$this->report_suppressed) {
-            // ignore
-            return;
-        }
-
         $data = $this->build_base_data();
         $data['level'] = strtolower($level);
 


### PR DESCRIPTION
Remove check for `error_reporting()` level and `report_suppressed` config flags when reporting custom/arbitrary messages. I do not see the correlation between these settings are preventing custom messages from being reported.
