### PR TITLE
Decoupling of RollbarLogger in init

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,23 @@ Rollbar::log(
 ?>
 ```
 
+## Using dependency injection
+
+If you're using dependency injection containers, you can create and get a `RollbarLogger` from the container and use it
+to initialize Rollbar error logging.
+
+It's up to the container to properly create and configure the logger.
+
+```php
+use Rollbar\Rollbar;
+use Rollbar\RollbarLogger;
+
+$logger = $container->get(RollbarLogger::class);
+
+// installs global error and exception handlers
+Rollbar::init($logger);
+```
+
 ## Using Monolog
 
 Here is an example of how to use Rollbar as a handler for Monolog:

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -38,17 +38,15 @@ class Rollbar
     {
         if ($configOrLogger instanceof RollbarLogger) {
             $logger = $configOrLogger;
-        } else {
-            $config = $configOrLogger;
         }
 
         // Replacing the logger rather than configuring the existing logger breaks BC
-        if (self::$logger && isset($config)) {
-            self::$logger->configure($config);
+        if (self::$logger && !isset($logger)) {
+            self::$logger->configure($configOrLogger);
             return;
         }
 
-        self::$logger = isset($logger) ? $logger : new RollbarLogger($config);
+        self::$logger = isset($logger) ? $logger : new RollbarLogger($configOrLogger);
     }
 
     public static function logger()

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -18,7 +18,7 @@ class Rollbar
         $handleFatal = true
     ) {
         if (is_null(self::$logger)) {
-            self::$logger = new RollbarLogger($config);
+            self::$logger = $config instanceof RollbarLogger ? $config : new RollbarLogger($config);
 
             if ($handleException) {
                 self::setupExceptionHandling();

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -7,6 +7,11 @@ if (!defined('ROLLBAR_TEST_TOKEN')) {
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
 
+/**
+ * Usage of static method Rollbar::logger() is intended here.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
 class RollbarTest extends \PHPUnit_Framework_TestCase
 {
 

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -14,12 +14,22 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
         'access_token' => ROLLBAR_TEST_TOKEN,
         'environment' => 'test'
     );
-    
-    public function tearDown()
+
+    private static function clearLogger()
     {
         $reflLoggerProperty = new \ReflectionProperty(Rollbar::class, 'logger');
         $reflLoggerProperty->setAccessible(true);
         $reflLoggerProperty->setValue(null);
+    }
+    
+    public static function setupBeforeClass()
+    {
+        self::clearLogger();
+    }
+
+    public function tearDown()
+    {
+        self::clearLogger();
     }
     
     public function testInitWithConfig()

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -17,7 +17,7 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
 
     private static function clearLogger()
     {
-        $reflLoggerProperty = new \ReflectionProperty(Rollbar::class, 'logger');
+        $reflLoggerProperty = new \ReflectionProperty('Rollbar\Rollbar', 'logger');
         $reflLoggerProperty->setAccessible(true);
         $reflLoggerProperty->setValue(null);
     }
@@ -36,13 +36,13 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
     {
         Rollbar::init(self::$simpleConfig);
         
-        $this->assertInstanceOf(RollbarLogger::class, Rollbar::logger());
+        $this->assertInstanceOf('Rollbar\RollbarLogger', Rollbar::logger());
         $this->assertAttributeEquals(new Config(self::$simpleConfig), 'config', Rollbar::logger());
     }
     
     public function testInitWithLogger()
     {
-        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
 
         Rollbar::init($logger);
         
@@ -51,7 +51,7 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
     
     public function testInitConfigureLogger()
     {
-        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
         $logger->expects($this->once())->method('configure')->with(self::$simpleConfig);
 
         Rollbar::init($logger);
@@ -62,9 +62,9 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
     {
         Rollbar::init(self::$simpleConfig);
 
-        $this->assertInstanceOf(RollbarLogger::class, Rollbar::logger());
+        $this->assertInstanceOf('Rollbar\RollbarLogger', Rollbar::logger());
 
-        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
 
         Rollbar::init($logger);
 


### PR DESCRIPTION
Allow passing a `RollbarLogger` in init instead of creating one from config.
This allows to use a custom `RollbarLogger` by extending the class. You can also get the logger from a container for container based frameworks.