### PR TITLE
Add emergency, alert, notice to supported levels (PSR3)

### DIFF
--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -8,9 +8,12 @@ class Level implements \JsonSerializable
     {
         if (is_null(self::$values)) {
             self::$values = array(
+                "emergency" => new Level("emergency", 10000000),
+                "alert" => new Level("alert", 1000000),
                 "critical" => new Level("critical", 100000),
                 "error" => new Level("error", 10000),
                 "warning" => new Level("warning", 1000),
+                "notice" => new Level("notice", 500),
                 "info" => new Level("info", 100),
                 "debug" => new Level("debug", 10),
                 "ignored" => new Level("ignore", 0),

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -292,4 +292,92 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             'x' // query string is scrubbed with "x" rather than "*"
         );
     }
+
+    public function testPsr3Emergency()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->emergency("Testing PHP Notifier");
+    }
+
+    public function testPsr3Alert()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->alert("Testing PHP Notifier");
+    }
+
+    public function testPsr3Critical()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->critical("Testing PHP Notifier");
+    }
+
+    public function testPsr3Error()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->error("Testing PHP Notifier");
+    }
+
+    public function testPsr3Warning()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->warning("Testing PHP Notifier");
+    }
+
+    public function testPsr3Notice()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->notice("Testing PHP Notifier");
+    }
+
+    public function testPsr3Info()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->info("Testing PHP Notifier");
+    }
+
+    public function testPsr3Debug()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
+
+        // Test that no \Psr\Log\InvalidArgumentException is thrown
+        $l->debug("Testing PHP Notifier");
+    }
 }


### PR DESCRIPTION
Hello,

This PR added a throw of a Psr exception, https://github.com/rollbar/rollbar-php/pull/131 , but some standards levels are not supported...

The priority are based on https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#11-basics which redirects to https://tools.ietf.org/html/rfc5424#section-6.2.1 ( end of 6.2.1 )