### PR TITLE
Check if include error code context config value explicitly is not null. Error code context should be off by default.

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -263,7 +263,7 @@ class DataBuilder implements DataBuilderInterface
     {
         $fromConfig = $this->tryGet($c, 'include_error_code_context');
         $this->includeCodeContext = true;
-        if ($fromConfig != null) {
+        if ($fromConfig !== null) {
             $this->includeCodeContext = $fromConfig;
         }
     }


### PR DESCRIPTION
When `include_error_code_context` is set to "false", the `$fromConfig != null` check will falsely return `false`. Explicitly checking for a null value will fix this.

And since this is not working at the moment, include code context is now on by default while it should be off.