### PR TITLE
GitHub Issue #173: add stack frame arguments values to traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,12 @@ Default: No proxy
 Default: `false`
 </dd>
 
+<dt>local_vars_dump</dt>
+<dd>Should backtraces include arguments passed to stack frames.
+
+Default: `false`
+</dd>
+
 </dl>
 
 Example use of error_sample_rates:

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -402,11 +402,15 @@ class DataBuilder implements DataBuilderInterface
             $filename = Utilities::coalesce($this->tryGet($frameInfo, 'file'), '<internal>');
             $lineno = Utilities::coalesce($this->tryGet($frameInfo, 'line'), 0);
             $method = $frameInfo['function'];
-            // TODO 4 (arguments are in $frame)
+            $args = Utilities::coalesce($this->tryGet($frameInfo, 'args'), null);
 
             $frame = new Frame($filename);
             $frame->setLineno($lineno)
                 ->setMethod($method);
+                
+            if ($this->localVarsDump && $args !== null) {
+                $frame->setArgs($args);
+            }
 
             if ($includeContext) {
                 $this->addCodeContextToFrame($frame, $filename, $lineno);

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -473,8 +473,8 @@ class DataBuilder implements DataBuilderInterface
         return new Message(
             (string)$toLog,
             $context,
-            $this->sendMessageTrace ? 
-                debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS) : 
+            $this->sendMessageTrace ?
+                debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS) :
                 null
         );
     }
@@ -997,12 +997,12 @@ class DataBuilder implements DataBuilderInterface
     
     /**
      * Wrap a PHP error in an ErrorWrapper class and add backtrace information
-     * 
+     *
      * @param string $errno
      * @param string $errstr
      * @param string $errfile
      * @param string $errline
-     * 
+     *
      * @return ErrorWrapper
      */
     public function generateErrorWrapper($errno, $errstr, $errfile, $errline)

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -994,4 +994,25 @@ class DataBuilder implements DataBuilderInterface
     {
         return strlen(json_encode($payload)) > self::MAX_PAYLOAD_SIZE;
     }
+    
+    /**
+     * Wrap a PHP error in an ErrorWrapper class and add backtrace information
+     * 
+     * @param string $errno
+     * @param string $errstr
+     * @param string $errfile
+     * @param string $errline
+     * 
+     * @return ErrorWrapper
+     */
+    public function generateErrorWrapper($errno, $errstr, $errfile, $errline)
+    {
+        // removing this function and the handler function to make sure they're
+        // not part of the backtrace
+        $backTrace = array_slice(
+            debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS),
+            2
+        );
+        return new ErrorWrapper($errno, $errstr, $errfile, $errline, $backTrace);
+    }
 }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -57,6 +57,7 @@ class DataBuilder implements DataBuilderInterface
     protected $includeExcCodeContext;
     protected $shiftFunction;
     protected $sendMessageTrace;
+    protected $localVarsDump;
 
     public function __construct($config)
     {
@@ -90,6 +91,7 @@ class DataBuilder implements DataBuilderInterface
         $this->setIncludeCodeContext($config);
         $this->setIncludeExcCodeContext($config);
         $this->setSendMessageTrace($config);
+        $this->setLocalVarsDump($config);
 
         $this->shiftFunction = $this->tryGet($config, 'shift_function');
         if (!isset($this->shiftFunction)) {
@@ -159,6 +161,12 @@ class DataBuilder implements DataBuilderInterface
     {
         $fromConfig = $this->tryGet($config, 'send_message_trace');
         $this->sendMessageTrace = self::$defaults->sendMessageTrace($fromConfig);
+    }
+
+    protected function setLocalVarsDump($config)
+    {
+        $fromConfig = $this->tryGet($config, 'local_vars_dump');
+        $this->localVarsDump = self::$defaults->localVarsDump($fromConfig);
     }
 
     protected function setCodeVersion($config)
@@ -461,7 +469,9 @@ class DataBuilder implements DataBuilderInterface
         return new Message(
             (string)$toLog,
             $context,
-            $this->sendMessageTrace ? debug_backtrace() : null
+            $this->sendMessageTrace ? 
+                debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS) : 
+                null
         );
     }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -86,6 +86,11 @@ class Defaults
     {
         return $sendMessageTrace ? $sendMessageTrace : $this->defaultSendMessageTrace;
     }
+    
+    public function localVarsDump($localVarsDump = null)
+    {
+        return $localVarsDump ? $localVarsDump : $this->defaultLocalVarsDump;
+    }
 
     private $defaultMessageLevel = "warning";
     private $defaultExceptionLevel = "error";
@@ -102,6 +107,7 @@ class Defaults
     private $defaultSendMessageTrace;
     private $defaultIncludeCodeContext;
     private $defaultIncludeExcCodeContext;
+    private $defaultLocalVarsDump;
 
     public function __construct()
     {
@@ -151,6 +157,7 @@ class Defaults
         $this->defaultSendMessageTrace = false;
         $this->defaultIncludeCodeContext = false;
         $this->defaultIncludeExcCodeContext = false;
+        $this->defaultLocalVarsDump = false;
     }
 
     public function messageLevel($level = null)

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -108,10 +108,13 @@ class Rollbar
 
     private static function generateErrorWrapper($errno, $errstr, $errfile, $errline)
     {
-        // removing this function and the handler function to make sure they're
-        // not part of the backtrace
-        $backTrace = array_slice(debug_backtrace(), 2);
-        return new ErrorWrapper($errno, $errstr, $errfile, $errline, $backTrace);
+        if (null === self::$logger) {
+            return;
+        }
+        
+        $dataBuilder = self::$logger->getDataBuilder();
+        
+        return $dataBuilder->generateErrorWrapper($errno, $errstr, $errfile, $errline);
     }
 
     private static function getNotInitializedResponse()

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -65,6 +65,11 @@ class RollbarLogger extends AbstractLogger
     {
         return $this->config->getAccessToken();
     }
+    
+    public function getDataBuilder()
+    {
+        return $this->config->getDataBuilder();
+    }
 
     protected function handleResponse($payload, $response)
     {

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -1009,4 +1009,11 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         return $data;
     }
+    
+    public function testGenerateErrorWrapper()
+    {
+        $result = $this->dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
+        
+        $this->assertInstanceOf(ErrorWrapper::class, $result);
+    }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -1015,6 +1015,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
         
-        $this->assertInstanceOf("ErrorWrapper", $result);
+        $this->assertTrue($result instanceof ErrorWrapper);
     }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -378,7 +378,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         $this->assertArrayNotHasKey(
             'args',
-            $frames[0], 
+            $frames[0],
             "Arguments in stack frames included when they should have not been."
         );
         

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -366,12 +366,12 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetMessageTraceArguments()
     {
         // Negative test
-        $c = new Config(array(
+        $config = new Config(array(
             'access_token' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'send_message_trace' => true
         ));
-        $dataBuilder = $c->getDataBuilder();
+        $dataBuilder = $config->getDataBuilder();
     
         $result = $dataBuilder->makeData(Level::fromName('error'), 'testing', array());
         $frames = $result->getBody()->getValue()->getBacktrace();
@@ -383,13 +383,13 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         );
         
         // Positive test
-        $c = new Config(array(
+        $config = new Config(array(
             'access_token' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'send_message_trace' => true,
             'local_vars_dump' => true
         ));
-        $dataBuilder = $c->getDataBuilder();
+        $dataBuilder = $config->getDataBuilder();
     
         $expected = 'testing';
         $result = $dataBuilder->makeData(Level::fromName('error'), $expected, array());
@@ -409,9 +409,12 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-        $ex = $this->exceptionTraceArgsHelper('trace args message');
-        $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
-        $this->assertNull($frames[0]->getArgs(), "Frames arguments available in trace when they should not be.");
+        $exception = $this->exceptionTraceArgsHelper('trace args message');
+        $frames = $dataBuilder->getExceptionTrace($exception)->getFrames();
+        $this->assertNull(
+            $frames[0]->getArgs(),
+            "Frames arguments available in trace when they should not be."
+        );
         
         // Positive test
         $dataBuilder = new DataBuilder(array(
@@ -420,11 +423,15 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'local_vars_dump' => true
         ));
         $expected = 'trace args message';
-        $ex = $this->exceptionTraceArgsHelper($expected);
-        $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
+        $exception = $this->exceptionTraceArgsHelper($expected);
+        $frames = $dataBuilder->getExceptionTrace($exception)->getFrames();
         $args = $frames[0]->getArgs();
         
-        $this->assertEquals($expected, $args[0], "Frames arguments NOT available in trace when they should be.");
+        $this->assertEquals(
+            $expected, 
+            $args[0], 
+            "Frames arguments NOT available in trace when they should be."
+        );
     }
     
     private function exceptionTraceArgsHelper($message)

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -416,8 +416,9 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $expected = 'trace args message';
         $ex = $this->exceptionTraceArgsHelper($expected);
         $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
+        $args = $frames[0]->getArgs();
         
-        $this->assertEquals($frames[0]->getArgs()[0], $expected, "Frames arguments NOT available in trace when they should be.");
+        $this->assertEquals($expected, $args[0], "Frames arguments NOT available in trace when they should be.");
     }
     
     private function exceptionTraceArgsHelper($message)

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -1015,6 +1015,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $result = $this->dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
         
-        $this->assertInstanceOf(ErrorWrapper::class, $result);
+        $this->assertInstanceOf("ErrorWrapper", $result);
     }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -348,6 +348,10 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertNull($result->getBody()->getValue()->getBacktrace());
+    }
+    
+    public function testGetMessageSendMessageTrace()
+    {
         
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
@@ -357,6 +361,39 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     
         $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
+        
+    }
+    
+    public function testGetMessageTraceArguments()
+    {
+        // Negative test
+        $c = new Config(array(
+            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests',
+            'send_message_trace' => true
+        ));
+        $dataBuilder = $c->getDataBuilder();
+    
+        $result = $dataBuilder->makeData(Level::fromName('error'), 'testing', array());
+        $frames = $result->getBody()->getValue()->getBacktrace();
+        
+        $this->assertArrayNotHasKey('args', $frames[0], "Arguments in stack frames included when they should have not been.");
+        
+        // Positive test
+        $c = new Config(array(
+            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests',
+            'send_message_trace' => true,
+            'local_vars_dump' => true
+        ));
+        $dataBuilder = $c->getDataBuilder();
+    
+        $expected = 'testing';
+        $result = $dataBuilder->makeData(Level::fromName('error'), $expected, array());
+        $frames = $result->getBody()->getValue()->getBacktrace();
+        
+        $this->assertEquals($frames[0]['args'][0], $expected, "Arguments in stack frames NOT included when they should be.");
+        
     }
 
     public function testExceptionFramesWithoutContext()

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -376,7 +376,11 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $result = $dataBuilder->makeData(Level::fromName('error'), 'testing', array());
         $frames = $result->getBody()->getValue()->getBacktrace();
         
-        $this->assertArrayNotHasKey('args', $frames[0], "Arguments in stack frames included when they should have not been.");
+        $this->assertArrayNotHasKey(
+            'args',
+            $frames[0], 
+            "Arguments in stack frames included when they should have not been."
+        );
         
         // Positive test
         $c = new Config(array(
@@ -391,7 +395,11 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $result = $dataBuilder->makeData(Level::fromName('error'), $expected, array());
         $frames = $result->getBody()->getValue()->getBacktrace();
         
-        $this->assertEquals($frames[0]['args'][0], $expected, "Arguments in stack frames NOT included when they should be.");
+        $this->assertEquals(
+            $expected,
+            $frames[0]['args'][0],
+            "Arguments in stack frames NOT included when they should be."
+        );
     }
     
     public function testExceptionTraceArguments()

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -361,7 +361,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     
         $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
         $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
-        
     }
     
     public function testGetMessageTraceArguments()
@@ -393,7 +392,6 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $frames = $result->getBody()->getValue()->getBacktrace();
         
         $this->assertEquals($frames[0]['args'][0], $expected, "Arguments in stack frames NOT included when they should be.");
-        
     }
     
     public function testExceptionTraceArguments()

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -395,6 +395,35 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($frames[0]['args'][0], $expected, "Arguments in stack frames NOT included when they should be.");
         
     }
+    
+    public function testExceptionTraceArguments()
+    {
+        // Negative test
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests'
+        ));
+        $ex = $this->exceptionTraceArgsHelper('trace args message');
+        $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
+        $this->assertNull($frames[0]->getArgs(), "Frames arguments available in trace when they should not be.");
+        
+        // Positive test
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'environment' => 'tests',
+            'local_vars_dump' => true
+        ));
+        $expected = 'trace args message';
+        $ex = $this->exceptionTraceArgsHelper($expected);
+        $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
+        
+        $this->assertEquals($frames[0]->getArgs()[0], $expected, "Frames arguments NOT available in trace when they should be.");
+    }
+    
+    private function exceptionTraceArgsHelper($message)
+    {
+        return new \Exception($message);
+    }
 
     public function testExceptionFramesWithoutContext()
     {


### PR DESCRIPTION
This PR adds `local_vars_dump` configuration option. If enabled traces sent to Rollbar will include the values of arguments passed to each frame in stack traces.