### PR TITLE
Fix check ignore [Fixes #151]

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -289,8 +289,15 @@ class Config
         if ($this->shouldSuppress()) {
             return true;
         }
-        if (isset($this->checkIgnore) && call_user_func($this->checkIgnore, $isUncaught, $toLog, $payload)) {
-            return true;
+        if (isset($this->checkIgnore)) {
+            try {
+                if (call_user_func($this->checkIgnore, $isUncaught, $toLog, $payload)) {
+                    return true;
+                }
+            } catch (Exception $e) {
+                // We should log that we are removing the custom checkIgnore
+                $this->checkIgnore = null;
+            }
         }
         if ($this->levelTooLow($payload)) {
             return true;

--- a/src/Config.php
+++ b/src/Config.php
@@ -284,12 +284,12 @@ class Config
         return $this->accessToken;
     }
 
-    public function checkIgnored($payload, $accessToken, $toLog)
+    public function checkIgnored($payload, $accessToken, $toLog, $isUncaught)
     {
         if ($this->shouldSuppress()) {
             return true;
         }
-        if (isset($this->checkIgnore) && call_user_func($this->checkIgnore)) {
+        if (isset($this->checkIgnore) && call_user_func($this->checkIgnore, $isUncaught, $toLog, $payload)) {
             return true;
         }
         if ($this->levelTooLow($payload)) {

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -85,6 +85,9 @@ class Rollbar
 
     public static function fatalHandler()
     {
+        if (is_null(self::$logger)) {
+            return;
+        }
         $last_error = error_get_last();
         if (!is_null($last_error)) {
             $errno = $last_error['type'];

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -1,6 +1,7 @@
 <?php namespace Rollbar;
 
 use Rollbar\Payload\Level;
+use Rollbar\Utilities;
 
 class Rollbar
 {
@@ -53,7 +54,7 @@ class Rollbar
     
     public static function exceptionHandler($exception)
     {
-        return self::log(Level::error(), $exception);
+        return self::log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
     }
 
     public static function log($level, $toLog, $extra = array())
@@ -75,7 +76,7 @@ class Rollbar
             return;
         }
         $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
-        self::$logger->log(Level::error(), $exception);
+        self::$logger->log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
     }
 
     public static function setupFatalHandling()
@@ -95,7 +96,8 @@ class Rollbar
             $errfile = $last_error['file'];
             $errline = $last_error['line'];
             $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
-            self::$logger->log(Level::critical(), $exception);
+            $extra = array(Utilities::IS_UNCAUGHT_KEY => true);
+            self::$logger->log(Level::critical(), $exception, $extra);
         }
     }
 

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -35,7 +35,7 @@ class RollbarLogger extends AbstractLogger
             throw new \Psr\Log\InvalidArgumentException("Invalid log level '$level'.");
         }
         $isUncaught = false;
-        if ($context[Utilities::IS_UNCAUGHT_KEY]) {
+        if (array_key_exists(Utilities::IS_UNCAUGHT_KEY, $context) && $context[Utilities::IS_UNCAUGHT_KEY]) {
             $isUncaught = true;
             unset($context[Utilities::IS_UNCAUGHT_KEY]);
         }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -3,6 +3,7 @@
 use Psr\Log\AbstractLogger;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
+use Rollbar\Utilities;
 
 class RollbarLogger extends AbstractLogger
 {
@@ -33,10 +34,15 @@ class RollbarLogger extends AbstractLogger
         if (Level::fromName($level) === null) {
             throw new \Psr\Log\InvalidArgumentException("Invalid log level '$level'.");
         }
+        $isUncaught = false;
+        if ($context[Utilities::IS_UNCAUGHT_KEY]) {
+            $isUncaught = true;
+            unset($context[Utilities::IS_UNCAUGHT_KEY]);
+        }
         $accessToken = $this->getAccessToken();
         $payload = $this->getPayload($accessToken, $level, $toLog, $context);
         
-        if ($this->config->checkIgnored($payload, $accessToken, $toLog)) {
+        if ($this->config->checkIgnored($payload, $accessToken, $toLog, $isUncaught)) {
             $response = new Response(0, "Ignored");
         } else {
             $scrubbed = $this->scrub($payload);

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -2,6 +2,8 @@
 
 final class Utilities
 {
+    const IS_UNCAUGHT_KEY = "__rollbar_is_uncaught_key";
+
     // In order to support < 5.6 we had to use __callStatic to define
     // coalesce, because the splat operator was introduced in 5.6
     public static function __callStatic($name, $args)

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -228,12 +228,13 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testCheckIgnoreParameters()
     {
         $called = false;
+        $that = $this;
         $c = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "checkIgnore" => function ($isIgnored, $exc, $payload) use (&$called) {
-                $this->assertTrue($isIgnored);
-                $this->assertEquals($exc, $this->error);
+            "checkIgnore" => function ($isIgnored, $exc, $payload) use (&$called, &$that) {
+                $that->assertTrue($isIgnored);
+                $that->assertEquals($exc, $that->error);
                 $called = true;
             }
         ));

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -214,7 +214,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $c = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "checkIgnore" => function ($isIgnored, $exc, $payload) use (&$called) {
+            "checkIgnore" => function ($isUncaught, $exc, $payload) use (&$called) {
                 $called = true;
             }
         ));
@@ -228,14 +228,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testCheckIgnoreParameters()
     {
         $called = false;
-        $that = $this;
+        $isUncaughtPassed = null;
+        $errorPassed = null;
         $c = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "checkIgnore" => function ($isIgnored, $exc, $payload) use (&$called, &$that) {
-                $that->assertTrue($isIgnored);
-                $that->assertEquals($exc, $that->error);
+            "checkIgnore" => function ($isUncaught, $exc, $payload) use (&$called, &$isUncaughtPassed, &$errorPassed) {
                 $called = true;
+                $isUncaughtPassed = $isUncaught;
+                $errorPassed = $exc;
             }
         ));
         $data = new Data($this->env, new Body(new Message("test")));
@@ -243,5 +244,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, true);
 
         $this->assertTrue($called);
+        $this->assertTrue($isUncaughtPassed);
+        $this->assertEquals($this->error, $errorPassed);
     }
 }


### PR DESCRIPTION
According to our docs and the old behaviour we pass three parameters to the user supplied checkIgnore function. The new library broke that. This brings the old behaviour back.