### PR TITLE
Fatal handler type check

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -9,6 +9,7 @@ class Rollbar
      * @var RollbarLogger
      */
     private static $logger = null;
+    private static $fatalErrors = array(E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR);
 
     public static function init(
         $config,
@@ -93,7 +94,7 @@ class Rollbar
             return;
         }
         $last_error = error_get_last();
-        if (!is_null($last_error)) {
+        if (!is_null($last_error) && in_array($lastError['type'], self::$fatalErrors, true)) {
             $errno = $last_error['type'];
             $errstr = $last_error['message'];
             $errfile = $last_error['file'];

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -94,7 +94,7 @@ class Rollbar
             return;
         }
         $last_error = error_get_last();
-        if (!is_null($last_error) && in_array($lastError['type'], self::$fatalErrors, true)) {
+        if (!is_null($last_error) && in_array($last_error['type'], self::$fatalErrors, true)) {
             $errno = $last_error['type'];
             $errstr = $last_error['message'];
             $errfile = $last_error['file'];


### PR DESCRIPTION
Since fatal error handler is connected to script shutdown function
and is executed after every script including ones without fatal errors,
`error_get_last()` might in some cases return last suppressed error that
was not caught by regular error handler. This causes it to be reported
when it should not be according to the configuration.

**Steps to reproduce** and get a reported occurrence on each script execution (which is a fun way to test your rate limits):
1. Set `included_errno` to include `E_NOTICE`, like this: `'included_errno' => E_ALL`
2. Do not have git repository in project directory.
3. Include Rollbar initialization in script and set ` $handleFatal` to `true` (it is by default).
4. Execute script.
5. See `E_NOTICE: Undefined offset: 0: Undefined offset: 0` reported for each execution. I did some digging, it is caused by https://github.com/rollbar/rollbar-php/blob/master/src/Defaults.php#L23
