### PR TITLE
Testing for existance of `exec()`

### DIFF
--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -19,9 +19,11 @@ class Defaults
     private static function getGitHash()
     {
         try {
-            exec('git rev-parse --verify HEAD 2> /dev/null', $output);
-            if ($output) {
-                return $output[0];
+            if (function_exists('exec')) {
+                exec('git rev-parse --verify HEAD 2> /dev/null', $output);
+                if ($output) {
+                    return $output[0];
+                }
             }
             return null;
         } catch (\Exception $e) {
@@ -32,9 +34,11 @@ class Defaults
     private static function getGitBranch()
     {
         try {
-            exec('git rev-parse --abbrev-ref HEAD 2> /dev/null', $output);
-            if ($output) {
-                return $output[0];
+            if (function_exists('exec')) {
+                exec('git rev-parse --abbrev-ref HEAD 2> /dev/null', $output);
+                if ($output) {
+                    return $output[0];
+                }
             }
             return null;
         } catch (\Exception $e) {


### PR DESCRIPTION
Tests for existence of `exec()` function so as not to raise notices on systems where "exec() has been disabled for security reasons".