### PR TITLE
Logging to Fluentd and StdErr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swo
 vendor
 composer.lock
+.idea
+composer.phar

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ Default: empty array, meaning all errors are reported.
   </dd>
 
   <dt>handler</dt>
-  <dd>Either `'blocking'` or `'agent'`. `'blocking'` uses curl to send requests immediately; `'agent'` writes a relay log to be consumed by [rollbar-agent](https://github.com/rollbar/rollbar-agent).
+  <dd>Either `'blocking'`, `'agent'` or `'errorlog'`. `'blocking'` uses curl to send requests immediately; `'agent'` writes a relay log to be consumed by [rollbar-agent](https://github.com/rollbar/rollbar-agent)
+  and `'errorlog'` writes directly to the error log of PHP.
 
 Default: `'blocking'`
   </dd>

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ]
   },
   "require": {
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "fluent/logger": "v1.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "4.5.*",

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -7,7 +7,7 @@ include 'Level.php';
  * Unless you need multiple RollbarNotifier instances in the same project, use this.
  */
 if ( !defined( 'BASE_EXCEPTION' ) ) {
-	define( 'BASE_EXCEPTION', version_compare( phpversion(), '7.0', '<' )? '\Exception': '\Throwable' );
+    define( 'BASE_EXCEPTION', version_compare( phpversion(), '7.0', '<' )? '\Exception': '\Throwable' );
 }
 
 class Rollbar {
@@ -436,7 +436,7 @@ class RollbarNotifier {
             case 4:
                 $level = Level::CRITICAL;
                 $constant = 'E_PARSE';
-		break;
+                break;
             case 8:
                 $level = Level::INFO;
                 $constant = 'E_NOTICE';
@@ -989,7 +989,13 @@ class RollbarNotifier {
     }
 
     protected function _send_payload_errorlog($payload) {
-        error_log(json_encode($payload) . PHP_EOL);
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $payload = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } else {
+            $payload = json_encode($payload);
+        }
+
+        file_put_contents('php://stderr', $payload);
     }
 
     /**
@@ -1035,7 +1041,13 @@ class RollbarNotifier {
         $this->log_info("Writing batch to errorlog");
 
         foreach ($batch as $item) {
-            error_log(json_encode($item) . PHP_EOL);
+            if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+                $item = json_encode($item, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            } else {
+                $item = json_encode($item);
+            }
+
+            file_put_contents('php://stderr', $item);
         }
     }
 

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -161,7 +161,8 @@ class RollbarNotifier {
         'capture_error_backtraces', 'code_version', 'environment', 'error_sample_rates', 'handler',
         'agent_log_location', 'host', 'logger', 'included_errno', 'person', 'person_fn', 'root', 'checkIgnore',
         'scrub_fields', 'shift_function', 'timeout', 'report_suppressed', 'use_error_reporting', 'proxy',
-        'include_error_code_context', 'include_exception_code_context', 'enable_utf8_sanitization');
+        'include_error_code_context', 'include_exception_code_context', 'enable_utf8_sanitization',
+        'fluent_host', 'fluent_port', 'fluent_tag');
 
     // cached values for request/server/person data
     private $_php_context = null;

--- a/src/rollbar.php
+++ b/src/rollbar.php
@@ -131,6 +131,7 @@ class RollbarNotifier {
     public $capture_error_backtraces = true;
     public $code_version = null;
     public $environment = 'production';
+    public $framework = 'php';
     public $error_sample_rates = array();
     // available handlers: blocking, agent, fluent, errorlog
     public $handler = 'blocking';
@@ -158,7 +159,7 @@ class RollbarNotifier {
     public $enable_utf8_sanitization = true;
 
     private $config_keys = array('access_token', 'base_api_url', 'batch_size', 'batched', 'branch',
-        'capture_error_backtraces', 'code_version', 'environment', 'error_sample_rates', 'handler',
+        'capture_error_backtraces', 'code_version', 'environment', 'framework', 'error_sample_rates', 'handler',
         'agent_log_location', 'host', 'logger', 'included_errno', 'person', 'person_fn', 'root', 'checkIgnore',
         'scrub_fields', 'shift_function', 'timeout', 'report_suppressed', 'use_error_reporting', 'proxy',
         'include_error_code_context', 'include_exception_code_context', 'enable_utf8_sanitization',
@@ -924,7 +925,7 @@ class RollbarNotifier {
             'environment' => $this->environment,
             'level' => $level,
             'language' => 'php',
-            'framework' => 'php',
+            'framework' => $this->framework,
             'php_context' => $this->_php_context,
             'notifier' => array(
                 'name' => 'rollbar-php',


### PR DESCRIPTION
For my dockerized Laravel Application I have implemented centralized logging with Fluentd. My php-fpm outputs any error on stderr inside of the container. The logs of the containers are forwarded to fluentd by the fluentd logging driver of docker.

To already have pre-formatted php error logs I extended the current stable release. I also chose the v0.18.2 release because the master is not yet supported by laravel-rollbar.

