### PR TITLE
Guessing query strings should err on being conservative

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -775,10 +775,10 @@ class DataBuilder implements DataBuilderInterface
                 $parsedValues = array_values($parsed);
                 
                 /**
-                 * If we have at least one key/value pair (i.e. a=b) then
+                 * If we have at least two pairs (i.e. a=b&c=d) then
                  * we treat the whole string as a query string.
                  */
-                if (count(array_filter($parsedValues)) > 0) {
+                if (count($parsed) > 1 && count(array_filter($parsedValues)) > 1) {
                     $query = $data;
                 }
             }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -760,29 +760,9 @@ class DataBuilder implements DataBuilderInterface
         }
         
         if (is_array($data)) { // scrub arrays
-        
             $data = $this->scrubArray($data, $replacement);
         } elseif (is_string($data)) { // scrub URLs and query strings
-            
             $query = parse_url($data, PHP_URL_QUERY);
-            
-            /**
-             * String is not a URL but it still might be just a plain
-             * query string in format arg1=val1&arg2=val2
-             */
-            if (!$query) {
-                parse_str($data, $parsed);
-                $parsedValues = array_values($parsed);
-                
-                /**
-                 * If we have at least two pairs (i.e. a=b&c=d) then
-                 * we treat the whole string as a query string.
-                 */
-                if (count($parsed) > 1 && count(array_filter($parsedValues)) > 1) {
-                    $query = $data;
-                }
-            }
-                
             if ($query) {
                 $data = str_replace(
                     $query,
@@ -791,7 +771,6 @@ class DataBuilder implements DataBuilderInterface
                 );
             }
         }
-        
         return $data;
     }
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -247,7 +247,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 array(
                     'sensitive'
                 ),
-                'b=%5B1023%2C1924%5D'
+                'b=[1023,1924]'
             )
         );
     }
@@ -298,8 +298,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'non sensitive data 1' => '123',
                 'non sensitive data 2' => '456',
                 'non sensitive data 3' => '4&56',
-                'non sensitive data 4' => 'a=4&56=', // this is a weird edge case
-                'non sensitive data 6' => 'baz=&foo=xxxxxxxx',
+                'non sensitive data 4' => 'a=4&56',
+                'non sensitive data 6' => 'baz&foo=bar', // this is a weird edge case
                 'sensitive data' => '********',
                 array(
                     'non sensitive data 3' => '789',

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -277,7 +277,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'non sensitive data 2' => '456',
                 'non sensitive data 3' => '4&56',
                 'non sensitive data 4' => 'a=4&56',
-                'non sensitive data 6' => 'baz&foo=bar',
+                'non sensitive data 6' => '?baz&foo=bar',
                 'sensitive data' => '456',
                 array(
                     'non sensitive data 3' => '789',
@@ -299,7 +299,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'non sensitive data 2' => '456',
                 'non sensitive data 3' => '4&56',
                 'non sensitive data 4' => 'a=4&56',
-                'non sensitive data 6' => 'baz&foo=bar', // this is a weird edge case
+                'non sensitive data 6' => '?baz=&foo=xxxxxxxx',
                 'sensitive data' => '********',
                 array(
                     'non sensitive data 3' => '789',
@@ -318,7 +318,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             // $testData
-            http_build_query(
+            '?' . http_build_query(
                 array(
                     'arg1' => 'val 1',
                     'sensitive' => 'scrubit',
@@ -329,7 +329,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'sensitive'
             ),
             // $expected
-            http_build_query(
+            '?' . http_build_query(
                 array(
                     'arg1' => 'val 1',
                     'sensitive' => 'xxxxxxxx',
@@ -343,7 +343,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             // $testData
-            http_build_query(
+            '?' . http_build_query(
                 array(
                     'arg1' => 'val 1',
                     'sensitive' => 'scrubit',
@@ -357,7 +357,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'sensitive'
             ),
             // $expected
-            http_build_query(
+            '?' . http_build_query(
                 array(
                     'arg1' => 'val 1',
                     'sensitive' => 'xxxxxxxx',
@@ -380,7 +380,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 array(
                     'non sensitive data 3' => '789',
                     'recursive sensitive data' => 'qwe',
-                    'non sensitive data 3' => http_build_query(
+                    'non sensitive data 3' => '?' . http_build_query(
                         array(
                             'arg1' => 'val 1',
                             'sensitive' => 'scrubit',
@@ -407,7 +407,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 array(
                     'non sensitive data 3' => '789',
                     'recursive sensitive data' => '********',
-                    'non sensitive data 3' => http_build_query(
+                    'non sensitive data 3' => '?' . http_build_query(
                         array(
                             'arg1' => 'val 1',
                             'sensitive' => 'xxxxxxxx',


### PR DESCRIPTION
Any string with an equal sign should not be considered a query string, otherwise exceptions with
database statements can end up url encoded.

For example:

```php
 18 class MyException extends Exception { }
 19
 20 $message = "Sql_Error_Data_truncated_for_column_'c_f'_at_row_1_SQL:_UPDATE_`a_b_c`_SET_`id`_='999',_`a_b_id`_='1234',_`c_r_id`_='888',_`position_id`_='44',_`user_id`_='32',_`date_created`_='2017-10-07_12:18:08_WHERE_`id`_= '1234'";
 21
 22 try {
 23     throw new \MyException($message);
 24 } catch (\Exception $e) {
 25     Rollbar::log(Level::error(), $e);
 26 }
```

Prior to this change, the message would get url encoded and be unreadable.