### PR TITLE
Fix the E_PARSE error level, forgot a `break`

### DIFF
--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -351,6 +351,7 @@ class RollbarNotifier {
             case 4:
                 $level = 'critical';
                 $constant = 'E_PARSE';
+		break;
             case 8:
                 $level = 'info';
                 $constant = 'E_NOTICE';


### PR DESCRIPTION
Add missing break statement, left E_PARSE errors in `info` level.