### PR TITLE
Fluentd errorlog from master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   "require": {
     "ext-curl": "*",
     "psr/log": "dev-master",
-    "packfire/php5.3-compat": "*"
+    "packfire/php5.3-compat": "*",
+    "fluent/logger": "v1.0.0"
   },
 
   "require-dev": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -181,6 +181,15 @@ class Config
                 );
             }
         }
+
+        if (isset($c['handler']) && 'errorlog' == $c['handler']) {
+            $default = "Rollbar\Senders\ErrorlogSender";
+
+            if (isset($c['message_type'])) {
+                $c['senderOptions'] = ['messageType' => $c['message_type']];
+            }
+        }
+
         $this->setupWithOptions($c, "sender", $expected, $default);
     }
 

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -501,7 +501,7 @@ class DataBuilder implements DataBuilderInterface
                 $request->$key = $val;
             }
         }
-        if (is_array($_SESSION) && count($_SESSION) > 0) {
+        if (isset($_SESSION) && is_array($_SESSION) && count($_SESSION) > 0) {
             $request->session = self::scrub($_SESSION, $scrubFields);
         }
         return $request;

--- a/src/Senders/ErrorlogSender.php
+++ b/src/Senders/ErrorlogSender.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Rollbar\Senders;
+
+use Rollbar\Payload\Payload;
+
+class ErrorlogSender implements SenderInterface
+{
+    const OPERATING_SYSTEM = 0;
+    const SAPI = 4;
+
+    protected $messageType;
+    protected $expandNewlines;
+
+    public function __construct($opts)
+    {
+        $this->messageType = isset($opts['messageType']) ? $opts['messageType'] : self::OPERATING_SYSTEM;
+
+        if ($this->messageType && false === in_array($this->messageType, [self::OPERATING_SYSTEM, self::SAPI])) {
+            $message = sprintf('The given message type "%s" is not supported', print_r($this->messageType, true));
+            throw new \InvalidArgumentException($message);
+        }
+    }
+
+    public function send(Payload $payload, $accessToken)
+    {
+        error_log((string) json_encode($payload->jsonSerialize()) . "\n", $this->messageType);
+    }
+}

--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Rollbar\Senders;
+
+use Fluent\Logger\FluentLogger;
+use Rollbar\Payload\Payload;
+
+class FLuentSender implements SenderInterface
+{
+    /** @var FluentLogger  */
+    private $fluentLogger = null;
+    private $fluentHost = FluentLogger::DEFAULT_ADDRESS;
+    private $fluentPort = FluentLogger::DEFAULT_LISTEN_PORT;
+    private $fluentTag = 'rollbar';
+
+    public function __construct($opts)
+    {
+        if (isset($opts['fluentHost'])) {
+            $this->fluentHost = $opts['fluentHost'];
+        }
+
+        if (isset($opts['fluentPort'])) {
+            $this->fluentPort = $opts['fluentPort'];
+        }
+
+        if (isset($opts['fluentTag'])) {
+            $this->fluentTag = $opts['fluentTag'];
+        }
+    }
+
+    public function send(Payload $payload, $accessToken)
+    {
+        if (empty($this->fluentLogger)) {
+            $this->loadFluentLogger();
+        }
+
+        $this->fluentLogger->post($this->fluentTag, $payload->jsonSerialize());
+    }
+
+    private function loadFluentLogger()
+    {
+        $this->fluentLogger = new FluentLogger($this->fluentHost, $this->fluentPort);
+    }
+}

--- a/tests/ErrorlogTest.php
+++ b/tests/ErrorlogTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Rollbar;
+
+class ErrorlogTest extends \PHPUnit_Framework_TestCase
+{
+    private $path = '/tmp/rollbar-php';
+    private $error_log = null;
+
+    protected function setUp()
+    {
+        if (!file_exists($this->path)) {
+            mkdir($this->path);
+        }
+    }
+
+    public function testErrorlog()
+    {
+        $this->error_log = ini_set('error_log', $this->path . '/rollbar-errorlog.rollbar');
+        Rollbar::init(array(
+            'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
+            'environment' => 'testing',
+            'handler' => 'errorlog'
+        ), false, false, false);
+        $logger = Rollbar::logger();
+        $logger->info("this is a test");
+        $file = fopen($this->path . '/rollbar-errorlog.rollbar', 'r');
+        $line = fgets($file);
+        $this->assertContains('this is a test', $line);
+    }
+
+    protected function tearDown()
+    {
+        $this->rrmdir($this->path);
+        ini_set('error_log', $this->error_log);
+    }
+
+    private function rrmdir($dir)
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $objects = scandir($dir);
+        foreach ($objects as $object) {
+            if ($object != "." && $object != "..") {
+                if (filetype($dir . "/" . $object) == "dir") {
+                    $this->rrmdir($dir . "/" . $object);
+                } else {
+                    unlink($dir . "/" . $object);
+                }
+            }
+        }
+        reset($objects);
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
For my dockerized Laravel Application I have implemented centralized logging with Fluentd. My php-fpm outputs any error on stderr inside of the container. The logs of the containers are forwarded to fluentd by the fluentd logging driver of docker.