### PR TITLE
Prevent endless loop if the $exc->getPrevious() equals the exception itself.

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -361,7 +361,7 @@ class DataBuilder implements DataBuilderInterface
         $baseException = $this->getBaseException();
         while ($previous instanceof $baseException) {
             $chain[] = $this->makeTrace($previous, $this->includeExcCodeContext);
-            if($exc->getPrevious() === $previous){
+            if ($exc->getPrevious() === $previous) {
                 break;
             }
             $previous = $previous->getPrevious();

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -361,6 +361,9 @@ class DataBuilder implements DataBuilderInterface
         $baseException = $this->getBaseException();
         while ($previous instanceof $baseException) {
             $chain[] = $this->makeTrace($previous, $this->includeExcCodeContext);
+            if($exc->getPrevious() === $previous){
+                break;
+            }
             $previous = $previous->getPrevious();
         }
 


### PR DESCRIPTION
Some external libraries in our project generate exception objects which contain reference to themselves as the previous exception.

This commit allows the Rollbar code to detect such a situation and break out from an otherwise endless loop.