### PR TITLE
Fix E_PARSE reporting level

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -348,6 +348,9 @@ class RollbarNotifier {
                 $level = 'warning';
                 $constant = 'E_WARNING';
                 break;
+            case 4:
+                $level = 'critical';
+                $constant = 'E_PARSE';
             case 8:
                 $level = 'info';
                 $constant = 'E_NOTICE';


### PR DESCRIPTION
Add E_PARSE at the correct reporting level. It's a fatal level, so critical is appropriate.