### PR TITLE
Current URL Detection: Use port 443 if protocol is https and no port is detected

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -546,6 +546,8 @@ class RollbarNotifier {
             $port = $_SERVER['HTTP_X_FORWARDED_PORT'];
         } else if (!empty($_SERVER['SERVER_PORT'])) {
             $port = $_SERVER['SERVER_PORT'];
+        } else if ($proto == 'https') {
+            $port = 443;
         } else {
             $port = 80;
         }


### PR DESCRIPTION
My webserver configuration doesn't publish the SERVER_PORT (only god knows why...). So if the protocol is https, do not use the default port 80, but instead use 443.