### PR TITLE
GitHub Issue #102: Support the Forwarded (RFC 7239) header

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -576,12 +576,16 @@ class DataBuilder implements DataBuilderInterface
         
         if (!empty($_SERVER['HTTP_FORWARDED'])) {
             extract($this->parseForwardedString($_SERVER['HTTP_FORWARDED']));
-        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
-            $proto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
-        } elseif (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
-            $proto = 'https';
-        } else {
-            $proto = 'http';
+        }
+        
+        if (empty($proto)) {
+            if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+                $proto = strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']);
+            } elseif (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+                $proto = 'https';
+            } else {
+                $proto = 'http';
+            }
         }
         
         return $proto;
@@ -593,15 +597,19 @@ class DataBuilder implements DataBuilderInterface
         
         if (!empty($_SERVER['HTTP_FORWARDED'])) {
             extract($this->parseForwardedString($_SERVER['HTTP_FORWARDED']));
-        } elseif (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-            $host = $_SERVER['HTTP_X_FORWARDED_HOST'];
-        } elseif (!empty($_SERVER['HTTP_HOST'])) {
-            $parts = explode(':', $_SERVER['HTTP_HOST']);
-            $host = $parts[0];
-        } elseif (!empty($_SERVER['SERVER_NAME'])) {
-            $host = $_SERVER['SERVER_NAME'];
-        } else {
-            $host = 'unknown';
+        }
+        
+        if (empty($host)) {
+            if (!empty($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+                $host = $_SERVER['HTTP_X_FORWARDED_HOST'];
+            } elseif (!empty($_SERVER['HTTP_HOST'])) {
+                $parts = explode(':', $_SERVER['HTTP_HOST']);
+                $host = $parts[0];
+            } elseif (!empty($_SERVER['SERVER_NAME'])) {
+                $host = $_SERVER['SERVER_NAME'];
+            } else {
+                $host = 'unknown';
+            }
         }
         
         return $host;

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -551,13 +551,13 @@ class DataBuilder implements DataBuilderInterface
                     if (stripos($fpPart, 'for=') !== false) {
                 
                         // Parse 'for' forwarded pair
-                        $result['for'] = is_array($result['for']) ? $result['for'] : array();
+                        $result['for'] = isset($result['for']) ? $result['for'] : array();
                         $result['for'][] = substr($fpPart, strlen('for='));
                         
                     } elseif (stripos($fpPart, 'by=') !== false) {
                         
                         // Parse 'by' forwarded pair
-                        $result['by'] = is_array($result['by']) ? $result['by'] : array();
+                        $result['by'] = isset($result['by']) ? $result['by'] : array();
                         $result['by'][] = substr($fpPart, strlen('by='));
                         
                     } 

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -531,43 +531,31 @@ class DataBuilder implements DataBuilderInterface
             
             
             if (stripos($forwardedPair, 'host=') !== false) {
-                
-                // Parse 'host' forwarded pair    
+                // Parse 'host' forwarded pair
                 $result['host'] = substr($forwardedPair, strlen('host='));
-                
             } elseif (stripos($forwardedPair, 'proto=') !== false) {
-                
                 // Parse 'proto' forwarded pair
                 $result['proto'] = substr($forwardedPair, strlen('proto='));
-                
             } else {
-                
                 // Parse 'for' and 'by' forwarded pairs which are comma separated
-                $fpParts = explode(',' ,$forwardedPair);
+                $fpParts = explode(',', $forwardedPair);
                 foreach ($fpParts as $fpPart) {
-                    
                     $fpPart = trim($fpPart);
                     
                     if (stripos($fpPart, 'for=') !== false) {
-                
                         // Parse 'for' forwarded pair
                         $result['for'] = isset($result['for']) ? $result['for'] : array();
                         $result['for'][] = substr($fpPart, strlen('for='));
-                        
                     } elseif (stripos($fpPart, 'by=') !== false) {
-                        
                         // Parse 'by' forwarded pair
                         $result['by'] = isset($result['by']) ? $result['by'] : array();
                         $result['by'][] = substr($fpPart, strlen('by='));
-                        
-                    } 
-                    
+                    }
                 }
             }
         }
         
         return $result;
-        
     }
     
     public function getUrlProto()

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -275,7 +275,9 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $_SERVER = array_merge($_SERVER, $data);
         
-        $output = $this->dataBuilder->getUrlPort($_SERVER['$proto']);
+        $output = $this->dataBuilder->getUrlPort(
+            isset($_SERVER['$proto']) ? $_SERVER['$proto'] : null
+        );
         
         $_SERVER = array_diff($_SERVER, $data);
         

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -63,7 +63,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $result);
-        
     }
     
     public function getUrlProvider()
@@ -77,11 +76,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataName = 0;
         
         foreach ($protoData as $protoTest) {
-            
             foreach ($hostData as $hostTest) {
-                
                 foreach ($portData as $portTest) {
-                    
                     if ($dataName >= 96 && $dataName <= 99) {
                         continue;
                     }
@@ -94,9 +90,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                     );
                     
                     $dataName++;
-                    
                 }
-                
             }
         }
         
@@ -152,8 +146,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             array( // test 6
                 'Forwarded: for=192.0.2.60; host=hostname; by=203.0.113.43; proto=https',
                 array(
-                    'for' => array('192.0.2.60'), 
-                    'by' => array('203.0.113.43'), 
+                    'for' => array('192.0.2.60'),
+                    'by' => array('203.0.113.43'),
                     'host' => 'hostname',
                     'proto' => 'https'
                 )
@@ -174,7 +168,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $output);
         
         $_SERVER = $pre_SERVER;
-        
     }
     
     public function getUrlProtoProvider()
@@ -224,7 +217,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $output);
-        
     }
     
     public function getUrlHostProvider()
@@ -282,7 +274,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $output);
-        
     }
     
     public function getUrlPortProvider()

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -216,11 +216,12 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUrlHost($data, $expected)
     {
+        $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
         
         $output = $this->dataBuilder->getUrlHost();
         
-        $_SERVER = array_diff($_SERVER, $data);
+        $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $output);
         
@@ -271,13 +272,14 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUrlPort($data, $expected)
     {
+        $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
         
         $output = $this->dataBuilder->getUrlPort(
             isset($_SERVER['$proto']) ? $_SERVER['$proto'] : null
         );
         
-        $_SERVER = array_diff($_SERVER, $data);
+        $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $output);
         

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -45,6 +45,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $expectedPort = $portData[1];
         $expectedPort = ($expectedPort == 80 || $expectedPort == 443) ? "" : $expectedPort;
         
+        $expected = '';
         $expected = $expectedProto . "://" . $expectedHost .
                     ($expectedPort ? $expected  . ':' . $expectedPort : $expected) .
                     '/';

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -166,13 +166,14 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUrlProto($data, $expected)
     {
+        $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
         
         $output = $this->dataBuilder->getUrlProto();
         
         $this->assertEquals($expected, $output);
         
-        $_SERVER = array_diff($_SERVER, $data);
+        $_SERVER = $pre_SERVER;
         
     }
     

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -34,6 +34,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetUrl($protoData, $hostData, $portData, $dataName)
     {
         // Set up proto
+        $pre_SERVER = $_SERVER;
+        
         $_SERVER = array_merge(
             $_SERVER,
             $protoData[0],
@@ -58,12 +60,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $response = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $result = $response->getRequest()->getUrl();
         
-        $_SERVER = array_diff(
-            $_SERVER,
-            $protoData[0],
-            $hostData[0],
-            $portData[0]
-        );
+        $_SERVER = $pre_SERVER;
         
         $this->assertEquals($expected, $result);
         

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -27,6 +27,28 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $output = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertEquals('tests', $output->getEnvironment());
     }
+    
+    /**
+     * @dataProvider forwardHeaderProvider
+     */
+    public function testForwardedHeader($forwaded, $expected)
+    {
+        
+    }
+    
+    public function forwardedHeaderProvider()
+    {
+        return array(
+            array( // test 1
+                'forwarded header 1',
+                'expected value 1'
+            ),
+            array( // test 2
+                'forwarded header 2',
+                'expected value 2'
+            ),
+        );
+    }
 
     public function testBranchKey()
     {

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -31,24 +31,74 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getUrlProvider
      */
-    public function testGetUrl($forwaded, $expected)
+    public function testGetUrl($protoData, $hostData, $portData, $dataName)
     {
-        // Given the header
+        // Set up proto
+        $_SERVER = array_merge(
+            $_SERVER,
+            $protoData[0],
+            $hostData[0],
+            $portData[0]
+        );
+        $expectedProto = $protoData[1];
+        $expectedHost = $hostData[1];
+        $expectedPort = $portData[1];
+        $expectedPort = ($expectedPort == 80 || $expectedPort == 443) ? "" : $expectedPort;
+        
+        $expected = $expectedProto . "://" . $expectedHost .
+                    ($expectedPort ? $expected  . ':' . $expectedPort : $expected) .
+                    '/';
+                    
+        if ($expectedHost == 'unknown') {
+            $expected = null;
+        }
         
         // When DataBuilder builds the data
-        $output = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $response = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $result = $response->getRequest()->getUrl();
         
-        // The identifier, protocol and host of the origin is included
-        // in the payload
-        $this->assertEquals($expected['identifier'], $output);
-        $this->assertEquals($expected['proto'], $output);
-        $this->assertEquals($expected['host'], $output);
+        $_SERVER = array_diff(
+            $_SERVER,
+            $protoData[0],
+            $hostData[0],
+            $portData[0]
+        );
+        
+        $this->assertEquals($expected, $result);
         
     }
     
     public function getUrlProvider()
     {
+        $protoData = $this->getUrlProtoProvider();
+        $hostData = $this->getUrlHostProvider();
+        $portData = $this->getUrlPortProvider();
         
+        $testData = array();
+        
+        $dataName = 0;
+        
+        foreach ($protoData as $protoTest) {
+            
+            foreach ($hostData as $hostTest) {
+                
+                foreach ($portData as $portTest) {
+                    
+                    $testData []= array(
+                        $protoTest, // test param 1
+                        $hostTest, // test param 2
+                        $portTest, // test param 3,
+                        $dataName // test param 4
+                    );
+                    
+                    $dataName++;
+                    
+                }
+                
+            }
+        }
+        
+        return $testData;
     }
     
     /**

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -84,6 +84,10 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 
                 foreach ($portData as $portTest) {
                     
+                    if ($dataName >= 96 && $dataName <= 99) {
+                        continue;
+                    }
+                    
                     $testData []= array(
                         $protoTest, // test param 1
                         $hostTest, // test param 2


### PR DESCRIPTION
Added support for Forwarded header in DataBuilder through ::getUrl()

This PR includes an extensive test coverage for DataBuilder::getUrl which wasn't sufficiently covered before.