### PR TITLE
GitHub Issue #53: Option to capture stack trace in report_message()

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,12 @@ $config['proxy'] = array(
 Default: No proxy
 </dd>
 
+<dt>send_message_trace</dt>
+<dd>Should backtrace be include with string messages reported to Rollbar
+
+Default: `false`
+</dd>
+
 </dl>
 
 Example use of error_sample_rates:

--- a/src/Config.php
+++ b/src/Config.php
@@ -44,6 +44,12 @@ class Config
     private $mt_randmax;
 
     private $included_errno = ROLLBAR_INCLUDED_ERRNO_BITMASK;
+    
+    /**
+     * @var boolean Should debug_backtrace() data be sent with string messages
+     * sent through RollbarLogger::log()
+     */
+    private $sendMessageTrace = false;
 
     public function __construct(array $configArray)
     {
@@ -97,6 +103,7 @@ class Config
         $this->setSender($c);
         $this->setResponseHandler($c);
         $this->setCheckIgnoreFunction($c);
+        $this->setSendMessageTrace($c);
 
         if (isset($c['included_errno'])) {
             $this->included_errno = $c['included_errno'];
@@ -198,6 +205,15 @@ class Config
         $this->checkIgnore = $c['checkIgnore'];
     }
 
+    private function setSendMessageTrace($c)
+    {
+        if (!isset($c['sendMessageTrace'])) {
+            return;
+        }
+
+        $this->sendMessageTrace = $c['sendMessageTrace'];
+    }
+
     /**
      * Allows setting up configuration options that might be specified by class
      * name. Any interface used with `setupWithOptions` should be constructed
@@ -282,6 +298,11 @@ class Config
     public function getAccessToken()
     {
         return $this->accessToken;
+    }
+
+    public function getSendMessageTrace()
+    {
+        return $this->sendMessageTrace;
     }
 
     public function checkIgnored($payload, $accessToken, $toLog)

--- a/src/Config.php
+++ b/src/Config.php
@@ -207,11 +207,11 @@ class Config
 
     private function setSendMessageTrace($c)
     {
-        if (!isset($c['sendMessageTrace'])) {
+        if (!isset($c['send_message_trace'])) {
             return;
         }
 
-        $this->sendMessageTrace = $c['sendMessageTrace'];
+        $this->sendMessageTrace = $c['send_message_trace'];
     }
 
     /**

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -435,7 +435,7 @@ class DataBuilder implements DataBuilderInterface
 
     protected function getMessage($toLog, $context)
     {
-        return new Message((string)$toLog, $context);
+        return new Message((string)$toLog, $context, debug_backtrace());
     }
 
     protected function getLevel($level, $toLog)

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -46,6 +46,7 @@ class DataBuilder implements DataBuilderInterface
     protected $baseException;
     protected $includeCodeContext;
     protected $shiftFunction;
+    protected $sendMessageTrace;
 
     public function __construct($config)
     {
@@ -77,6 +78,7 @@ class DataBuilder implements DataBuilderInterface
         $this->setNotifier($config);
         $this->setBaseException($config);
         $this->setIncludeCodeContext($config);
+        $this->setSendMessageTrace($config);
 
         $this->shiftFunction = $this->tryGet($config, 'shift_function');
         if (!isset($this->shiftFunction)) {
@@ -140,6 +142,12 @@ class DataBuilder implements DataBuilderInterface
     {
         $fromConfig = $this->tryGet($config, 'errorLevels');
         $this->errorLevels = self::$defaults->errorLevels($fromConfig);
+    }
+
+    protected function setSendMessageTrace($config)
+    {
+        $fromConfig = $this->tryGet($config, 'sendMessageTrace');
+        $this->sendMessageTrace = self::$defaults->sendMessageTrace($fromConfig);
     }
 
     protected function setCodeVersion($c)
@@ -435,7 +443,11 @@ class DataBuilder implements DataBuilderInterface
 
     protected function getMessage($toLog, $context)
     {
-        return new Message((string)$toLog, $context, debug_backtrace());
+        return new Message(
+            (string)$toLog,
+            $context,
+            $this->sendMessageTrace ? debug_backtrace() : null
+        );
     }
 
     protected function getLevel($level, $toLog)

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -146,7 +146,7 @@ class DataBuilder implements DataBuilderInterface
 
     protected function setSendMessageTrace($config)
     {
-        $fromConfig = $this->tryGet($config, 'sendMessageTrace');
+        $fromConfig = $this->tryGet($config, 'send_message_trace');
         $this->sendMessageTrace = self::$defaults->sendMessageTrace($fromConfig);
     }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -71,6 +71,11 @@ class Defaults
             'access_token'
         );
     }
+    
+    public function sendMessageTrace($sendMessageTrace = null)
+    {
+        return $sendMessageTrace ? $sendMessageTrace : $this->defaultSendMessageTrace;
+    }
 
     private $defaultMessageLevel = "warning";
     private $defaultExceptionLevel = "error";
@@ -84,6 +89,7 @@ class Defaults
     private $defaultNotifier;
     private $defaultBaseException;
     private $defaultScrubFields;
+    private $defaultSendMessageTrace;
 
     public function __construct()
     {
@@ -130,6 +136,7 @@ class Defaults
         $this->defaultBaseException = self::getBaseException();
         $this->defaultScrubFields = self::getScrubFields();
         $this->defaultCodeVersion = "";
+        $this->defaultSendMessageTrace = false;
     }
 
     public function messageLevel($level = null)

--- a/src/Payload/Message.php
+++ b/src/Payload/Message.php
@@ -6,10 +6,15 @@ class Message extends ContentInterface
 {
     private $body;
     private $extra;
+    private $backtrace;
 
-    public function __construct($body, array $extra = null)
-    {
+    public function __construct(
+        $body, 
+        array $extra = null, 
+        $backtrace = null
+    ) {
         $this->setBody($body);
+        $this->setBacktrace($backtrace);
         $this->extra = $extra == null ? array() : $extra;
     }
 
@@ -21,6 +26,17 @@ class Message extends ContentInterface
     public function setBody($body)
     {
         $this->body = $body;
+        return $this;
+    }
+    
+    public function getBacktrace()
+    {
+        return $this->backtrace;
+    }
+
+    public function setBacktrace($backtrace)
+    {
+        $this->backtrace = $backtrace;
         return $this;
     }
 
@@ -36,7 +52,10 @@ class Message extends ContentInterface
 
     public function jsonSerialize()
     {
-        $toSerialize = array("body" => $this->getBody());
+        $toSerialize = array(
+            "body" => $this->getBody(),
+            "backtrace" => $this->getBacktrace()
+        );
         foreach ($this->extra as $key => $value) {
             $toSerialize[$key] = $value;
         }

--- a/src/Payload/Message.php
+++ b/src/Payload/Message.php
@@ -9,8 +9,8 @@ class Message extends ContentInterface
     private $backtrace;
 
     public function __construct(
-        $body, 
-        array $extra = null, 
+        $body,
+        array $extra = null,
         $backtrace = null
     ) {
         $this->setBody($body);

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -213,7 +213,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $c = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "sendMessageTrace" => true
+            "send_message_trace" => true
         ));
         
         $this->assertTrue($c->getSendMessageTrace());

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -224,4 +224,22 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($called);
     }
+
+    public function testSendMessageTrace()
+    {
+        $c = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env,
+            "sendMessageTrace" => true
+        ));
+        
+        $this->assertTrue($c->getSendMessageTrace());
+        
+        $c = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env
+        ));
+        
+        $this->assertFalse($c->getSendMessageTrace());
+    }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -64,7 +64,21 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     
     public function testGetMessage()
     {
-        $result = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests'
+        ));
+        
+        $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $this->assertNull($result->getBody()->getValue()->getBacktrace());
+        
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests',
+            'sendMessageTrace' => true
+        ));
+    
+        $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
     }
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -351,7 +351,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'sendMessageTrace' => true
+            'send_message_trace' => true
         ));
     
         $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -61,6 +61,12 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertEquals('my host', $output->getServer()->getHost());
     }
+    
+    public function testGetMessage()
+    {
+        $result = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
+    }
 
     public function testFramesWithoutContext()
     {

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -134,4 +134,9 @@ class DefaultsTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($expected, $this->d->scrubFields());
     }
+    
+    public function testSendMessageTrace()
+    {
+        $this->assertFalse($this->d->sendMessageTrace());
+    }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -2,6 +2,13 @@
 
 class MessageTest extends \PHPUnit_Framework_TestCase
 {
+    public function testBacktrace()
+    {
+        $expected = array('trace 1' => 'value 1');
+        $msg = new Message("Test", array(), $expected);
+        $this->assertEquals($expected, $msg->getBacktrace());
+    }
+    
     public function testBody()
     {
         $msg = new Message("Test");

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -25,7 +25,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testLog()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "eb2561a52efb4d4bba5a1d4b68be13e9",
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
             "environment" => "testing-php"
         ));
         $response = $l->log(Level::warning(), "Testing PHP Notifier", array());

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -25,7 +25,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testLog()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => "eb2561a52efb4d4bba5a1d4b68be13e9",
             "environment" => "testing-php"
         ));
         $response = $l->log(Level::warning(), "Testing PHP Notifier", array());


### PR DESCRIPTION
Added backtrace to message logged with `Rollbar::log(string)`. This is going to be saved to the Rollbar API as `data.body.message.backtrace`

Ideally, it would be great to also update Rollbar UI to support displaying those stack traces in a human-friendly format. Currently, it's just a stack trace dump as string from PHP's `debug_backtrace()`

I experimented a bit with sending the message wrapped in an exception which would display the trace info in a human-friendly way by the default. However, doing that removes the ability to inspect `data.body.message.extra`