### PR TITLE
Fix potential index into empty array

### DIFF
--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -19,8 +19,11 @@ class Defaults
     private static function getGitHash()
     {
         try {
-            @exec('git rev-parse --verify HEAD 2> /dev/null', $output);
-            return @$output[0];
+            exec('git rev-parse --verify HEAD 2> /dev/null', $output);
+            if ($output) {
+                return $output[0];
+            }
+            return null;
         } catch (\Exception $e) {
             return null;
         }
@@ -29,8 +32,11 @@ class Defaults
     private static function getGitBranch()
     {
         try {
-            @exec('git rev-parse --abbrev-ref HEAD 2> /dev/null', $output);
-            return @$output[0];
+            exec('git rev-parse --abbrev-ref HEAD 2> /dev/null', $output);
+            if ($output) {
+                return $output[0];
+            }
+            return null;
         } catch (\Exception $e) {
             return null;
         }


### PR DESCRIPTION
This issue was raised as repro steps in https://github.com/rollbar/rollbar-php/pull/161
Fix the bug that leads to an error. Also get rid of the error swallowing @ usage.