### PR TITLE
Fixed crash when getting stack trace from file with unexpected line endings.

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -424,12 +424,8 @@ class DataBuilder implements DataBuilderInterface
             return;
         }
 
-        $source = explode(PHP_EOL, file_get_contents($filename));
-        if (!is_array($source)) {
-            return;
-        }
+        $source = $this->getSourceLines($filename);
 
-        $source = str_replace(array("\n", "\t", "\r"), '', $source);
         $total = count($source);
         $line = $line - 1;
         $frame->setCode($source[$line]);
@@ -979,5 +975,34 @@ class DataBuilder implements DataBuilderInterface
     public function needsTruncating(array $payload)
     {
         return strlen(json_encode($payload)) > self::MAX_PAYLOAD_SIZE;
+    }
+
+    /**
+     * Parses an array of code lines from source file with given filename.
+     *
+     * Attempts to automatically detect the line break character used in the file.
+     *
+     * @param string $filename
+     * @return string[] An array of lines of code from the given source file.
+     */
+    private function getSourceLines($filename)
+    {
+        $rawSource = file_get_contents($filename);
+
+        $source = explode(PHP_EOL, $rawSource);
+
+        if (count($source) === 1) {
+            if (substr_count($rawSource, "\n") > substr_count($rawSource, "\r")) {
+                $source = explode("\n", $rawSource);
+                return $source;
+            } else {
+                $source = explode("\r", $rawSource);
+                return $source;
+            }
+        }
+
+        $source = str_replace(array("\n", "\t", "\r"), '', $source);
+
+        return $source;
     }
 }


### PR DESCRIPTION
I.e., for file with line endings different from system default (the PHP_EOL). 

For example: if a method in the stack trace was contained in a file with Unix
line endings("\n") on a development Windows machine (where PHP_EOL is "\r\n").
Then the application crashes endlessly, as a new exception is thrown every time
a stack trace is being generated for the last one. Because the program tries
to read line X from an array with only one element (since the split of file
into lines by line breaks failed) which in turn throws another error.

The error was quite severe as it loops on itself endlessly.