### PR TITLE
Changed all references of Exception to be \Throwable…

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -4,6 +4,10 @@
  *
  * Unless you need multiple RollbarNotifier instances in the same project, use this.
  */
+if ( !defined( 'BASE_EXCEPTION' ) ) {
+	define( 'BASE_EXCEPTION', version_compare( phpversion(), '7.0', '<' )? '\Exception': '\Throwable' );
+}
+
 class Rollbar {
     /** @var RollbarNotifier */
     public static $instance = null;
@@ -177,8 +181,8 @@ class RollbarNotifier {
 
     public function report_exception($exc, $extra_data = null, $payload_data = null) {
         try {
-            if (!$exc instanceof \Throwable) {
-                throw new Exception('Report exception requires an instance of \Throwable.');
+            if ( !is_a( $exc, BASE_EXCEPTION ) ) {
+                throw new Exception(sprintf('Report exception requires an instance of %s.', BASE_EXCEPTION ));
             }
 
             return $this->_report_exception($exc, $extra_data, $payload_data);
@@ -237,9 +241,9 @@ class RollbarNotifier {
     }
 
     /**
-     * @param \Throwable $exc
+     * @param \Throwable|\Exception $exc
      */
-    protected function _report_exception(\Throwable $exc, $extra_data = null, $payload_data = null) {
+    protected function _report_exception( $exc, $extra_data = null, $payload_data = null) {
         if (!$this->check_config()) {
             return;
         }
@@ -604,11 +608,11 @@ class RollbarNotifier {
     }
 
     /**
-     * @param \Throwable $exc
+     * @param \Throwable|\Exception $exc
      * @param mixed $extra_data
      * @return array
      */
-    protected function build_exception_trace(\Throwable $exc, $extra_data = null)
+    protected function build_exception_trace($exc, $extra_data = null)
     {
         $message = $exc->getMessage();
 
@@ -628,18 +632,18 @@ class RollbarNotifier {
     }
 
     /**
-     * @param \Throwable $exc
+     * @param \Throwable|\Exception $exc
      * @param array $extra_data
      * @return array
      */
-    protected function build_exception_trace_chain(\Throwable $exc, $extra_data = null)
+    protected function build_exception_trace_chain( $exc, $extra_data = null)
     {
         $chain = array();
         $chain[] = $this->build_exception_trace($exc, $extra_data);
 
         $previous = $exc->getPrevious();
 
-        while ($previous instanceof \Throwable) {
+        while ( is_a( $previous, BASE_EXCEPTION ) ) {
             $chain[] = $this->build_exception_trace($previous);
             $previous = $previous->getPrevious();
         }
@@ -648,10 +652,10 @@ class RollbarNotifier {
     }
 
     /**
-     * @param \Throwable $exc
+     * @param \Throwable|\Exception $exc
      * @return array
      */
-    protected function build_exception_frames(\Throwable $exc) {
+    protected function build_exception_frames($exc) {
         $frames = array();
 
         foreach ($exc->getTrace() as $frame) {

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -177,8 +177,8 @@ class RollbarNotifier {
 
     public function report_exception($exc, $extra_data = null, $payload_data = null) {
         try {
-            if (!$exc instanceof Exception) {
-                throw new Exception('Report exception requires an instance of Exception.');
+            if (!$exc instanceof \Throwable) {
+                throw new Exception('Report exception requires an instance of \Throwable.');
             }
 
             return $this->_report_exception($exc, $extra_data, $payload_data);
@@ -237,9 +237,9 @@ class RollbarNotifier {
     }
 
     /**
-     * @param Exception $exc
+     * @param \Throwable $exc
      */
-    protected function _report_exception(Exception $exc, $extra_data = null, $payload_data = null) {
+    protected function _report_exception(\Throwable $exc, $extra_data = null, $payload_data = null) {
         if (!$this->check_config()) {
             return;
         }
@@ -604,11 +604,11 @@ class RollbarNotifier {
     }
 
     /**
-     * @param Exception $exc
+     * @param \Throwable $exc
      * @param mixed $extra_data
      * @return array
      */
-    protected function build_exception_trace(Exception $exc, $extra_data = null)
+    protected function build_exception_trace(\Throwable $exc, $extra_data = null)
     {
         $message = $exc->getMessage();
 
@@ -628,18 +628,18 @@ class RollbarNotifier {
     }
 
     /**
-     * @param Exception $exc
+     * @param \Throwable $exc
      * @param array $extra_data
      * @return array
      */
-    protected function build_exception_trace_chain(Exception $exc, $extra_data = null)
+    protected function build_exception_trace_chain(\Throwable $exc, $extra_data = null)
     {
         $chain = array();
         $chain[] = $this->build_exception_trace($exc, $extra_data);
 
         $previous = $exc->getPrevious();
 
-        while ($previous instanceof Exception) {
+        while ($previous instanceof \Throwable) {
             $chain[] = $this->build_exception_trace($previous);
             $previous = $previous->getPrevious();
         }
@@ -648,10 +648,10 @@ class RollbarNotifier {
     }
 
     /**
-     * @param Exception $exc
+     * @param \Throwable $exc
      * @return array
      */
-    protected function build_exception_frames(Exception $exc) {
+    protected function build_exception_frames(\Throwable $exc) {
         $frames = array();
 
         foreach ($exc->getTrace() as $frame) {


### PR DESCRIPTION
 so that all type of Exceptions in PHP7 can be caught by Rollbar.
Maybe you want to start a php7 repo so there's no clash?