### PR TITLE
Remove fluent log output from composer test

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -52,11 +52,11 @@ class Rollbar
     {
         set_exception_handler('Rollbar\Rollbar::exceptionHandler');
     }
-    
+
     public static function exceptionHandler($exception)
     {
         self::log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
-        
+
         restore_exception_handler();
         throw $exception;
     }
@@ -80,7 +80,7 @@ class Rollbar
             $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
             self::$logger->log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
         }
-        
+
         return false;
     }
 
@@ -106,14 +106,24 @@ class Rollbar
         }
     }
 
+    /**
+     * resets the instance
+     */
+    public static function reset()
+    {
+        restore_error_handler();
+        restore_exception_handler();
+        self::$logger = null;
+    }
+
     private static function generateErrorWrapper($errno, $errstr, $errfile, $errline)
     {
         if (null === self::$logger) {
             return;
         }
-        
+
         $dataBuilder = self::$logger->getDataBuilder();
-        
+
         return $dataBuilder->generateErrorWrapper($errno, $errstr, $errfile, $errline);
     }
 
@@ -121,15 +131,15 @@ class Rollbar
     {
         return new Response(0, "Rollbar Not Initialized");
     }
-    
+
     // @codingStandardsIgnoreStart
-    
+
     /**
      * Below methods are deprecated and still available only for backwards
      * compatibility. If you're still using them in your application, please
      * transition to using the ::log method as soon as possible.
      */
-    
+
     /**
      * @param \Exception $exc Exception to be logged
      * @param array $extra_data Additional data to be logged with the exception
@@ -143,7 +153,7 @@ class Rollbar
      */
     public static function report_exception($exc, $extra_data = null, $payload_data = null)
     {
-        
+
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
         }
@@ -164,7 +174,7 @@ class Rollbar
      */
     public static function report_message($message, $level = null, $extra_data = null, $payload_data = null)
     {
-        
+
         $level = $level ? Level::fromName($level) : Level::error();
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
@@ -204,6 +214,6 @@ class Rollbar
     {
         return;
     }
-    
+
     // @codingStandardsIgnoreEnd
 }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -3,13 +3,14 @@
 namespace Rollbar\Senders; // in a different namespace, so we can monkey-patch microtime.
 
 use Rollbar;
+use Rollbar\BaseUnitTestCase;
 
 function microtime($getAsFloat)
 {
     return 2;
 }
 
-class AgentTest extends \PHPUnit_Framework_TestCase
+class AgentTest extends BaseUnitTestCase
 {
     private $path = '/tmp/rollbar-php';
 
@@ -38,6 +39,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
     protected function tearDown()
     {
         $this->rrmdir($this->path);
+        parent::tearDown();
     }
 
     private function rrmdir($dir)

--- a/tests/BackwardsCompatibilityConfigTest.php
+++ b/tests/BackwardsCompatibilityConfigTest.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar;
 
-class BackwardsCompatibilityConfigTest extends \PHPUnit_Framework_TestCase
+class BackwardsCompatibilityConfigTest extends BaseUnitTestCase
 {
     public function testConfigValues()
     {

--- a/tests/BaseUnitTestCase.php
+++ b/tests/BaseUnitTestCase.php
@@ -1,0 +1,14 @@
+<?php
+namespace Rollbar;
+
+
+abstract class BaseUnitTestCase extends \PHPUnit_Framework_TestCase
+{
+
+    protected function tearDown()
+    {
+        // make sure each test starts with a "fresh" instance
+        Rollbar::reset();
+        parent::tearDown();
+    }
+}

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Body;
 
-class BodyTest extends \PHPUnit_Framework_TestCase
+class BodyTest extends BaseUnitTestCase
 {
     public function testBodyValue()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,7 +10,7 @@ use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
 use Psr\Log\LogLevel;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends BaseUnitTestCase
 {
     private $error;
 
@@ -22,6 +22,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         m::close();
+        parent::tearDown();
     }
 
     private $token = "abcd1234efef5678abcd1234567890be";
@@ -208,63 +209,63 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         ));
         $c->send($p, $this->token);
     }
-    
+
     public function testEndpoint()
     {
         $payload = m::mock("Rollbar\Payload\Payload");
-            
+
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
             "endpoint" => "http://localhost/api/1/"
         ));
-        
+
         $this->assertEquals(
             "http://localhost/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testEndpointDefault()
     {
         $payload = m::mock("Rollbar\Payload\Payload");
-            
+
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env
         ));
-        
+
         $this->assertEquals(
             "https://api.rollbar.com/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testBaseApiUrl()
     {
         $payload = m::mock("Rollbar\Payload\Payload");
-            
+
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
             "base_api_url" => "http://localhost/api/1/"
         ));
-        
+
         $this->assertEquals(
             "http://localhost/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testBaseApiUrlDefault()
     {
         $payload = m::mock("Rollbar\Payload\Payload");
-            
+
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env
         ));
-        
+
         $this->assertEquals(
             "https://api.rollbar.com/api/1/item/",
             $config->getSender()->getEndpoint()
@@ -278,14 +279,14 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             "environment" => $this->env,
             "send_message_trace" => true
         ));
-        
+
         $this->assertTrue($c->getSendMessageTrace());
-        
+
         $c = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env
         ));
-        
+
         $this->assertFalse($c->getSendMessageTrace());
     }
 
@@ -328,7 +329,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($isUncaughtPassed);
         $this->assertEquals($this->error, $errorPassed);
     }
-    
+
     public function testCaptureErrorStacktraces()
     {
         $logger = new RollbarLogger(array(
@@ -336,15 +337,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             "environment" => $this->env,
             "capture_error_stacktraces" => false
         ));
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::fromName('error'),
             new \Exception(),
             array()
         );
-        
+
         $this->assertEmpty($result->getBody()->getValue()->getFrames());
     }
 
@@ -363,23 +364,23 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             },
             "use_error_reporting" => $use_error_reporting
         ));
-        
+
         $data = new Data($this->env, new Body(new Message("test")));
         $data->setLevel(Level::fromName('error'));
-        
+
         if ($error_reporting !== null) {
             $errorReportingTemp = error_reporting();
             error_reporting($error_reporting);
         }
-        
+
         $result = $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, false);
         $this->assertEquals($expected, $result);
-        
+
         if ($error_reporting) {
             error_reporting($errorReportingTemp);
         }
     }
-    
+
     public function useErrorReportingProvider()
     {
         return array(

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Context;
 
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends BaseUnitTestCase
 {
     public function testContextPre()
     {

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Data;
 
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends BaseUnitTestCase
 {
     private $body;
     private $data;

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -5,7 +5,7 @@ use Rollbar\Payload\Level;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
 
-class DefaultsTest extends \PHPUnit_Framework_TestCase
+class DefaultsTest extends BaseUnitTestCase
 {
     /**
      * @var Defaults
@@ -134,7 +134,7 @@ class DefaultsTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals($expected, $this->d->scrubFields());
     }
-    
+
     public function testSendMessageTrace()
     {
         $this->assertFalse($this->d->sendMessageTrace());

--- a/tests/ErrorWrapperTest.php
+++ b/tests/ErrorWrapperTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\ErrorWrapper;
 
-class ErrorWrapperTest extends \PHPUnit_Framework_TestCase
+class ErrorWrapperTest extends BaseUnitTestCase
 {
     public function testBacktrace()
     {

--- a/tests/ExceptionInfoTest.php
+++ b/tests/ExceptionInfoTest.php
@@ -1,6 +1,8 @@
 <?php namespace Rollbar\Payload;
 
-class ExceptionInfoTest extends \PHPUnit_Framework_TestCase
+use Rollbar\BaseUnitTestCase;
+
+class ExceptionInfoTest extends BaseUnitTestCase
 {
     public function testClass()
     {

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -4,7 +4,7 @@ namespace Rollbar;
 
 use Psr\Log\LogLevel;
 
-class FluentTest extends \PHPUnit_Framework_TestCase
+class FluentTest extends BaseUnitTestCase
 {
 
     public function testFluent()

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Frame;
 
-class FrameTest extends \PHPUnit_Framework_TestCase
+class FrameTest extends BaseUnitTestCase
 {
     private $exception;
     private $frame;

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Level;
 
-class LevelTest extends \PHPUnit_Framework_TestCase
+class LevelTest extends BaseUnitTestCase
 {
     public function testLevel()
     {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,6 +1,8 @@
 <?php namespace Rollbar\Payload;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+use Rollbar\BaseUnitTestCase;
+
+class MessageTest extends BaseUnitTestCase
 {
     public function testBacktrace()
     {
@@ -8,7 +10,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $msg = new Message("Test", array(), $expected);
         $this->assertEquals($expected, $msg->getBacktrace());
     }
-    
+
     public function testBody()
     {
         $msg = new Message("Test");

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Notifier;
 
-class NotifierTest extends \PHPUnit_Framework_TestCase
+class NotifierTest extends BaseUnitTestCase
 {
     public function testName()
     {

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -4,7 +4,7 @@ use \Mockery as m;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
 
-class PayloadTest extends \PHPUnit_Framework_TestCase
+class PayloadTest extends BaseUnitTestCase
 {
     public function testPayloadData()
     {
@@ -13,7 +13,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
                     ->shouldReceive('getAccessToken')
                     ->andReturn('012345678901234567890123456789ab')
                     ->mock();
-        
+
         $payload = new Payload($data, $config->getAccessToken());
 
         $this->assertEquals($data, $payload->getData());
@@ -83,7 +83,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
             ->shouldReceive('scrub')
             ->andReturn(new \ArrayObject())
             ->mock();
-        
+
         $payload = new Payload($data, $accessToken);
         $encoded = json_encode($payload->jsonSerialize());
         $json = '{"data":{},"access_token":"'.$accessToken.'"}';

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Person;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends BaseUnitTestCase
 {
     public function testId()
     {

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -15,7 +15,7 @@ function do_something()
     throw new \Exception();
 }
 
-class ReadmeTest extends \PHPUnit_Framework_TestCase
+class ReadmeTest extends BaseUnitTestCase
 {
 
     /**
@@ -30,36 +30,36 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
                 'environment' => 'production'
             )
         );
-        
+
         try {
             throw new \Exception('test exception');
         } catch (\Exception $e) {
             Rollbar::log(Level::error(), $e);
         }
-        
+
         // Message at level 'info'
         Rollbar::log(Level::info(), 'testing info level');
-        
+
         // With extra data (3rd arg) and custom payload options (4th arg)
         Rollbar::log(
             Level::info(),
             'testing extra data',
             array("some_key" => "some value") // key-value additional data
         );
-        
+
         // If you want to check if logging with Rollbar was successful
         $response = Rollbar::log(Level::info(), 'testing wasSuccessful()');
         if (!$response->wasSuccessful()) {
             throw new \Exception('logging with Rollbar failed');
         }
-        
+
         // raises an E_NOTICE which will *not* be reported by the error handler
         // $foo = $bar;
-        
+
         // will be reported by the exception handler
         throw new \Exception('testing exception handler');
     }
-    
+
     public function testSetup1()
     {
         $config = array(
@@ -71,10 +71,10 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             'root' => '/Users/brian/www/myapp'
         );
         Rollbar::init($config);
-        
+
         $this->assertTrue(true);
     }
-    
+
     public function testSetup2()
     {
         $config = array(
@@ -85,14 +85,14 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             // optional - path to directory your code is in. used for linking stack traces.
             'root' => '/Users/brian/www/myapp'
         );
-        
+
         $set_exception_handler = false;
         $set_error_handler = false;
         Rollbar::init($config, $set_exception_handler, $set_error_handler);
-        
+
         $this->assertTrue(true);
     }
-    
+
     public function testBasicUsage()
     {
         try {
@@ -103,7 +103,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             Rollbar::log(Level::error(), $e, array("my" => "extra", "data" => 42));
         }
     }
-    
+
     public function testBasicUsage2()
     {
         Rollbar::log(Level::warning(), 'could not connect to mysql server');
@@ -113,17 +113,17 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
             array('x' => 10, 'code' => 'blue')
         );
     }
-    
+
     public function testMonolog()
     {
-        $config = array('access_token' => ROLLBAR_TEST_TOKEN);
-        
+        $config = array('access_token' => ROLLBAR_TEST_TOKEN, 'environment' => 'testing');
+
         // installs global error and exception handlers
         Rollbar::init($config);
-        
+
         $log = new Logger('test');
         $log->pushHandler(new \Monolog\Handler\PsrHandler(Rollbar::logger()));
-        
+
         try {
             throw new \Exception('exception for monolog');
         } catch (\Exception $e) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Request;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends BaseUnitTestCase
 {
     public function testUrl()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\Response;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends BaseUnitTestCase
 {
     public function testStatus()
     {

--- a/tests/RollbarJsHelperTest.php
+++ b/tests/RollbarJsHelperTest.php
@@ -1,16 +1,16 @@
 <?php namespace Rollbar;
 
-class JsHelperTest extends \PHPUnit_Framework_TestCase
+class JsHelperTest extends BaseUnitTestCase
 {
     protected $jsHelper;
     protected $testSnippetPath;
-    
+
     public function setUp()
     {
         $this->jsHelper = new RollbarJsHelper(array());
         $this->testSnippetPath = realpath(__DIR__ . "/../data/rollbar.snippet.js");
     }
-    
+
     public function testSnippetPath()
     {
         $this->assertEquals(
@@ -18,28 +18,28 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             $this->jsHelper->snippetPath()
         );
     }
-    
+
     /**
      * @dataProvider shouldAddJsProvider
      */
     public function testShouldAddJs($setup, $expected)
     {
         $mock = \Mockery::mock('Rollbar\RollbarJsHelper');
-             
+
         $status = $setup['status'];
-        
+
         $mock->shouldReceive('isHtml')
              ->andReturn($setup['isHtml']);
-             
+
         $mock->shouldReceive('hasAttachment')
              ->andReturn($setup['hasAttachment']);
-             
+
         $mock->shouldReceive('shouldAddJs')
              ->passthru();
-        
+
         $this->assertEquals($expected, $mock->shouldAddJs($status, array()));
     }
-    
+
     public function shouldAddJsProvider()
     {
         return array(
@@ -77,7 +77,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     /**
      * @dataProvider isHtmlProvider
      */
@@ -88,7 +88,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             $this->jsHelper->isHtml($headers)
         );
     }
-    
+
     public function isHtmlProvider()
     {
         return array(
@@ -106,7 +106,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     /**
      * @dataProvider hasAttachmentProvider
      */
@@ -117,7 +117,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             $this->jsHelper->hasAttachment($headers)
         );
     }
-    
+
     public function hasAttachmentProvider()
     {
         return array(
@@ -134,14 +134,14 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     public function testJsSnippet()
     {
         $expected = file_get_contents($this->testSnippetPath);
-        
+
         $this->assertEquals($expected, $this->jsHelper->jsSnippet());
     }
-    
+
     /**
      * @dataProvider shouldAppendNonceProvider
      */
@@ -152,7 +152,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             $this->jsHelper->shouldAppendNonce($headers)
         );
     }
-    
+
     public function shouldAppendNonceProvider()
     {
         return array(
@@ -176,7 +176,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     /**
      * @dataProvider scriptTagProvider
      */
@@ -185,7 +185,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
         if ($expected === 'Exception') {
             try {
                 $result = $this->jsHelper->scriptTag($content, $headers, $nonce);
-                
+
                 $this->fail();
             } catch (\Exception $e) {
                 $this->assertTrue(true);
@@ -193,11 +193,11 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             }
         } else {
             $result = $this->jsHelper->scriptTag($content, $headers, $nonce);
-            
+
             $this->assertEquals($expected, $result);
         }
     }
-    
+
     public function scriptTagProvider()
     {
         return array(
@@ -225,7 +225,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
-    
+
     public function testConfigJsTag()
     {
         $config = array(
@@ -233,42 +233,42 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
                 'config1' => 'value 1'
             )
         );
-        
+
         $expectedJson = json_encode($config['options']);
         $expected = "var _rollbarConfig = $expectedJson;";
-        
+
         $helper = new RollbarJsHelper($config);
         $result = $helper->configJsTag();
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     /**
      * @dataProvider addJsProvider
      */
     public function testBuildJs($setup, $expected)
     {
         extract($setup);
-        
+
         $result = RollbarJsHelper::buildJs($config, $headers, $nonce);
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     /**
      * @dataProvider addJsProvider
      */
     public function testAddJs($setup, $expected)
     {
         extract($setup);
-             
+
         $helper = new RollbarJsHelper($config);
-        
+
         $result = $helper->addJs($headers, $nonce);
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     public function addJsProvider()
     {
         $this->setUp();

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -3,9 +3,9 @@
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 
-class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
+class RollbarLoggerTest extends BaseUnitTestCase
 {
-    
+
     public function setUp()
     {
         $_SESSION = array();
@@ -55,17 +55,17 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $response = $l->log(Level::error(), new ErrorWrapper(E_USER_ERROR, '', null, null, array()), array());
         $this->assertEquals(0, $response->getStatus());
     }
-    
+
     private function scrubTestHelper($config = array(), $context = array())
     {
         $scrubFields = array('sensitive');
-        
+
         $defaultConfig = array(
             'access_token' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'scrub_fields' => $scrubFields
         );
-        
+
         $config = new Config(array_replace_recursive($defaultConfig, $config));
 
         $dataBuilder = new DataBuilder($config->getConfigArray());
@@ -75,10 +75,10 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $scrubbed = $payload->jsonSerialize();
 
         $result = $dataBuilder->scrub($scrubbed);
-        
+
         return $result;
     }
-    
+
     /**
      * @param string $dataName Human-readable name of the type of data under test
      * @param array $result The result of the code under test
@@ -93,8 +93,8 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $recursive = true,
         $replacement = '*'
     ) {
-    
-        
+
+
         $this->assertEquals(
             str_repeat($replacement, 8),
             $result[$scrubField],
@@ -109,7 +109,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             );
         }
     }
-    
+
     public function scrubDataProvider()
     {
         return array(
@@ -125,7 +125,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -135,8 +135,8 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $result = $this->scrubTestHelper();
         $this->scrubTestAssert('$_GET', $result['data']['request']['GET']);
     }
-    
-    
+
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -156,14 +156,14 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $result = $this->scrubTestHelper();
         $this->scrubTestAssert('$_SESSION', $result['data']['request']['session']);
     }
-    
+
     public function testGetScrubbedHeaders()
     {
         $_SERVER['HTTP_CONTENT_TYPE'] = 'text/html; charset=utf-8';
         $_SERVER['HTTP_SENSITIVE'] = 'Scrub this';
-        
+
         $scrubField = 'Sensitive';
-        
+
         $result = $this->scrubTestHelper(array('scrub_fields' => array($scrubField)));
         $this->scrubTestAssert(
             'Headers',
@@ -181,15 +181,15 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $extras = array(
             'extraField1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(array('requestExtras' => $extras));
-        
+
         $this->scrubTestAssert(
             "Request extras",
             $result['data']['request']['extraField1']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -198,15 +198,15 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $extras = array(
             'extraField1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(array('serverExtras' => $extras));
-        
+
         $this->scrubTestAssert(
             "Server extras",
             $result['data']['server']['extraField1']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -220,7 +220,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             $result['data']['custom']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -229,7 +229,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $bodyContext = array(
             'context1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(
             array('custom' => $bodyContext),
             $bodyContext
@@ -240,18 +240,18 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             $result['data']['body']['message']['context1']
         );
     }
-    
+
     public function scrubQueryStringDataProvider()
     {
         $data = $this->scrubDataProvider();
-        
+
         foreach ($data as &$test) {
             $test[0] = http_build_query($test[0]);
         }
-        
+
         return $data;
     }
-    
+
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
@@ -259,7 +259,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['REQUEST_URI'] = "/index.php?$testData";
-        
+
         $result = $this->scrubTestHelper();
         $parsed = array();
         parse_str(parse_url($result['data']['request']['url'], PHP_URL_QUERY), $parsed);
@@ -272,18 +272,18 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             'x' // query string is scrubbed with "x" rather than "*"
         );
     }
-    
+
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
     public function testGetRequestScrubQueryString($testData)
     {
         $_SERVER['QUERY_STRING'] = "?$testData";
-        
+
         $result = $this->scrubTestHelper();
         $parsed = array();
         parse_str($result['data']['request']['query_string'], $parsed);
-        
+
         $this->scrubTestAssert(
             "Query string",
             $parsed,

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -7,19 +7,19 @@ if (!defined('ROLLBAR_TEST_TOKEN')) {
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
 
-class RollbarTest extends \PHPUnit_Framework_TestCase
+class RollbarTest extends BaseUnitTestCase
 {
 
     private static $simpleConfig = array(
         'access_token' => ROLLBAR_TEST_TOKEN,
         'environment' => 'test'
     );
-    
+
     public function setUp()
     {
         Rollbar::init(self::$simpleConfig);
     }
-    
+
     public function testLogException()
     {
         try {
@@ -27,16 +27,16 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             Rollbar::log(Level::error(), $e);
         }
-        
+
         $this->assertTrue(true);
     }
-    
+
     public function testLogMessage()
     {
         Rollbar::log(Level::info(), 'testing info level');
         $this->assertTrue(true);
     }
-    
+
     public function testLogExtraData()
     {
         Rollbar::log(
@@ -44,7 +44,7 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
             'testing extra data',
             array("some_key" => "some value") // key-value additional data
         );
-        
+
         $this->assertTrue(true);
     }
 
@@ -58,20 +58,20 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
         $uuid = Rollbar::report_message("Hello world");
         $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
     }
-    
+
     public function testBackwardsSimpleError()
     {
         Rollbar::init(self::$simpleConfig);
-        
+
         $result = Rollbar::report_php_error(E_ERROR, "Runtime error", "the_file.php", 1);
         // always returns false.
         $this->assertFalse($result);
     }
-    
+
     public function testBackwardsSimpleException()
     {
         Rollbar::init(self::$simpleConfig);
-        
+
         $uuid = null;
         try {
             throw new \Exception("test exception");

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\Payload\Server;
 
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends BaseUnitTestCase
 {
     public function testHost()
     {

--- a/tests/TraceChainTest.php
+++ b/tests/TraceChainTest.php
@@ -1,9 +1,10 @@
 <?php namespace Rollbar\Payload\TraceChain;
 
 use \Mockery as m;
+use Rollbar\BaseUnitTestCase;
 use Rollbar\Payload\TraceChain;
 
-class TraceChainTest extends \PHPUnit_Framework_TestCase
+class TraceChainTest extends BaseUnitTestCase
 {
     private $trace1;
     private $trace2;

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -2,9 +2,9 @@
 
 use \Mockery as m;
 use Rollbar\Payload\Trace;
-use rollbar\Payload\Frame;
+use Rollbar\Payload\Frame;
 
-class TraceTest extends \PHPUnit_Framework_TestCase
+class TraceTest extends BaseUnitTestCase
 {
     public function testTraceConstructor()
     {

--- a/tests/Truncation/FramesStrategyTest.php
+++ b/tests/Truncation/FramesStrategyTest.php
@@ -2,9 +2,10 @@
 
 namespace Rollbar\Truncation;
 
+use Rollbar\BaseUnitTestCase;
 use Rollbar\DataBuilder;
 
-class FramesStrategyTest extends \PHPUnit_Framework_TestCase
+class FramesStrategyTest extends BaseUnitTestCase
 {
     /**
      * @dataProvider executeProvider
@@ -15,13 +16,13 @@ class FramesStrategyTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-                    
+
         $strategy = new FramesStrategy($dataBuilder);
         $result = $strategy->execute($data);
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     public function executeProvider()
     {
         $data = array(
@@ -76,7 +77,7 @@ class FramesStrategyTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
-        
+
         return $data;
     }
 }

--- a/tests/Truncation/MinBodyStrategyTest.php
+++ b/tests/Truncation/MinBodyStrategyTest.php
@@ -2,11 +2,12 @@
 
 namespace Rollbar\Truncation;
 
+use Rollbar\BaseUnitTestCase;
 use Rollbar\DataBuilder;
 
-class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
+class MinBodyStrategyTest extends BaseUnitTestCase
 {
-    
+
     /**
      * @dataProvider executeProvider
      */
@@ -16,17 +17,17 @@ class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-                    
+
         $strategy = new MinBodyStrategy($dataBuilder);
         $result = $strategy->execute($data);
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     public function executeProvider()
     {
         $data = array();
-        
+
         $traceData = array(
             'exception' => array(
                 'description' => 'Test description',
@@ -37,7 +38,7 @@ class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
             ),
             'frames' => array('Frame 1', 'Frame 2', 'Frame 3')
         );
-        
+
         $expected = $traceData;
         unset($expected['exception']['description']);
         $expected['exception']['message'] = str_repeat(
@@ -45,20 +46,20 @@ class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
             MinBodyStrategy::EXCEPTION_MESSAGE_LIMIT
         );
         $expected['frames'] = array('Frame 1', 'Frame 3');
-        
-        
+
+
         $data['trace data set'] = array(
             $this->payloadStructureProvider(array('trace' => $traceData)),
             $this->payloadStructureProvider(array('trace' => $expected))
         );
-        
+
         $data['trace_chain data set'] = array(
             $this->payloadStructureProvider(array('trace_chain' => $traceData)),
             $this->payloadStructureProvider(array('trace_chain' => $expected))
         );
         return $data;
     }
-    
+
     protected function payloadStructureProvider($body)
     {
         return array(

--- a/tests/Truncation/RawStrategyTest.php
+++ b/tests/Truncation/RawStrategyTest.php
@@ -2,14 +2,15 @@
 
 namespace Rollbar\Truncation;
 
+use Rollbar\BaseUnitTestCase;
 use Rollbar\DataBuilder;
 
-class RawStrategyTest extends \PHPUnit_Framework_TestCase
+class RawStrategyTest extends BaseUnitTestCase
 {
     public function testExecute()
     {
         $payload = array('test' => 'test data');
-        
+
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
@@ -17,7 +18,7 @@ class RawStrategyTest extends \PHPUnit_Framework_TestCase
 
         $strategy = new RawStrategy($dataBuilder);
         $result = $strategy->execute($payload);
-        
+
         $this->assertEquals(
             strlen(json_encode($payload)),
             strlen(json_encode($result))

--- a/tests/Truncation/StringsStrategyTest.php
+++ b/tests/Truncation/StringsStrategyTest.php
@@ -2,9 +2,10 @@
 
 namespace Rollbar\Truncation;
 
+use Rollbar\BaseUnitTestCase;
 use Rollbar\DataBuilder;
 
-class StringsStrategyTest extends \PHPUnit_Framework_TestCase
+class StringsStrategyTest extends BaseUnitTestCase
 {
     /**
      * @dataProvider executeProvider
@@ -15,48 +16,48 @@ class StringsStrategyTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-                    
+
         $strategy = new StringsStrategy($dataBuilder);
         $result = $strategy->execute($data);
-        
+
         $this->assertEquals($expected, $result);
     }
-    
+
     public function executeProvider()
     {
         $data = array();
-        
+
         $data["truncate nothing"] = array(
             $this->payloadStructureProvider(str_repeat("A", 10)),
             $this->payloadStructureProvider(str_repeat("A", 10))
         );
-        
+
         $thresholds = StringsStrategy::getThresholds();
         foreach ($thresholds as $threshold) {
             $data['truncate strings to ' . $threshold] = $this->thresholdTestProvider($threshold);
         }
-        
+
         return $data;
     }
-    
+
     protected function thresholdTestProvider($threshold)
     {
         $stringLengthToTrim = $threshold+1;
-        
+
         $payload = $this->payloadStructureProvider(array());
         $expected = $this->payloadStructureProvider(array());
-        
+
         while (strlen(json_encode($payload)) < DataBuilder::MAX_PAYLOAD_SIZE) {
             $payload['data']['body']['message']['body']['value'] []=
                 str_repeat('A', $stringLengthToTrim);
-                
+
             $expected['data']['body']['message']['body']['value'] []=
                 str_repeat('A', $threshold);
         }
-        
+
         return array($payload,$expected);
     }
-    
+
     protected function payloadStructureProvider($message)
     {
         return array(

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -1,6 +1,6 @@
 <?php namespace Rollbar;
 
-class UtilitiesTest extends \PHPUnit_Framework_TestCase
+class UtilitiesTest extends BaseUnitTestCase
 {
     public function testCoalesce()
     {


### PR DESCRIPTION
- introduce `reset` function in `Rollbar` class
- introduce custom base class `BaseUnitTestCase` which calls `Rollbar::reset()` in `tearDown` for each test
- all tests inherit from new `BaseUnitTestCase` class

Alternative approach for [PR 197](https://github.com/rollbar/rollbar-php/pull/197) to fix [issue 188](https://github.com/rollbar/rollbar-php/issues/188)

Unfortunately I don't know how to fix this test:

```
There was 1 failure:

1) Rollbar\DataBuilderTest::testPersonFuncException
Exception in person_fn was not caught.

/var/www/tests/DataBuilderTest.php:638
```