### PR TITLE
Specifying latest PSR log to avoid minimum-stability issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 
   "require": {
     "ext-curl": "*",
-    "psr/log": "dev-master",
+    "psr/log": "~1.0.2",
     "packfire/php5.3-compat": "*"
   },
 


### PR DESCRIPTION
If a 3rd party has minimum-stability: stable set in their composer.json, they are un able to install rollbar-php.  This is due to rollbar-php requiring psr/log @ dev-master which is not a stable release.

It is best practice to include a specific version for a vendor library