### PR TITLE
changed 'report_suppressed' behaviour to not report if set irrespective ...

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -231,7 +231,7 @@ class RollbarNotifier {
             return;
         }
 
-        if (error_reporting() === 0 && !$this->report_suppressed) {
+        if (error_reporting() === 0 || !$this->report_suppressed) {
             // ignore
             return;
         }
@@ -281,7 +281,7 @@ class RollbarNotifier {
             return;
         }
 
-        if (error_reporting() === 0 && !$this->report_suppressed) {
+        if (error_reporting() === 0 || !$this->report_suppressed) {
             // ignore
             return;
         }


### PR DESCRIPTION
...of error_reporting state

The previous behaviour prevented suppression if error reporting is enabled.  In my use case, this prevents me from setting report_suppressed based on the environment.  E.g. I don't want to report when running in my local dev env but I might want to on a group dev env.

This is my first ever pull request, pls be gentle, I have nfc whether I've done it right :)
