### PR TITLE
GitHub Issue #153: Issues with using a custom API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,9 +224,16 @@ All of the following options can be passed as keys in the `$config` array.
 Default: `/var/www`
 </dd>
 
+<dt>endpoint
+</dt>
+<dd>The API URL to post to. Note: the URL has to end with a trailing slash.
+
+Default: `https://api.rollbar.com/api/1/`
+</dd>
+
 <dt>base_api_url
 </dt>
-<dd>The base api url to post to.
+<dd><strong>Deprecated (use <i>endpoint</i> instead).</strong> The base api url to post to.
 
 Default: `https://api.rollbar.com/api/1/`
 </dd>

--- a/src/Config.php
+++ b/src/Config.php
@@ -162,7 +162,11 @@ class Config
         $default = "Rollbar\Senders\CurlSender";
 
         if (array_key_exists('base_api_url', $c)) {
-            $c['senderOptions']['endpoint'] = $c['base_api_url'];
+            $c['senderOptions']['endpoint'] = $c['base_api_url'] . 'item/';
+        }
+
+        if (array_key_exists('endpoint', $c)) {
+            $c['senderOptions']['endpoint'] = $c['endpoint'] . 'item/';
         }
 
         if (array_key_exists('timeout', $c)) {
@@ -262,6 +266,11 @@ class Config
     public function getDataBuilder()
     {
         return $this->dataBuilder;
+    }
+    
+    public function getSender()
+    {
+        return $this->sender;
     }
 
     /**

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -38,6 +38,11 @@ class CurlSender implements SenderInterface
             $this->verifyPeer = $opts['verifyPeer'];
         }
     }
+    
+    public function getEndpoint()
+    {
+        return $this->endpoint;
+    }
 
     public function send($scrubbedPayload, $accessToken)
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -207,6 +207,40 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         ));
         $c->send($p, $this->token);
     }
+    
+    public function testEndpoint()
+    {
+        $payload = m::mock("Rollbar\Payload\Payload");
+            
+        $config = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env,
+            "sender" => $sender,
+            "endpoint" => "http://localhost/api/1/"
+        ));
+        
+        $this->assertEquals(
+            "http://localhost/api/1/item/",
+            $config->getSender()->getEndpoint()
+        );
+    }
+    
+    public function testBaseApiUrl()
+    {
+        $payload = m::mock("Rollbar\Payload\Payload");
+            
+        $config = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env,
+            "sender" => $sender,
+            "base_api_url" => "http://localhost/api/1/"
+        ));
+        
+        $this->assertEquals(
+            "http://localhost/api/1/item/",
+            $config->getSender()->getEndpoint()
+        );
+    }
 
     public function testCheckIgnore()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -215,7 +215,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "sender" => $sender,
             "endpoint" => "http://localhost/api/1/"
         ));
         
@@ -232,7 +231,6 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "sender" => $sender,
             "base_api_url" => "http://localhost/api/1/"
         ));
         

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -224,6 +224,21 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         );
     }
     
+    public function testEndpointDefault()
+    {
+        $payload = m::mock("Rollbar\Payload\Payload");
+            
+        $config = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env
+        ));
+        
+        $this->assertEquals(
+            "https://api.rollbar.com/api/1/item/",
+            $config->getSender()->getEndpoint()
+        );
+    }
+    
     public function testBaseApiUrl()
     {
         $payload = m::mock("Rollbar\Payload\Payload");
@@ -236,6 +251,21 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         
         $this->assertEquals(
             "http://localhost/api/1/item/",
+            $config->getSender()->getEndpoint()
+        );
+    }
+    
+    public function testBaseApiUrlDefault()
+    {
+        $payload = m::mock("Rollbar\Payload\Payload");
+            
+        $config = new Config(array(
+            "access_token" => $this->token,
+            "environment" => $this->env
+        ));
+        
+        $this->assertEquals(
+            "https://api.rollbar.com/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }


### PR DESCRIPTION
In 1.0.0 the behavior of `base_api_url` was changed and required additional _item/_ at the end. This was both not in sync with other SDKs and backwards incompatible.

This PR brings back the the behavior from 0.18.2 which doesn't require the _item/_ URL path.

Also, `base_api_url` is deprecated from now on in favor of `endpoint` which is in sync with how other SDKs work.