### PR TITLE
Use strict comparisons when matching scrub keys

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -508,7 +508,7 @@ class RollbarNotifier {
     }
 
     protected function _key_should_be_scrubbed($key, $potential_regex_filters) {
-        if (in_array($key, $this->scrub_fields)) return true;
+        if (in_array($key, $this->scrub_fields, true)) return true;
         foreach ($potential_regex_filters as $potential_regex) {
             if (@preg_match($potential_regex, $key)) return true;
         }


### PR DESCRIPTION
Better solution for bug highlighted in PR #64.

Because of the loose comparison used by default by `in_array()`, the code below causes the output that follows:
```
$fruits = ['apple', 'banana', 'cherry'];
var_dump(in_array(0, $fruits));
var_dump(in_array(0, $fruits, true));
```
```
bool(true)
bool(false)
```
In the rollbar library, this means that any zero indexed array always has its first element scrubbed.