### PR TITLE
Update link to Rollbar Laravel

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ $config['person_fn'] = 'get_current_user';
 
 ## Related projects
 
-A Laravel-specific package is available for integrating with Laravel: [Laravel-Rollbar](https://github.com/jenssegers/Laravel-Rollbar)
+A Laravel-specific package is available for integrating with Laravel: [Rollbar Laravel](https://github.com/rollbar/rollbar-php-laravel)
 
 A CakePHP-specific package is avaliable for integrating with CakePHP 2.x:
 [CakeRollbar](https://github.com/tranfuga25s/CakeRollbar)


### PR DESCRIPTION
Change link to https://github.com/rollbar/rollbar-php-laravel in the doc. This also needs updating at https://rollbar.com/docs/notifier/rollbar-php/