### PR TITLE
Change `branch` to default to `null` instead of `'master'`

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -93,7 +93,7 @@ class RollbarNotifier {
     public $base_api_url = 'https://api.rollbar.com/api/1/';
     public $batch_size = 50;
     public $batched = true;
-    public $branch = 'master';
+    public $branch = null;
     public $capture_error_backtraces = true;
     public $code_version = null;
     public $environment = 'production';

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -395,6 +395,39 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         ), $payload['data']['request']['headers']);
     }
 
+    public function testServerBranchDefaultsEmpty() {
+        $config = self::$simpleConfig;
+
+        $notifier = m::mock('RollbarNotifier[send_payload]', array($config))
+            ->shouldAllowMockingProtectedMethods();
+        $notifier->shouldReceive('send_payload')->once()
+            ->with(m::on(function($input) use (&$payload) {
+                $payload = $input;
+                return true;
+            }));
+
+        $uuid = $notifier->report_message('Hello');
+
+        $this->assertFalse(isset($payload['data']['server']['branch']));
+    }
+
+    public function testServerBranchConfig() {
+        $config = self::$simpleConfig;
+        $config['branch'] = 'my-branch';
+
+        $notifier = m::mock('RollbarNotifier[send_payload]', array($config))
+            ->shouldAllowMockingProtectedMethods();
+        $notifier->shouldReceive('send_payload')->once()
+            ->with(m::on(function($input) use (&$payload) {
+                $payload = $input;
+                return true;
+            }));
+
+        $uuid = $notifier->report_message('Hello');
+
+        $this->assertEquals($payload['data']['server']['branch'], 'my-branch');
+    }
+
     /* --- Internal exceptions --- */
 
     public function testInternalExceptionInReportException() {


### PR DESCRIPTION
This makes more sense (branch is optional, so there's no reason for it
to have a default value), and make the Rollbar UI's 'default branch'
feature work as expected.