### PR TITLE
Added trace chain of previous exceptions.

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -176,6 +176,10 @@ class RollbarNotifier {
 
     public function report_exception($exc, $extra_data = null, $payload_data = null) {
         try {
+            if (!$exc instanceof Exception) {
+                throw new Exception('Report exception requires an instance of Exception.');
+            }
+
             return $this->_report_exception($exc, $extra_data, $payload_data);
         } catch (Exception $e) {
             try {
@@ -232,9 +236,9 @@ class RollbarNotifier {
     }
 
     /**
-     * @param $exc Exception
+     * @param Exception $exc
      */
-    protected function _report_exception($exc, $extra_data = null, $payload_data = null) {
+    protected function _report_exception(Exception $exc, $extra_data = null, $payload_data = null) {
         if (!$this->check_config()) {
             return;
         }
@@ -246,24 +250,12 @@ class RollbarNotifier {
 
         $data = $this->build_base_data();
 
-        // exception info
-        $message = 'unknown';
-        if (method_exists($exc, 'getMessage')) {
-            $message = $exc->getMessage();
-        }
-
         $data['body'] = array(
-            'trace' => array(
-                'frames' => $this->build_exception_frames($exc),
-                'exception' => array(
-                    'class' => get_class($exc),
-                    'message' => $message
-                )
-            )
+            'trace' => $this->build_exception_trace($exc, $extra_data),
         );
 
-        if ($extra_data !== null) {
-            $data['body']['trace']['extra'] = $extra_data;
+        if ($exc->getPrevious() instanceof Exception) {
+            $data['body']['trace_chain'] = $this->build_exception_trace_chain($exc);
         }
 
         // request, server, person data
@@ -578,15 +570,52 @@ class RollbarNotifier {
     }
 
     /**
-     * @param $exc Exception
+     * @param Exception $exc
+     * @param mixed $extra_data
      * @return array
      */
-    protected function build_exception_frames($exc) {
-        $frames = array();
+    protected function build_exception_trace(Exception $exc, $extra_data = null)
+    {
+        $message = $exc->getMessage();
 
-        if (!method_exists($exc, 'getTrace')) {
-            return $frames;
+        $trace = array(
+            'frames' => $this->build_exception_frames($exc),
+            'exception' => array(
+                'class' => get_class($exc),
+                'message' => !empty($message) ? $message : 'unknown',
+            ),
+        );
+
+        if ($extra_data !== null) {
+            $trace['extra'] = $extra_data;
         }
+
+        return $trace;
+    }
+
+    /**
+     * @param Exception $exc
+     * @return array
+     */
+    protected function build_exception_trace_chain(Exception $exc)
+    {
+        $chain = [];
+        $previous = $exc->getPrevious();
+
+        while ($previous instanceof Exception ) {
+            $chain[] = $this->build_exception_trace($previous);
+            $previous = $previous->getPrevious();
+        }
+
+        return $chain;
+    }
+
+    /**
+     * @param Exception $exc
+     * @return array
+     */
+    protected function build_exception_frames(Exception $exc) {
+        $frames = array();
 
         foreach ($exc->getTrace() as $frame) {
             $frames[] = array(

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -599,7 +599,7 @@ class RollbarNotifier {
      */
     protected function build_exception_trace_chain(Exception $exc)
     {
-        $chain = [];
+        $chain = array();
         $previous = $exc->getPrevious();
 
         while ($previous instanceof Exception ) {


### PR DESCRIPTION
Added logging of previous exceptions, which is support by the Rollbar API.

Can this be merged as soon as possible? At the moment the exceptions that we are logging to Rollbar are effectively useless, because they do not show the previous exceptions. In most PHP Frameworks (we're using Zend 2) the framework will catch and re-throw original exceptions, so we're not currently able to track down the original bug without previous exceptions also being logged.