### PR TITLE
Improve param scrubbing

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -500,7 +500,7 @@ class RollbarNotifier {
     protected function _key_should_be_scrubbed($key, $potential_regex_filters) {
         if (in_array($key, $this->scrub_fields)) return true;
         foreach ($potential_regex_filters as $potential_regex) {
-            if (preg_match($potential_regex, $key)) return true;
+            if (@preg_match($potential_regex, $key)) return true;
         }
         return false;
     }

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -328,7 +328,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         );
         $_POST = array(
             'post_key' => 'post_value',
-            'password' => 'hunter2',
+            'PASSWORD' => 'hunter2',
             'something_special' => 'excalibur',
             'array_key' => array(
                 'subarray_key' => 'subarray_value',
@@ -338,7 +338,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         );
         $_SESSION = array(
             'session_key' => 'session_value',
-            'session_password' => 'hunter2'
+            'SeSsIoN_pAssWoRd' => 'hunter2'
         );
         $_SERVER = array(
             'HTTP_HOST' => 'example.com',
@@ -370,7 +370,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
 
         $this->assertSame(array(
             'post_key' => 'post_value',
-            'password' => '*******',
+            'PASSWORD' => '*******',
             'something_special' => '*********',
             'array_key' => array(
                 'subarray_key' => 'subarray_value',
@@ -381,7 +381,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
 
         $this->assertSame(array(
             'session_key' => 'session_value',
-            'session_password' => '*******',
+            'SeSsIoN_pAssWoRd' => '*******',
         ), $payload['data']['request']['session']);
 
         $this->assertSame(array(

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -330,6 +330,9 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
             'post_key' => 'post_value',
             'PASSWORD' => 'hunter2',
             'something_special' => 'excalibur',
+            'array_token' => array(
+                'secret_key' => 'secret_value'
+            ),
             'array_key' => array(
                 'subarray_key' => 'subarray_value',
                 'subarray_password' => 'hunter2',
@@ -372,6 +375,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
             'post_key' => 'post_value',
             'PASSWORD' => '*******',
             'something_special' => '*********',
+            'array_token' => '*',
             'array_key' => array(
                 'subarray_key' => 'subarray_value',
                 'subarray_password' => '*******',

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -320,6 +320,76 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('example.com', $payload['data']['request']['headers']['Host']);
     }
 
+    public function testParamScrubbing() {
+        $_GET = array(
+            'get_key' => 'get_value',
+            'auth_token' => '12345',
+            'client_password' => 'hunter2',
+        );
+        $_POST = array(
+            'post_key' => 'post_value',
+            'password' => 'hunter2',
+            'something_special' => 'excalibur',
+            'array_key' => array(
+                'subarray_key' => 'subarray_value',
+                'subarray_password' => 'hunter2',
+                'something_special' => 'excalibur'
+            )
+        );
+        $_SESSION = array(
+            'session_key' => 'session_value',
+            'session_password' => 'hunter2'
+        );
+        $_SERVER = array(
+            'HTTP_HOST' => 'example.com',
+            'REQUEST_URI' => '/example.php',
+            'REQUEST_METHOD' => 'POST',
+            'HTTP_PASSWORD' => 'hunter2',
+            'HTTP_AUTH_TOKEN' => '12345',
+            'REMOTE_ADDR' => '127.0.0.1'
+        );
+
+        $config = self::$simpleConfig;
+        $config['scrub_fields'] = array('something_special', '/token|password/i');
+        
+        $notifier = m::mock('RollbarNotifier[send_payload]', array($config))
+            ->shouldAllowMockingProtectedMethods();
+        $notifier->shouldReceive('send_payload')->once()
+            ->with(m::on(function($input) use (&$payload) {
+                $payload = $input;
+                return true;
+            }));
+
+        $uuid = $notifier->report_message('Hello');
+
+        $this->assertSame(array(
+            'get_key' => 'get_value',
+            'auth_token' => '*****',
+            'client_password' => '*******',
+        ), $payload['data']['request']['GET']);
+
+        $this->assertSame(array(
+            'post_key' => 'post_value',
+            'password' => '*******',
+            'something_special' => '*********',
+            'array_key' => array(
+                'subarray_key' => 'subarray_value',
+                'subarray_password' => '*******',
+                'something_special' => '*********',
+            )
+        ), $payload['data']['request']['POST']);
+
+        $this->assertSame(array(
+            'session_key' => 'session_value',
+            'session_password' => '*******',
+        ), $payload['data']['request']['session']);
+
+        $this->assertSame(array(
+            'Host' => 'example.com',
+            'Password' => '*******',
+            'Auth-Token' => '*****',
+        ), $payload['data']['request']['headers']);
+    }
 
     /* --- Internal exceptions --- */
 


### PR DESCRIPTION
This PR adds several improvements to param scrubbing:

- regexes can be used in the `scrub_fields` list. ex: `$config['scrub_fields'] = array('/password/i');`
- If a param has an array as a value, the array will be recursively scrubbed
- `$_GET` and headers are also scrubbed before being recorded