### PR TITLE
GitHub Issue #132: backwards compatibility with 0.18.2

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -101,4 +101,74 @@ class Rollbar
     {
         return new Response(0, "Rollbar Not Initialized");
     }
+    
+    /**
+     * Below methods are deprecated and still available only for backwards
+     * compatibility. If you're still using them in your application, please
+     * transition to using the ::log method as soon as possible.
+     */
+    
+    /**
+     * @param \Exception $exc Exception to be logged
+     * @param array $extra_data Additional data to be logged with the exception
+     * @param array $payload_data This is deprecated as of v1.0.0 and remains for
+     * backwards compatibility. The content fo this array will be merged with
+     * $extra_data.
+     * 
+     * @deprecated 1.0.0 This method has been replaced by ::log
+     */
+    public static function report_exception($exc, $extra_data = null, $payload_data = null) {
+        
+        $extra_data = array_merge($extra_data, $payload_data);
+        self::log($exc, $extra_data, Level::error());
+        
+    }
+
+    /**
+     * @param string $message Message to be logged
+     * @param string|Level::error() $level One of the values in \Rollbar\Payload\Level::$values 
+     * @param array $extra_data Additional data to be logged with the exception
+     * @param array $payload_data This is deprecated as of v1.0.0 and remains for
+     * backwards compatibility. The content fo this array will be merged with
+     * $extra_data.
+     * 
+     * @deprecated 1.0.0 This method has been replaced by ::log
+     */
+    public static function report_message($message, $level = null, $extra_data = null, $payload_data = null) {
+        
+        $level = $level ? Level::fromName($level) : Level::error();
+        $extra_data = array_merge($extra_data, $payload_data);
+        self::log($message, $extra_data, $level);
+        
+    }
+
+
+    /**
+     * Catch any fatal errors that are causing the shutdown
+     * 
+     * @deprecated 1.0.0 This method has been replaced by ::fatalHandler
+     */
+    public static function report_fatal_error() {
+        self::fatalHandler();
+    }
+
+
+    /**
+     * This function must return false so that the default php error handler runs
+     * 
+     * @deprecated 1.0.0 This method has been replaced by ::log
+     */
+    public static function report_php_error($errno, $errstr, $errfile, $errline) {
+        self::errorHandler($errno, $errstr, $errfile, $errline);
+        return false;
+    }
+
+    /**
+     * Do nothing silently to not cause backwards compatibility issues.
+     * 
+     * @deprecated 1.0.0
+     */
+    public static function flush() {
+        return;
+    }
 }

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -115,12 +115,14 @@ class Rollbar
      * backwards compatibility. The content fo this array will be merged with
      * $extra_data.
      * 
+     * @return string uuid
+     * 
      * @deprecated 1.0.0 This method has been replaced by ::log
      */
     public static function report_exception($exc, $extra_data = null, $payload_data = null) {
         
         $extra_data = array_merge($extra_data, $payload_data);
-        self::log($exc, $extra_data, Level::error());
+        return self::log($exc, $extra_data, Level::error())->getUuid();
         
     }
 
@@ -132,13 +134,15 @@ class Rollbar
      * backwards compatibility. The content fo this array will be merged with
      * $extra_data.
      * 
+     * @return string uuid
+     * 
      * @deprecated 1.0.0 This method has been replaced by ::log
      */
     public static function report_message($message, $level = null, $extra_data = null, $payload_data = null) {
         
         $level = $level ? Level::fromName($level) : Level::error();
         $extra_data = array_merge($extra_data, $payload_data);
-        self::log($message, $extra_data, $level);
+        return self::log($message, $extra_data, $level)->getUuid();
         
     }
 

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -1,5 +1,7 @@
 <?php namespace Rollbar;
 
+use \Rollbar\Payload\Level;
+
 class Rollbar
 {
     /**
@@ -68,7 +70,7 @@ class Rollbar
             return;
         }
         $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
-        self::$logger->log(null, $exception);
+        self::$logger->log(Level::error(), $exception);
     }
 
     public static function setupFatalHandling()
@@ -85,7 +87,7 @@ class Rollbar
             $errfile = $last_error['file'];
             $errline = $last_error['line'];
             $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
-            self::$logger->log(null, $exception);
+            self::$logger->log(Level::critical(), $exception);
         }
     }
 
@@ -121,7 +123,9 @@ class Rollbar
      */
     public static function report_exception($exc, $extra_data = null, $payload_data = null) {
         
-        $extra_data = array_merge($extra_data, $payload_data);
+        if ($payload_data) {
+            $extra_data = array_merge($extra_data, $payload_data);
+        }
         return self::log($exc, $extra_data, Level::error())->getUuid();
         
     }
@@ -141,7 +145,9 @@ class Rollbar
     public static function report_message($message, $level = null, $extra_data = null, $payload_data = null) {
         
         $level = $level ? Level::fromName($level) : Level::error();
-        $extra_data = array_merge($extra_data, $payload_data);
+        if ($payload_data) {
+            $extra_data = array_merge($extra_data, $payload_data);
+        }
         return self::log($message, $extra_data, $level)->getUuid();
         
     }

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -116,69 +116,72 @@ class Rollbar
      * @param array $payload_data This is deprecated as of v1.0.0 and remains for
      * backwards compatibility. The content fo this array will be merged with
      * $extra_data.
-     * 
+     *
      * @return string uuid
-     * 
+     *
      * @deprecated 1.0.0 This method has been replaced by ::log
      */
-    public static function report_exception($exc, $extra_data = null, $payload_data = null) {
+    public static function report_exception($exc, $extra_data = null, $payload_data = null)
+    {
         
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
         }
         return self::log($exc, $extra_data, Level::error())->getUuid();
-        
     }
 
     /**
      * @param string $message Message to be logged
-     * @param string|Level::error() $level One of the values in \Rollbar\Payload\Level::$values 
+     * @param string|Level::error() $level One of the values in \Rollbar\Payload\Level::$values
      * @param array $extra_data Additional data to be logged with the exception
      * @param array $payload_data This is deprecated as of v1.0.0 and remains for
      * backwards compatibility. The content fo this array will be merged with
      * $extra_data.
-     * 
+     *
      * @return string uuid
-     * 
+     *
      * @deprecated 1.0.0 This method has been replaced by ::log
      */
-    public static function report_message($message, $level = null, $extra_data = null, $payload_data = null) {
+    public static function report_message($message, $level = null, $extra_data = null, $payload_data = null)
+    {
         
         $level = $level ? Level::fromName($level) : Level::error();
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
         }
         return self::log($message, $extra_data, $level)->getUuid();
-        
     }
 
 
     /**
      * Catch any fatal errors that are causing the shutdown
-     * 
+     *
      * @deprecated 1.0.0 This method has been replaced by ::fatalHandler
      */
-    public static function report_fatal_error() {
+    public static function report_fatal_error()
+    {
         self::fatalHandler();
     }
 
 
     /**
      * This function must return false so that the default php error handler runs
-     * 
+     *
      * @deprecated 1.0.0 This method has been replaced by ::log
      */
-    public static function report_php_error($errno, $errstr, $errfile, $errline) {
+    public static function report_php_error($errno, $errstr, $errfile, $errline)
+    {
         self::errorHandler($errno, $errstr, $errfile, $errline);
         return false;
     }
 
     /**
      * Do nothing silently to not cause backwards compatibility issues.
-     * 
+     *
      * @deprecated 1.0.0
      */
-    public static function flush() {
+    public static function flush()
+    {
         return;
     }
 }

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -104,6 +104,8 @@ class Rollbar
         return new Response(0, "Rollbar Not Initialized");
     }
     
+    // @codingStandardsIgnoreStart
+    
     /**
      * Below methods are deprecated and still available only for backwards
      * compatibility. If you're still using them in your application, please
@@ -184,4 +186,6 @@ class Rollbar
     {
         return;
     }
+    
+    // @codingStandardsIgnoreEnd
 }

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -4,14 +4,16 @@ if (!defined('ROLLBAR_TEST_TOKEN')) {
     define('ROLLBAR_TEST_TOKEN', 'ad865e76e7fb496fab096ac07b1dbabb');
 }
 
-class RollbarTest extends \PHPUnit_Framework_TestCase {
+class RollbarTest extends \PHPUnit_Framework_TestCase
+{
 
     private static $simpleConfig = array(
         'access_token' => ROLLBAR_TEST_TOKEN,
         'environment' => 'test'
     );
 
-    public function testInit() {
+    public function testInit()
+    {
         Rollbar::init(self::$simpleConfig);
 
         $this->assertNotNull(Rollbar::logger());
@@ -20,14 +22,16 @@ class RollbarTest extends \PHPUnit_Framework_TestCase {
     /**
      * Below are backwards compatibility tests with v0.18.2
      */
-    public function testSimpleMessage() {
+    public function testSimpleMessage()
+    {
         Rollbar::init(self::$simpleConfig);
 
         $uuid = Rollbar::report_message("Hello world");
         $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
     }
     
-    public function testSimpleError() {
+    public function testSimpleError()
+    {
         Rollbar::init(self::$simpleConfig);
         
         $result = Rollbar::report_php_error(E_ERROR, "Runtime error", "the_file.php", 1);
@@ -35,7 +39,8 @@ class RollbarTest extends \PHPUnit_Framework_TestCase {
         $this->assertFalse($result);
     }
     
-    public function testSimpleException() {
+    public function testSimpleException()
+    {
         Rollbar::init(self::$simpleConfig);
         
         $uuid = null;
@@ -48,9 +53,9 @@ class RollbarTest extends \PHPUnit_Framework_TestCase {
         $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
     }
 
-    public function testFlush() {
+    public function testFlush()
+    {
         Rollbar::flush();
         $this->assertTrue(true);
     }
-
 }

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -1,0 +1,56 @@
+<?php namespace Rollbar;
+
+if (!defined('ROLLBAR_TEST_TOKEN')) {
+    define('ROLLBAR_TEST_TOKEN', 'ad865e76e7fb496fab096ac07b1dbabb');
+}
+
+class RollbarTest extends \PHPUnit_Framework_TestCase {
+
+    private static $simpleConfig = array(
+        'access_token' => ROLLBAR_TEST_TOKEN,
+        'environment' => 'test'
+    );
+
+    public function testInit() {
+        Rollbar::init(self::$simpleConfig);
+
+        $this->assertNotNull(Rollbar::logger());
+    }
+
+    /**
+     * Below are backwards compatibility tests with v0.18.2
+     */
+    public function testSimpleMessage() {
+        Rollbar::init(self::$simpleConfig);
+
+        $uuid = Rollbar::report_message("Hello world");
+        $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
+    }
+    
+    public function testSimpleError() {
+        Rollbar::init(self::$simpleConfig);
+        
+        $result = Rollbar::report_php_error(E_ERROR, "Runtime error", "the_file.php", 1);
+        // always returns false.
+        $this->assertFalse($result);
+    }
+    
+    public function testSimpleException() {
+        Rollbar::init(self::$simpleConfig);
+        
+        $uuid = null;
+        try {
+            throw new \Exception("test exception");
+        } catch (\Exception $e) {
+            $uuid = Rollbar::report_exception($e);
+        }
+
+        $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
+    }
+
+    public function testFlush() {
+        Rollbar::flush();
+        $this->assertTrue(true);
+    }
+
+}


### PR DESCRIPTION
Added the following methods to \Rollbar\Rollbar:

- report_message() - wrapper for log()
- report_exception() - wrapper for log()
- report_fatal_error() - wrapper for fatalHandler()
- report_php_error() - wrapper for errorHandler()
- flush() - empty method to not cause fatal errors in users' codebases

Added tests in tests/RollbarTest.php to check backward compatibility.