### PR TITLE
fix how include_error_code_context works with defaults

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -45,7 +45,7 @@ class DataBuilder implements DataBuilderInterface
     protected $notifier;
     protected $baseException;
     protected $includeCodeContext;
-    protected $includeExceptionCodeContext;
+    protected $includeExcCodeContext;
     protected $shiftFunction;
     protected $sendMessageTrace;
 
@@ -79,7 +79,7 @@ class DataBuilder implements DataBuilderInterface
         $this->setNotifier($config);
         $this->setBaseException($config);
         $this->setIncludeCodeContext($config);
-        $this->setIncludeExceptionCodeContext($config);
+        $this->setIncludeExcCodeContext($config);
         $this->setSendMessageTrace($config);
 
         $this->shiftFunction = $this->tryGet($config, 'shift_function');
@@ -152,39 +152,39 @@ class DataBuilder implements DataBuilderInterface
         $this->sendMessageTrace = self::$defaults->sendMessageTrace($fromConfig);
     }
 
-    protected function setCodeVersion($c)
+    protected function setCodeVersion($config)
     {
-        $fromConfig = $this->tryGet($c, 'codeVersion');
+        $fromConfig = $this->tryGet($config, 'codeVersion');
         if (!isset($fromConfig)) {
-            $fromConfig = $this->tryGet($c, 'code_version');
+            $fromConfig = $this->tryGet($config, 'code_version');
         }
         $this->codeVersion = self::$defaults->codeVersion($fromConfig);
     }
 
-    protected function setPlatform($c)
+    protected function setPlatform($config)
     {
-        $fromConfig = $this->tryGet($c, 'platform');
+        $fromConfig = $this->tryGet($config, 'platform');
         $this->platform = self::$defaults->platform($fromConfig);
     }
 
-    protected function setFramework($c)
+    protected function setFramework($config)
     {
-        $this->framework = $this->tryGet($c, 'framework');
+        $this->framework = $this->tryGet($config, 'framework');
     }
 
-    protected function setContext($c)
+    protected function setContext($config)
     {
-        $this->context = $this->tryGet($c, 'context');
+        $this->context = $this->tryGet($config, 'context');
     }
 
-    protected function setRequestParams($c)
+    protected function setRequestParams($config)
     {
-        $this->requestParams = $this->tryGet($c, 'requestParams');
+        $this->requestParams = $this->tryGet($config, 'requestParams');
     }
 
-    protected function setRequestBody($c)
+    protected function setRequestBody($config)
     {
-        $this->requestBody = $this->tryGet($c, 'requestBody');
+        $this->requestBody = $this->tryGet($config, 'requestBody');
         
         if (!$this->requestBody) {
             $this->requestBody = file_get_contents("php://input");
@@ -196,94 +196,94 @@ class DataBuilder implements DataBuilderInterface
         $this->requestExtras = $this->tryGet($c, "requestExtras");
     }
 
-    protected function setPerson($c)
+    protected function setPerson($config)
     {
-        $this->person = $this->tryGet($c, 'person');
+        $this->person = $this->tryGet($config, 'person');
     }
 
-    protected function setPersonFunc($c)
+    protected function setPersonFunc($config)
     {
-        $this->personFunc = $this->tryGet($c, 'person_fn');
+        $this->personFunc = $this->tryGet($config, 'person_fn');
     }
 
-    protected function setServerRoot($c)
+    protected function setServerRoot($config)
     {
-        $fromConfig = $this->tryGet($c, 'serverRoot');
+        $fromConfig = $this->tryGet($config, 'serverRoot');
         if (!isset($fromConfig)) {
-            $fromConfig = $this->tryGet($c, 'root');
+            $fromConfig = $this->tryGet($config, 'root');
         }
         $this->serverRoot = self::$defaults->serverRoot($fromConfig);
     }
 
-    protected function setServerBranch($c)
+    protected function setServerBranch($config)
     {
-        $fromConfig = $this->tryGet($c, 'serverBranch');
+        $fromConfig = $this->tryGet($config, 'serverBranch');
         if (!isset($fromConfig)) {
-            $fromConfig = $this->tryGet($c, 'branch');
+            $fromConfig = $this->tryGet($config, 'branch');
         }
         $this->serverBranch = self::$defaults->gitBranch($fromConfig);
     }
 
-    protected function setServerCodeVersion($c)
+    protected function setServerCodeVersion($config)
     {
-        $this->serverCodeVersion = $this->tryGet($c, 'serverCodeVersion');
+        $this->serverCodeVersion = $this->tryGet($config, 'serverCodeVersion');
     }
 
-    protected function setServerExtras($c)
+    protected function setServerExtras($config)
     {
-        $this->serverExtras = $this->tryGet($c, 'serverExtras');
+        $this->serverExtras = $this->tryGet($config, 'serverExtras');
     }
 
-    protected function setCustom($c)
+    protected function setCustom($config)
     {
-        $this->custom = $this->tryGet($c, 'custom');
+        $this->custom = $this->tryGet($config, 'custom');
     }
 
-    protected function setFingerprint($c)
+    protected function setFingerprint($config)
     {
-        $this->fingerprint = $this->tryGet($c, 'fingerprint');
+        $this->fingerprint = $this->tryGet($config, 'fingerprint');
         if (!is_null($this->fingerprint) && !is_callable($this->fingerprint)) {
             $msg = "If set, config['fingerprint'] must be a callable that returns a uuid string";
             throw new \InvalidArgumentException($msg);
         }
     }
 
-    protected function setTitle($c)
+    protected function setTitle($config)
     {
-        $this->title = $this->tryGet($c, 'title');
+        $this->title = $this->tryGet($config, 'title');
         if (!is_null($this->title) && !is_callable($this->title)) {
             $msg = "If set, config['title'] must be a callable that returns a string";
             throw new \InvalidArgumentException($msg);
         }
     }
 
-    protected function setNotifier($c)
+    protected function setNotifier($config)
     {
-        $fromConfig = $this->tryGet($c, 'notifier');
+        $fromConfig = $this->tryGet($config, 'notifier');
         $this->notifier = self::$defaults->notifier($fromConfig);
     }
 
-    protected function setBaseException($c)
+    protected function setBaseException($config)
     {
-        $fromConfig = $this->tryGet($c, 'baseException');
+        $fromConfig = $this->tryGet($config, 'baseException');
         $this->baseException = self::$defaults->baseException($fromConfig);
     }
 
-    protected function setIncludeCodeContext($c)
+    protected function setIncludeCodeContext($config)
     {
-        $fromConfig = $this->tryGet($c, 'include_error_code_context');
+        $fromConfig = $this->tryGet($config, 'include_error_code_context');
         $this->includeCodeContext = self::$defaults->includeCodeContext($fromConfig);
     }
 
-    protected function setIncludeExceptionCodeContext($c)
+    protected function setIncludeExcCodeContext($config)
     {
-        $fromConfig = $this->tryGet($c, 'include_exception_code_context');
-        $this->includeExceptionCodeContext = self::$defaults->includeExceptionCodeContext($fromConfig);
+        $fromConfig = $this->tryGet($config, 'include_exception_code_context');
+        $this->includeExcCodeContext = self::$defaults->includeExcCodeContext($fromConfig);
     }
 
-    protected function setHost($c)
+    protected function setHost($config)
     {
-        $this->host = $this->tryGet($c, 'host');
+        $this->host = $this->tryGet($config, 'host');
     }
 
     /**
@@ -345,13 +345,13 @@ class DataBuilder implements DataBuilderInterface
     public function getExceptionTrace($exc)
     {
         $chain = array();
-        $chain[] = $this->makeTrace($exc, $this->includeExceptionCodeContext);
+        $chain[] = $this->makeTrace($exc, $this->includeExcCodeContext);
 
         $previous = $exc->getPrevious();
 
         $baseException = $this->getBaseException();
         while ($previous instanceof $baseException) {
-            $chain[] = $this->makeTrace($previous, $this->includeExceptionCodeContext);
+            $chain[] = $this->makeTrace($previous, $this->includeExcCodeContext);
             $previous = $previous->getPrevious();
         }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -90,6 +90,8 @@ class Defaults
     private $defaultBaseException;
     private $defaultScrubFields;
     private $defaultSendMessageTrace;
+    private $defaultIncludeCodeContext;
+    private $defaultExceptionIncludeCodeContext;
 
     public function __construct()
     {
@@ -137,6 +139,8 @@ class Defaults
         $this->defaultScrubFields = self::getScrubFields();
         $this->defaultCodeVersion = "";
         $this->defaultSendMessageTrace = false;
+        $this->defaultIncudeCodeContext = false;
+        $this->defaultIncludeExceptionCodeContext = false;
     }
 
     public function messageLevel($level = null)
@@ -197,5 +201,15 @@ class Defaults
     public function scrubFields($scrubFields = null)
     {
         return Utilities::coalesce($scrubFields, $this->defaultScrubFields);
+    }
+
+    public function includeCodeContext($includeCodeContext = null)
+    {
+        return Utilities::coalesce($includeCodeContext, $this->defaultIncludeCodeContext);
+    }
+
+    public function includeExceptionCodeContext($includeExceptionCodeContext = null)
+    {
+        return Utilities::coalesce($includeExceptionCodeContext, $this->defaultIncludeExceptionCodeContext);
     }
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -91,7 +91,7 @@ class Defaults
     private $defaultScrubFields;
     private $defaultSendMessageTrace;
     private $defaultIncludeCodeContext;
-    private $defaultIncludeExceptionCodeContext;
+    private $defaultIncludeExcCodeContext;
 
     public function __construct()
     {
@@ -140,7 +140,7 @@ class Defaults
         $this->defaultCodeVersion = "";
         $this->defaultSendMessageTrace = false;
         $this->defaultIncludeCodeContext = false;
-        $this->defaultIncludeExceptionCodeContext = false;
+        $this->defaultIncludeExcCodeContext = false;
     }
 
     public function messageLevel($level = null)
@@ -208,8 +208,8 @@ class Defaults
         return Utilities::coalesce($includeCodeContext, $this->defaultIncludeCodeContext);
     }
 
-    public function includeExceptionCodeContext($includeExceptionCodeContext = null)
+    public function includeExcCodeContext($includeExcCodeContext = null)
     {
-        return Utilities::coalesce($includeExceptionCodeContext, $this->defaultIncludeExceptionCodeContext);
+        return Utilities::coalesce($includeExcCodeContext, $this->defaultIncludeExcCodeContext);
     }
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -91,7 +91,7 @@ class Defaults
     private $defaultScrubFields;
     private $defaultSendMessageTrace;
     private $defaultIncludeCodeContext;
-    private $defaultExceptionIncludeCodeContext;
+    private $defaultIncludeExceptionCodeContext;
 
     public function __construct()
     {
@@ -139,7 +139,7 @@ class Defaults
         $this->defaultScrubFields = self::getScrubFields();
         $this->defaultCodeVersion = "";
         $this->defaultSendMessageTrace = false;
-        $this->defaultIncudeCodeContext = false;
+        $this->defaultIncludeCodeContext = false;
         $this->defaultIncludeExceptionCodeContext = false;
     }
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -412,7 +412,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'line' => 99
             ),
         );
-        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backtrace))->getFrames();
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(E_ERROR, 'bork', null, null, $backtrace))->getFrames();
         $this->assertNull($output[0]->getContext());
     }
 
@@ -455,7 +455,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         }
         fclose($file);
 
-        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backTrace))->getFrames();
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(E_ERROR, 'bork', null, null, $backTrace))->getFrames();
         $pre = $output[0]->getContext()->getPre();
 
         $expected = array();
@@ -507,7 +507,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         }
         fclose($file);
 
-        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backTrace))->getFrames();
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(E_ERROR, 'bork', null, null, $backTrace))->getFrames();
         $this->assertNull($output[0]->getContext());
     }
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -366,7 +366,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'include_error_code_context' => true,
             'include_exception_code_context' => false
         ));
-        $output = $dataBuilder->makeFrames(new \Exception());
+        $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNull($output[1]->getContext());
     }
 
@@ -376,7 +376,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-        $output = $dataBuilder->makeFrames(new \Exception());
+        $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNull($output[1]->getContext());
     }
 
@@ -387,7 +387,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'environment' => 'tests',
             'include_exception_code_context' => true
         ));
-        $output = $dataBuilder->makeFrames(new \Exception());
+        $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNotEmpty($output[1]->getContext());
     }
 
@@ -412,7 +412,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'line' => 99
             ),
         );
-        $output = $dataBuilder->makeFrames(new ErrorWrapper(null, null, null, null, $backtrace), true);
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backtrace))->getFrames();
         $this->assertNull($output[0]->getContext());
     }
 
@@ -455,7 +455,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         }
         fclose($file);
 
-        $output = $dataBuilder->makeFrames(new ErrorWrapper(null, null, null, null, $backTrace), true);
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backTrace))->getFrames();
         $pre = $output[0]->getContext()->getPre();
 
         $expected = array();
@@ -507,7 +507,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         }
         fclose($file);
 
-        $output = $dataBuilder->makeFrames(new ErrorWrapper(null, null, null, null, $backTrace));
+        $output = $dataBuilder->getErrorTrace(new ErrorWrapper(null, null, null, null, $backTrace))->getFrames();
         $this->assertNull($output[0]->getContext());
     }
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -399,7 +399,19 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'include_error_code_context' => false,
             'include_exception_code_context' => true
         ));
-        $backtrace = array(array());
+        $testFilePath = __DIR__ . '/DataBuilderTest.php';
+        $backtrace = array(
+            array(
+                'file' => $testFilePath,
+                'function' => 'testFramesWithoutContext',
+                'line' => 42
+            ),
+            array(
+                'file' => $testFilePath,
+                'function' => 'testFramesWithContext',
+                'line' => 99
+            ),
+        );
         $output = $dataBuilder->makeFrames(new ErrorWrapper(null, null, null, null, $backtrace), true);
         $this->assertNull($output[0]->getContext());
     }


### PR DESCRIPTION
Also add back the include_exception_code_context option that is mentioned in the docs but disappeared