### PR TITLE
Force cURL to use ipv4 for Dns resolving

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -780,6 +780,7 @@ class RollbarNotifier {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-Rollbar-Access-Token: ' . $access_token));
+        curl_setopt($ch, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4 );
         $result = curl_exec($ch);
         $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);


### PR DESCRIPTION
I had an issue today trying rollbar for the first time. After a few debugs i realised that curl_exec returned false.
curl_error returned it "cannot resolve host". After a few searches i managed to make it works by adding that curl option that forces it to resolve hostname into an IPV4 address.

I tested it on a vagrant VM using virtualBox on Windows 8.1
My VM : Ubuntu server 14.04, PHP 5.5.14, cUrl 7.35.0
