### PR TITLE
GitHub Issue #72: status 200 when using set_exception_handler

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -53,7 +53,15 @@ class Rollbar
     
     public static function exceptionHandler($exception)
     {
-        return self::log(Level::error(), $exception);
+        self::log(Level::error(), $exception);
+        
+        if (ini_get('display_errors')) {
+            restore_exception_handler();
+            throw $exception;
+        } else {
+            header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error', true, 500);
+            exit(1);    
+        }
     }
 
     public static function log($level, $toLog, $extra = array())

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -60,7 +60,7 @@ class Rollbar
             throw $exception;
         } else {
             header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error', true, 500);
-            exit(1);    
+            exit(1);
         }
     }
 

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -55,13 +55,8 @@ class Rollbar
     {
         self::log(Level::error(), $exception);
         
-        if (ini_get('display_errors')) {
-            restore_exception_handler();
-            throw $exception;
-        } else {
-            header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error', true, 500);
-            exit(1);
-        }
+        restore_exception_handler();
+        throw $exception;
     }
 
     public static function log($level, $toLog, $extra = array())


### PR DESCRIPTION
This changes the exception handler to trigger logging with Rollbar and follow with the default PHP global exception handler instead of overriding it. This effectively brings back the default PHP behavior for uncaught exceptions which is:

```
if (php_ini.display_errors == 1) {
    show error info
    HTTP RESPONSE CODE 200
} else {
    HTTP RESPONSE CODE 500
}
```