### PR TITLE
Require the curl extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
   "autoload": {
     "classmap": ["src/rollbar.php"]
   },
+  "require": {
+    "ext-curl": "*"
+  },
   "require-dev": {
     "phpunit/phpunit": "4.5.*",
     "mockery/mockery": "0.9.*"


### PR DESCRIPTION
I would also add a minimum PHP requirement.