### PR TITLE
Remove fluent log output from composer test

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
 	 convertErrorsToExceptions="true"
 	 convertNoticesToExceptions="true"
 	 convertWarningsToExceptions="true"
-	 processIsolation="false"
+	 processIsolation="true"
 	 stopOnFailure="false"
 	 syntaxCheck="false">
   <testsuites>

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -30,36 +30,36 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
                 'environment' => 'production'
             )
         );
-        
+
         try {
             throw new \Exception('test exception');
         } catch (\Exception $e) {
             Rollbar::log(Level::error(), $e);
         }
-        
+
         // Message at level 'info'
         Rollbar::log(Level::info(), 'testing info level');
-        
+
         // With extra data (3rd arg) and custom payload options (4th arg)
         Rollbar::log(
             Level::info(),
             'testing extra data',
             array("some_key" => "some value") // key-value additional data
         );
-        
+
         // If you want to check if logging with Rollbar was successful
         $response = Rollbar::log(Level::info(), 'testing wasSuccessful()');
         if (!$response->wasSuccessful()) {
             throw new \Exception('logging with Rollbar failed');
         }
-        
+
         // raises an E_NOTICE which will *not* be reported by the error handler
         // $foo = $bar;
-        
+
         // will be reported by the exception handler
         throw new \Exception('testing exception handler');
     }
-    
+
     public function testSetup1()
     {
         $config = array(
@@ -71,10 +71,10 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             'root' => '/Users/brian/www/myapp'
         );
         Rollbar::init($config);
-        
+
         $this->assertTrue(true);
     }
-    
+
     public function testSetup2()
     {
         $config = array(
@@ -85,14 +85,14 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             // optional - path to directory your code is in. used for linking stack traces.
             'root' => '/Users/brian/www/myapp'
         );
-        
+
         $set_exception_handler = false;
         $set_error_handler = false;
         Rollbar::init($config, $set_exception_handler, $set_error_handler);
-        
+
         $this->assertTrue(true);
     }
-    
+
     public function testBasicUsage()
     {
         try {
@@ -103,7 +103,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             Rollbar::log(Level::error(), $e, array("my" => "extra", "data" => 42));
         }
     }
-    
+
     public function testBasicUsage2()
     {
         Rollbar::log(Level::warning(), 'could not connect to mysql server');
@@ -113,17 +113,17 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             array('x' => 10, 'code' => 'blue')
         );
     }
-    
+
     public function testMonolog()
     {
-        $config = array('access_token' => ROLLBAR_TEST_TOKEN);
-        
+        $config = array('access_token' => ROLLBAR_TEST_TOKEN, 'environment' => 'testing');
+
         // installs global error and exception handlers
         Rollbar::init($config);
-        
+
         $log = new Logger('test');
         $log->pushHandler(new \Monolog\Handler\PsrHandler(Rollbar::logger()));
-        
+
         try {
             throw new \Exception('exception for monolog');
         } catch (\Exception $e) {

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -2,7 +2,7 @@
 
 use \Mockery as m;
 use Rollbar\Payload\Trace;
-use rollbar\Payload\Frame;
+use Rollbar\Payload\Frame;
 
 class TraceTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
- isolated tests from each other
- fixed broken tests

Unfortunately I don't know how to fix this test:

```
There was 1 failure:

1) Rollbar\DataBuilderTest::testPersonFuncException
Exception in person_fn was not caught.

/var/www/tests/DataBuilderTest.php:638
```