### PR TITLE
GitHub Issue #123: Enable code coverage and integrate with Code Climate + Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor
 composer.lock
 .idea
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script: composer test
 
 addons:
   code_climate:
-    repo_token: 78d27c9cf1bb57964da0d98f1e40b6aa92c9c7d06a7a4268a0b87d7d921c4123
+    repo_token: 2c9de7918bc4d249e793a84d5767db500e404d79d2bc497ba13deb6a71989126
 
 after_success:
   - vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ install: composer install --no-interaction
 
 script: composer test
 
-addons:
-  code_climate:
-    repo_token:
-      secure: Zh3sCkr1LizGn7cB3DVAVDeYCS4XQJ7sEgqbLyZFA+0YTKbT7kP0tIWx0juXF3Twps/wEIAz4Q7snK1aGzqkg53wcedbx27TSViSnmCMr7ViVrGPj9QMNzoB6xS5sG3LPbQ1Qa6osGL4IbFSiCkEuNYj9NGFYCAlT6qej1fnZ/c=
-
 after_success:
   - vendor/bin/test-reporter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script: composer test
 
 addons:
   code_climate:
-    repo_token: 2c9de7918bc4d249e793a84d5767db500e404d79d2bc497ba13deb6a71989126
+    repo_token: b10dfa69b04844a8ca9696a5092370008dcc4ac5ca723adcb14d815fbeaebbc7
 
 after_success:
   - vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script: composer test
 
 addons:
   code_climate:
-    repo_token: b10dfa69b04844a8ca9696a5092370008dcc4ac5ca723adcb14d815fbeaebbc7
+    repo_token:
+      secure: "Zh3sCkr1LizGn7cB3DVAVDeYCS4XQJ7sEgqbLyZFA+0YTKbT7kP0tIWx0juXF3Twps/wEIAz4Q7snK1aGzqkg53wcedbx27TSViSnmCMr7ViVrGPj9QMNzoB6xS5sG3LPbQ1Qa6osGL4IbFSiCkEuNYj9NGFYCAlT6qej1fnZ/c="
 
 after_success:
   - vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,5 @@ addons:
 
 after_success:
   - vendor/bin/test-reporter
+
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script: composer test
 addons:
   code_climate:
     repo_token:
-      secure: "Zh3sCkr1LizGn7cB3DVAVDeYCS4XQJ7sEgqbLyZFA+0YTKbT7kP0tIWx0juXF3Twps/wEIAz4Q7snK1aGzqkg53wcedbx27TSViSnmCMr7ViVrGPj9QMNzoB6xS5sG3LPbQ1Qa6osGL4IbFSiCkEuNYj9NGFYCAlT6qej1fnZ/c="
+      secure: Zh3sCkr1LizGn7cB3DVAVDeYCS4XQJ7sEgqbLyZFA+0YTKbT7kP0tIWx0juXF3Twps/wEIAz4Q7snK1aGzqkg53wcedbx27TSViSnmCMr7ViVrGPj9QMNzoB6xS5sG3LPbQ1Qa6osGL4IbFSiCkEuNYj9NGFYCAlT6qej1fnZ/c=
 
 after_success:
   - vendor/bin/test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ sudo: false
 install: composer install --no-interaction
 
 script: composer test
+
+addons:
+  code_climate:
+    repo_token: 78d27c9cf1bb57964da0d98f1e40b6aa92c9c7d06a7a4268a0b87d7d921c4123
+
+after_success:
+  - vendor/bin/test-reporter

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 
   "scripts": {
     "test": [
-      "phpunit",
+      "phpunit --coverage-clover build/logs/clover.xml",
       "phpcs --standard=PSR1,PSR2 src tests"
     ],
     "fix": "phpcbf --standard=PSR1,PSR2 src tests"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
   "require-dev": {
     "phpunit/phpunit": "4.8.*",
     "mockery/mockery": "0.9.*",
-    "squizlabs/php_codesniffer": "2.*"
+    "squizlabs/php_codesniffer": "2.*",
+    "codeclimate/php-test-reporter": "dev-master"
   },
 
   "scripts": {


### PR DESCRIPTION
This branch enables generating Clover-style code coverage reports as part of the PHPUnit test run and instructs Travis CI to send results to Code Climate.

Code Climate interface is available at: https://codeclimate.com/github/rollbar/rollbar-php
The first code coverage analysis should be available after the first Travis build after merging this pull request into master.