### PR TITLE
Fix infinite loop when exception has previous set

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -339,7 +339,7 @@ class DataBuilder implements DataBuilderInterface
         $baseException = $this->getBaseException();
         while ($previous instanceof $baseException) {
             $chain[] = $this->makeTrace($previous);
-            $previous = $exc->getPrevious();
+            $previous = $previous->getPrevious();
         }
 
         if (count($chain) > 1) {


### PR DESCRIPTION
When reporting exception that has `previous` property set to some value, it seem that there is an infinite loop when rollbar tries to iterate down the exception tree.