### PR TITLE
Fix php < 5.4 compatibility

### DIFF
--- a/rollbar.php
+++ b/rollbar.php
@@ -806,7 +806,7 @@ class RollbarNotifier {
         curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-Rollbar-Access-Token: ' . $access_token));
 
         if ($this->proxy) {
-            $proxy = is_array($this->proxy) ? $this->proxy : ['address' => $this->proxy];
+            $proxy = is_array($this->proxy) ? $this->proxy : array('address' => $this->proxy);
 
             if (isset($proxy['address'])) {
                 curl_setopt($ch, CURLOPT_PROXY, $proxy['address']);


### PR DESCRIPTION
The proxy feature merged in #44 introduced the array syntax that only works on php versions >=5.4 per http://php.net/manual/en/language.types.array.php introducing an implicit version dependency. This changes the syntax to `array()` so it still works on older versions of php.