### PR TITLE
scrubbing URL query params

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -457,7 +457,7 @@ class RollbarNotifier {
     protected function build_request_data() {
         if ($this->_request_data === null) {
             $request = array(
-                'url' => $this->current_url(),
+                'url' => $this->scrub_url($this->current_url()),
                 'user_ip' => $this->user_ip(),
                 'headers' => $this->headers(),
                 'method' => isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null,
@@ -476,6 +476,15 @@ class RollbarNotifier {
         }
 
         return $this->_request_data;
+    }
+
+    protected function scrub_url($url) {
+        $url_query = parse_url($url, PHP_URL_QUERY);
+        if (!$url_query) return $url;
+        parse_str($url_query, $parsed_output);
+        $scrubbed_params = $this->scrub_request_params($parsed_output);
+        $scrubbed_url = str_replace($url_query, http_build_query($scrubbed_params), $url);
+        return $scrubbed_url;
     }
 
     protected function scrub_request_params($params) {

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -498,7 +498,7 @@ class RollbarNotifier {
                 $scrubbed[$k] = $this->_scrub($v, $replacement);
             } elseif (is_array($v)) {
                 // recursively handle array params
-                $scrubbed[$k] = $this->scrub_request_params($v);
+                $scrubbed[$k] = $this->scrub_request_params($v, $replacement);
             } else {
                 $scrubbed[$k] = $v;
             }

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -482,19 +482,20 @@ class RollbarNotifier {
         $url_query = parse_url($url, PHP_URL_QUERY);
         if (!$url_query) return $url;
         parse_str($url_query, $parsed_output);
-        $scrubbed_params = $this->scrub_request_params($parsed_output);
+        // using x since * requires URL-encoding
+        $scrubbed_params = $this->scrub_request_params($parsed_output, 'x');
         $scrubbed_url = str_replace($url_query, http_build_query($scrubbed_params), $url);
         return $scrubbed_url;
     }
 
-    protected function scrub_request_params($params) {
+    protected function scrub_request_params($params, $replacement = '*') {
         $scrubbed = array();
         $potential_regex_filters = array_filter($this->scrub_fields, function($field) {
             return strpos($field, '/') === 0;
         });
         foreach ($params as $k => $v) {
             if ($this->_key_should_be_scrubbed($k, $potential_regex_filters)) {
-                $scrubbed[$k] = $this->_scrub($v);
+                $scrubbed[$k] = $this->_scrub($v, $replacement);
             } elseif (is_array($v)) {
                 // recursively handle array params
                 $scrubbed[$k] = $this->scrub_request_params($v);
@@ -514,9 +515,9 @@ class RollbarNotifier {
         return false;
     }
 
-    protected function _scrub($value) {
+    protected function _scrub($value, $replacement = '*') {
         $count = is_array($value) ? count($value) : strlen($value);
-        return str_repeat('*', $count);
+        return str_repeat($replacement, $count);
     }
 
     protected function headers() {

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -345,7 +345,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         );
         $_SERVER = array(
             'HTTP_HOST' => 'example.com',
-            'REQUEST_URI' => '/example.php',
+            'REQUEST_URI' => '/example.php?access_token=12345&harry=potter',
             'REQUEST_METHOD' => 'POST',
             'HTTP_PASSWORD' => 'hunter2',
             'HTTP_AUTH_TOKEN' => '12345',
@@ -393,6 +393,9 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
             'Password' => '*******',
             'Auth-Token' => '*****',
         ), $payload['data']['request']['headers']);
+
+        // %2A is the the urlencoded version of *
+        $this->assertSame("http://example.com/example.php?access_token=%2A%2A%2A%2A%2A&harry=potter", $payload['data']['request']['url']);
     }
 
     public function testServerBranchDefaultsEmpty() {

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -394,8 +394,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
             'Auth-Token' => '*****',
         ), $payload['data']['request']['headers']);
 
-        // %2A is the the urlencoded version of *
-        $this->assertSame("http://example.com/example.php?access_token=%2A%2A%2A%2A%2A&harry=potter", $payload['data']['request']['url']);
+        $this->assertSame("http://example.com/example.php?access_token=xxxxx&harry=potter", $payload['data']['request']['url']);
     }
 
     public function testServerBranchDefaultsEmpty() {

--- a/tests/RollbarNotifierTest.php
+++ b/tests/RollbarNotifierTest.php
@@ -401,6 +401,7 @@ class RollbarNotifierTest extends PHPUnit_Framework_TestCase {
         return  array(
             array("/example.php", array('blah'), "http://example.com/example.php"),
             array("/example.php?blah=hello", array('blah'), "http://example.com/example.php?blah=xxxxx"),
+            array("/example.php?nested%5Bblah%5D=hello", array('blah'), "http://example.com/example.php?nested%5Bblah%5D=xxxxx"),
             array("/nonsense39423t#$Y*%@(Y", array('blah'), "http://example.com/nonsense39423t#$Y*%@(Y"),
             array("/nonsense_params?39423t=#$Y*%@(Y", array('blah'), "http://example.com/nonsense_params?39423t=#$Y*%@(Y"),
             array("/nonsense_with_spaces?39423t=#$Y *%@(Y", array('blah'), "http://example.com/nonsense_with_spaces?39423t=#$Y *%@(Y"),


### PR DESCRIPTION
This PR extends scrubbing to the URL that shows up in rollbar. Currently if a sensitive param is passed as a URL query parameter, it's scrubbed in the GET params list, but shows up in plain text as part of the URL.