### PR TITLE
GitHub Issue #140: Refactor usage of levels in log methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,21 @@ Rollbar::init(
 try {
     throw new \Exception('test exception');
 } catch (\Exception $e) {
-    Rollbar::log(Level::error(), $e);
+    Rollbar::log(Level::ERROR, $e);
 }
 
 // Message at level 'info'
-Rollbar::log(Level::info(), 'testing info level');
+Rollbar::log(Level::INFO, 'testing info level');
 
 // With extra data (3rd arg) and custom payload options (4th arg)
 Rollbar::log(
-    Level::info(),
+    Level::INFO,
     'testing extra data',
     array("some_key" => "some value") // key-value additional data
 );
         
 // If you want to check if logging with Rollbar was successful
-$response = Rollbar::log(Level::info(), 'testing wasSuccessful()');
+$response = Rollbar::log(Level::INFO, 'testing wasSuccessful()');
 if (!$response->wasSuccessful()) {
     throw new \Exception('logging with Rollbar failed');
 }
@@ -175,9 +175,9 @@ use Rollbar\Payload\Level;
 try {
     do_something();
 } catch (\Exception $e) {
-    Rollbar::log(Level::error(), $e);
+    Rollbar::log(Level::ERROR, $e);
     // or
-    Rollbar::log(Level::error(), $e, array("my" => "extra", "data" => 42));
+    Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
 }
 ?>
 ```
@@ -189,9 +189,9 @@ You can also send Rollbar log-like messages:
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
 
-Rollbar::log(Level::warning(), 'could not connect to mysql server');
+Rollbar::log(Level::WARNING, 'could not connect to mysql server');
 Rollbar::log(
-    Level::info(), 
+    Level::INFO, 
     'Here is a message with some additional data',
     array('x' => 10, 'code' => 'blue')
 );

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",
     "monolog/monolog": "*",
-    "packfire/php5.3-compat": "*"
+    "packfire/php5.3-compat": "*",
+    "phpmd/phpmd" : "@stable"
   },
 
   "suggest": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -134,6 +134,10 @@ class Config
 
     private function setDataBuilder($c)
     {
+        if (!isset($c['levelFactory'])) {
+            $c['levelFactory'] = $this->levelFactory;
+        }
+        
         $exp = "Rollbar\DataBuilderInterface";
         $def = "Rollbar\DataBuilder";
         $this->setupWithOptions($c, "dataBuilder", $exp, $def, true);
@@ -314,6 +318,11 @@ class Config
     public function getDataBuilder()
     {
         return $this->dataBuilder;
+    }
+    
+    public function getLevelFactory()
+    {
+        return $this->levelFactory;
     }
     
     public function getSender()

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,6 +18,12 @@ class Config
      */
     private $dataBuilder;
     private $configArray;
+    
+    /**
+     * @var LevelFactory
+     */
+    private $levelFactory;
+    
     /**
      * @var TransformerInterface
      */
@@ -54,6 +60,8 @@ class Config
 
     public function __construct(array $configArray)
     {
+        $this->levelFactory = new LevelFactory();
+        
         $this->updateConfig($configArray);
 
         if (isset($configArray['error_sample_rates'])) {
@@ -144,7 +152,7 @@ class Config
         } elseif ($c['minimumLevel'] instanceof Level) {
             $this->minimumLevel = $c['minimumLevel']->toInt();
         } elseif (is_string($c['minimumLevel'])) {
-            $level = Level::fromName($c['minimumLevel']);
+            $level = $this->levelFactory->fromName($c['minimumLevel']);
             if ($level !== null) {
                 $this->minimumLevel = $level->toInt();
             }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -60,6 +60,9 @@ class DataBuilder implements DataBuilderInterface
     protected $localVarsDump;
     protected $captureErrorStacktraces;
     
+    /**
+     * @var LevelFactory
+     */
     protected $levelFactory;
 
     public function __construct($config)
@@ -96,13 +99,12 @@ class DataBuilder implements DataBuilderInterface
         $this->setSendMessageTrace($config);
         $this->setLocalVarsDump($config);
         $this->setCaptureErrorStacktraces($config);
+        $this->setLevelFactory($config);
 
         $this->shiftFunction = $this->tryGet($config, 'shift_function');
         if (!isset($this->shiftFunction)) {
             $this->shiftFunction = true;
         }
-        
-        $this->levelFactory = new LevelFactory();
     }
 
     protected function getOrCall($name, $level, $toLog, $context)
@@ -308,6 +310,16 @@ class DataBuilder implements DataBuilderInterface
     {
         $fromConfig = $this->tryGet($config, 'include_exception_code_context');
         $this->includeExcCodeContext = self::$defaults->includeExcCodeContext($fromConfig);
+    }
+    
+    protected function setLevelFactory($config)
+    {
+        $this->levelFactory = $this->tryGet($config, 'levelFactory');
+        if (!$this->levelFactory) {
+            throw new \InvalidArgumentException(
+                'Missing dependency: LevelFactory not provided to the DataBuilder.'
+            );
+        }
     }
 
     protected function setHost($config)

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -59,6 +59,8 @@ class DataBuilder implements DataBuilderInterface
     protected $sendMessageTrace;
     protected $localVarsDump;
     protected $captureErrorStacktraces;
+    
+    protected $levelFactory;
 
     public function __construct($config)
     {
@@ -99,6 +101,8 @@ class DataBuilder implements DataBuilderInterface
         if (!isset($this->shiftFunction)) {
             $this->shiftFunction = true;
         }
+        
+        $this->levelFactory = new LevelFactory();
     }
 
     protected function getOrCall($name, $level, $toLog, $context)
@@ -506,8 +510,8 @@ class DataBuilder implements DataBuilderInterface
                 $level = $this->messageLevel;
             }
         }
-        $level = strtolower($level);
-        return $this->tryGet($this->psrLevels, $level);
+        $level = $this->tryGet($this->psrLevels, strtolower($level));
+        return $this->levelFactory->fromName($level);
     }
 
     protected function getTimestamp()

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -312,7 +312,7 @@ class DataBuilder implements DataBuilderInterface
     }
 
     /**
-     * @param Level $level
+     * @param string $level
      * @param \Exception | \Throwable | string $toLog
      * @param $context
      * @return Data
@@ -507,7 +507,7 @@ class DataBuilder implements DataBuilderInterface
             }
         }
         $level = strtolower($level);
-        return Level::fromName($this->tryGet($this->psrLevels, $level));
+        return $this->tryGet($this->psrLevels, $level);
     }
 
     protected function getTimestamp()
@@ -766,7 +766,7 @@ class DataBuilder implements DataBuilderInterface
                 $personData = call_user_func($this->personFunc);
             } catch (\Exception $exception) {
                 Rollbar::scope(array('person_fn' => null))->
-                    log(Level::fromName("error"), $exception);
+                    log(Level::ERROR, $exception);
             }
         }
 

--- a/src/LevelFactory.php
+++ b/src/LevelFactory.php
@@ -28,7 +28,7 @@ class LevelFactory
 
     /**
      * @param string $name level name
-     * 
+     *
      * @return Level
      */
     public function fromName($name)
@@ -40,14 +40,13 @@ class LevelFactory
     
     /**
      * Check if the provided level is a valid level
-     * 
+     *
      * @param string $level
-     * 
+     *
      * @return string
      */
     public function isValidLevel($level)
     {
         return $this->fromName($level) ? true : false;
     }
-    
 }

--- a/src/LevelFactory.php
+++ b/src/LevelFactory.php
@@ -1,0 +1,53 @@
+<?php namespace Rollbar;
+
+use Rollbar\Payload\Level;
+
+class LevelFactory
+{
+    
+    private static $values;
+
+    private static function init()
+    {
+        if (is_null(self::$values)) {
+            self::$values = array(
+                Level::EMERGENCY => new Level("critical", 100000),
+                Level::ALERT => new Level("critical", 100000),
+                Level::CRITICAL => new Level("critical", 100000),
+                Level::ERROR => new Level("error", 10000),
+                Level::WARNING => new Level("warning", 1000),
+                Level::NOTICE => new Level("info", 100),
+                Level::INFO => new Level("info", 100),
+                Level::DEBUG => new Level("debug", 10),
+                Level::IGNORED => new Level("ignore", 0),
+                Level::IGNORE => new Level("ignore", 0)
+
+            );
+        }
+    }
+
+    /**
+     * @param string $name level name
+     * 
+     * @return Level
+     */
+    public function fromName($name)
+    {
+        self::init();
+        $name = strtolower($name);
+        return array_key_exists($name, self::$values) ? self::$values[$name] : null;
+    }
+    
+    /**
+     * Check if the provided level is a valid level
+     * 
+     * @param string $level
+     * 
+     * @return string
+     */
+    public function isValidLevel($level)
+    {
+        return $this->fromName($level) ? true : false;
+    }
+    
+}

--- a/src/Payload/Data.php
+++ b/src/Payload/Data.php
@@ -62,7 +62,7 @@ class Data implements \JsonSerializable
 
     public function setLevel($level)
     {
-        $this->level = Level::fromName($level);
+        $this->level = $level;
         return $this;
     }
 

--- a/src/Payload/Data.php
+++ b/src/Payload/Data.php
@@ -60,9 +60,9 @@ class Data implements \JsonSerializable
         return $this->level;
     }
 
-    public function setLevel(Level $level)
+    public function setLevel($level)
     {
-        $this->level = $level;
+        $this->level = Level::fromName($level);
         return $this;
     }
 

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -1,19 +1,7 @@
 <?php namespace Rollbar\Payload;
 
-<<<<<<< HEAD
 use Rollbar\LevelFactory;
 
-=======
-/**
- * @method static Level critical()
- * @method static Level error()
- * @method static Level warning()
- * @method static Level debug()
- * @method static Level info()
- * @method static Level ignored()
- * @method static Level ignore()
- */
->>>>>>> origin/master
 class Level implements \JsonSerializable
 {
     /**

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -2,16 +2,27 @@
 
 class Level implements \JsonSerializable
 {
-    const IGNORE = 'ignore';
-    const IGNORED = 'ignored';
-    const DEBUG = 'debug';
-    const INFO = 'info';
-    const NOTICE = 'notice';
-    const WARNING = 'warning';
-    const ERROR = 'error';
-    const CRITICAL = 'critical';
-    const ALERT = 'alert';
+    /**
+     * Those are PSR-3 compatible loggin levels. They are mapped to Rollbar
+     * service supported levels in Level::init()
+     */
     const EMERGENCY = 'emergency';  
+    const ALERT = 'alert';
+    const CRITICAL = 'critical';
+    const ERROR = 'error';
+    const WARNING = 'warning';
+    const NOTICE = 'notice';
+    const INFO = 'info';
+    const DEBUG = 'debug';
+    
+    /**
+     * @deprecated 1.2.0
+     */
+    const IGNORED = 'ignored';
+    /**
+     * @deprecated 1.2.0
+     */
+    const IGNORE = 'ignore';
     
     private static $values;
 
@@ -19,16 +30,16 @@ class Level implements \JsonSerializable
     {
         if (is_null(self::$values)) {
             self::$values = array(
-                "emergency" => new Level("critical", 100000),
-                "alert" => new Level("critical", 100000),
-                "critical" => new Level("critical", 100000),
-                "error" => new Level("error", 10000),
-                "warning" => new Level("warning", 1000),
-                "notice" => new Level("info", 100),
-                "info" => new Level("info", 100),
-                "debug" => new Level("debug", 10),
-                "ignored" => new Level("ignore", 0),
-                "ignore" => new Level("ignore", 0)
+                self::EMERGENCY => new Level("critical", 100000),
+                self::ALERT => new Level("critical", 100000),
+                self::CRITICAL => new Level("critical", 100000),
+                self::ERROR => new Level("error", 10000),
+                self::WARNING => new Level("warning", 1000),
+                self::NOTICE => new Level("info", 100),
+                self::INFO => new Level("info", 100),
+                self::DEBUG => new Level("debug", 10),
+                self::IGNORED => new Level("ignore", 0),
+                self::IGNORE => new Level("ignore", 0)
 
             );
         }

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -6,7 +6,7 @@ class Level implements \JsonSerializable
      * Those are PSR-3 compatible loggin levels. They are mapped to Rollbar
      * service supported levels in Level::init()
      */
-    const EMERGENCY = 'emergency';  
+    const EMERGENCY = 'emergency';
     const ALERT = 'alert';
     const CRITICAL = 'critical';
     const ERROR = 'error';

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -28,7 +28,7 @@ class Level implements \JsonSerializable
 
     /**
      * @deprecated 1.2.0
-     * 
+     *
      * Usage of Level::error(), Level::warning(), Level::info(), Level::notice(),
      * Level::debug() is no longer supported. It has been replaced with matching
      * class constants, i.e.: Level::ERROR

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -2,6 +2,17 @@
 
 class Level implements \JsonSerializable
 {
+    const IGNORE = 'ignore';
+    const IGNORED = 'ignored';
+    const DEBUG = 'debug';
+    const INFO = 'info';
+    const NOTICE = 'notice';
+    const WARNING = 'warning';
+    const ERROR = 'error';
+    const CRITICAL = 'critical';
+    const ALERT = 'alert';
+    const EMERGENCY = 'emergency';  
+    
     private static $values;
 
     private static function init()

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -1,5 +1,7 @@
 <?php namespace Rollbar\Payload;
 
+use Rollbar\LevelFactory;
+
 class Level implements \JsonSerializable
 {
     /**
@@ -23,42 +25,24 @@ class Level implements \JsonSerializable
      * @deprecated 1.2.0
      */
     const IGNORE = 'ignore';
-    
-    private static $values;
-
-    private static function init()
-    {
-        if (is_null(self::$values)) {
-            self::$values = array(
-                self::EMERGENCY => new Level("critical", 100000),
-                self::ALERT => new Level("critical", 100000),
-                self::CRITICAL => new Level("critical", 100000),
-                self::ERROR => new Level("error", 10000),
-                self::WARNING => new Level("warning", 1000),
-                self::NOTICE => new Level("info", 100),
-                self::INFO => new Level("info", 100),
-                self::DEBUG => new Level("debug", 10),
-                self::IGNORED => new Level("ignore", 0),
-                self::IGNORE => new Level("ignore", 0)
-
-            );
-        }
-    }
-
-    public static function __callStatic($name, $args)
-    {
-        return self::fromName($name);
-    }
 
     /**
-     * @param string $name level name
-     * @return Level
+     * @deprecated 1.2.0
+     * 
+     * Usage of Level::error(), Level::warning(), Level::info(), Level::notice(),
+     * Level::debug() is no longer supported. It has been replaced with matching
+     * class constants, i.e.: Level::ERROR
      */
-    public static function fromName($name)
+    public static function __callStatic($name, $args)
     {
-        self::init();
-        $name = strtolower($name);
-        return array_key_exists($name, self::$values) ? self::$values[$name] : null;
+        $factory = new LevelFactory();
+        $level = $factory->fromName($name);
+        
+        if (!$level) {
+            throw new \Exception("Level '$level' doesn't exist.");
+        }
+        
+        return $level;
     }
 
     /**
@@ -67,7 +51,7 @@ class Level implements \JsonSerializable
     private $level;
     private $val;
 
-    private function __construct($level, $val)
+    public function __construct($level, $val)
     {
         $this->level = $level;
         $this->val = $val;

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -55,7 +55,7 @@ class Rollbar
     
     public static function exceptionHandler($exception)
     {
-        self::log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
+        self::log(Level::ERROR, $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
         
         restore_exception_handler();
         throw $exception;
@@ -78,7 +78,7 @@ class Rollbar
     {
         if (null !== self::$logger) {
             $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
-            self::$logger->log(Level::error(), $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
+            self::$logger->log(Level::ERROR, $exception, array(Utilities::IS_UNCAUGHT_KEY => true));
         }
         
         return false;
@@ -102,7 +102,7 @@ class Rollbar
             $errline = $last_error['line'];
             $exception = self::generateErrorWrapper($errno, $errstr, $errfile, $errline);
             $extra = array(Utilities::IS_UNCAUGHT_KEY => true);
-            self::$logger->log(Level::critical(), $exception, $extra);
+            self::$logger->log(Level::CRITICAL, $exception, $extra);
         }
     }
 
@@ -147,12 +147,12 @@ class Rollbar
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
         }
-        return self::log(Level::error(), $exc, $extra_data)->getUuid();
+        return self::log(Level::ERROR, $exc, $extra_data)->getUuid();
     }
 
     /**
      * @param string $message Message to be logged
-     * @param string|Level::error() $level One of the values in \Rollbar\Payload\Level::$values
+     * @param string $level One of the values in \Rollbar\Payload\Level::$values
      * @param array $extra_data Additional data to be logged with the exception
      * @param array $payload_data This is deprecated as of v1.0.0 and remains for
      * backwards compatibility. The content fo this array will be merged with
@@ -165,7 +165,7 @@ class Rollbar
     public static function report_message($message, $level = null, $extra_data = null, $payload_data = null)
     {
         
-        $level = $level ? Level::fromName($level) : Level::error();
+        $level = $level ? $level : Level::ERROR;
         if ($payload_data) {
             $extra_data = array_merge($extra_data, $payload_data);
         }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -8,10 +8,12 @@ use Rollbar\Utilities;
 class RollbarLogger extends AbstractLogger
 {
     private $config;
+    private $levelFactory;
 
     public function __construct(array $config)
     {
         $this->config = new Config($config);
+        $this->levelFactory = new LevelFactory();
     }
 
     public function configure(array $config)
@@ -31,7 +33,7 @@ class RollbarLogger extends AbstractLogger
 
     public function log($level, $toLog, array $context = array())
     {
-        if (Level::fromName($level) === null) {
+        if (!$this->levelFactory->isValidLevel($level)) {
             throw new \Psr\Log\InvalidArgumentException("Invalid log level '$level'.");
         }
         $isUncaught = false;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,7 +8,6 @@ use Rollbar\Payload\Level;
 use Rollbar\Payload\Message;
 use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
-use Psr\Log\LogLevel;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -100,7 +99,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             "dataBuilder" => $fdb
         );
         $config = new Config($arr);
-        $expected = array(LogLevel::EMERGENCY, "oops", array());
+        $expected = array(Level::EMERGENCY, "oops", array());
         $config->getRollbarData($expected[0], $expected[1], $expected[2]);
         $this->assertEquals($expected, array_pop(FakeDataBuilder::$logged));
     }
@@ -132,9 +131,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         ));
         $this->runConfigTest($c);
 
-        $c->configure(array("minimumLevel" => Level::WARNING()));
+        $c->configure(array("minimumLevel" => Level::WARNING));
         $this->runConfigTest($c);
-
+        
         $c->configure(array("minimumLevel" => Level::WARNING()->toInt()));
         $this->runConfigTest($c);
     }
@@ -300,7 +299,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             }
         ));
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::fromName('error'));
+        $data->setLevel(Level::ERROR);
         $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, false);
 
         $this->assertTrue($called);
@@ -321,7 +320,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             }
         ));
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::fromName('error'));
+        $data->setLevel(Level::ERROR);
         $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, true);
 
         $this->assertTrue($called);
@@ -365,7 +364,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         ));
         
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::fromName('error'));
+        $data->setLevel(Level::ERROR);
         
         if ($error_reporting !== null) {
             $errorReportingTemp = error_reporting();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -298,8 +298,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 $called = true;
             }
         ));
+        $levelFactory = new LevelFactory();
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::ERROR);
+        $data->setLevel($levelFactory->fromName(Level::ERROR));
         $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, false);
 
         $this->assertTrue($called);
@@ -319,8 +320,9 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 $errorPassed = $exc;
             }
         ));
+        $levelFactory = new LevelFactory();
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::ERROR);
+        $data->setLevel($levelFactory->fromName(Level::ERROR));
         $c->checkIgnored(new Payload($data, $c->getAccessToken()), $this->token, $this->error, true);
 
         $this->assertTrue($called);
@@ -339,7 +341,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = $logger->getDataBuilder();
         
         $result = $dataBuilder->makeData(
-            Level::fromName('error'),
+            Level::ERROR,
             new \Exception(),
             array()
         );
@@ -363,8 +365,10 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             "use_error_reporting" => $use_error_reporting
         ));
         
+        $levelFactory = new LevelFactory();
+        
         $data = new Data($this->env, new Body(new Message("test")));
-        $data->setLevel(Level::ERROR);
+        $data->setLevel($levelFactory->fromName(Level::ERROR));
         
         if ($error_reporting !== null) {
             $errorReportingTemp = error_reporting();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -303,11 +303,11 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         
         $config->checkIgnored(
             new Payload(
-                $data, 
+                $data,
                 $config->getAccessToken()
-            ), 
-            $this->token, 
-            $this->error, 
+            ),
+            $this->token,
+            $this->error,
             false
         );
 
@@ -323,8 +323,15 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array(
             "access_token" => $this->token,
             "environment" => $this->env,
-            "checkIgnore" => function ($isUncaught, $exc, $payload) use 
-                             (&$called, &$isUncaughtPassed, &$errorPassed) {
+            "checkIgnore" => function (
+                $isUncaught,
+                $exc,
+                $payload
+            ) use (
+                &$called,
+                &$isUncaughtPassed,
+                &$errorPassed
+) {
                 $called = true;
                 $isUncaughtPassed = $isUncaught;
                 $errorPassed = $exc;
@@ -338,11 +345,11 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         
         $config->checkIgnored(
             new Payload(
-                $data, 
+                $data,
                 $config->getAccessToken()
-            ), 
-            $this->token, 
-            $this->error, 
+            ),
+            $this->token,
+            $this->error,
             true
         );
 
@@ -399,11 +406,11 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         
         $result = $config->checkIgnored(
             new Payload(
-                $data, 
+                $data,
                 $config->getAccessToken()
-            ), 
-            $this->token, 
-            $this->error, 
+            ),
+            $this->token,
+            $this->error,
             false
         );
         

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -25,7 +25,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testMakeData()
     {
-        $output = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $this->dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('tests', $output->getEnvironment());
     }
     
@@ -58,7 +58,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         }
         
         // When DataBuilder builds the data
-        $response = $this->dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $response = $this->dataBuilder->makeData(Level::ERROR, "testing", array());
         $result = $response->getRequest()->getUrl();
         
         $_SERVER = $pre_SERVER;
@@ -319,7 +319,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'branch' => 'test-branch'
         ));
 
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('test-branch', $output->getServer()->getBranch());
     }
 
@@ -330,7 +330,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'environment' => 'tests',
             'code_version' => '3.4.1'
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('3.4.1', $output->getCodeVersion());
     }
 
@@ -341,7 +341,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'environment' => 'tests',
             'host' => 'my host'
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('my host', $output->getServer()->getHost());
     }
     
@@ -352,7 +352,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'environment' => 'tests'
         ));
         
-        $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $result = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertNull($result->getBody()->getValue()->getBacktrace());
     }
     
@@ -365,7 +365,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'send_message_trace' => true
         ));
     
-        $result = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $result = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
     }
     
@@ -379,7 +379,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         ));
         $dataBuilder = $c->getDataBuilder();
     
-        $result = $dataBuilder->makeData(Level::fromName('error'), 'testing', array());
+        $result = $dataBuilder->makeData(Level::ERROR, 'testing', array());
         $frames = $result->getBody()->getValue()->getBacktrace();
         
         $this->assertArrayNotHasKey(
@@ -398,7 +398,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = $c->getDataBuilder();
     
         $expected = 'testing';
-        $result = $dataBuilder->makeData(Level::fromName('error'), $expected, array());
+        $result = $dataBuilder->makeData(Level::ERROR, $expected, array());
         $frames = $result->getBody()->getValue()->getBacktrace();
         
         $this->assertEquals(
@@ -601,7 +601,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 'email' => 'test@test.com'
             )
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
     }
 
@@ -617,7 +617,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                 );
             }
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
     }
     
@@ -632,7 +632,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         ));
         
         try {
-            $logger->log(Level::fromName('error'), "testing exceptions in person_fn", array());
+            $logger->log(Level::ERROR, "testing exceptions in person_fn", array());
             $this->assertTrue(true); // assert that exception was not thrown
         } catch (\Exception $exception) {
             $this->fail("Exception in person_fn was not caught.");
@@ -646,7 +646,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'environment' => 'tests',
             'root' => '/var/www/app'
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('/var/www/app', $output->getServer()->getRoot());
     }
 
@@ -984,7 +984,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests'
         ));
-        $output = $dataBuilder->makeData(Level::fromName('error'), "testing", array());
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $requestBody = $output->getRequest()->getBody();
         
         $this->assertEquals($streamInput, $requestBody);
@@ -1045,7 +1045,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         ));
         
         $result = $dataBuilder->makeData(
-            Level::fromName('error'),
+            Level::ERROR,
             new \Exception(),
             array()
         );

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -17,9 +17,11 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $_SESSION = array();
+        
         $this->dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
     }
 
@@ -316,7 +318,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'branch' => 'test-branch'
+            'branch' => 'test-branch',
+            'levelFactory' => new LevelFactory
         ));
 
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
@@ -328,7 +331,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'code_version' => '3.4.1'
+            'code_version' => '3.4.1',
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('3.4.1', $output->getCodeVersion());
@@ -339,7 +343,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'host' => 'my host'
+            'host' => 'my host',
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('my host', $output->getServer()->getHost());
@@ -349,7 +354,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
         
         $result = $dataBuilder->makeData(Level::ERROR, "testing", array());
@@ -362,7 +368,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'send_message_trace' => true
+            'send_message_trace' => true,
+            'levelFactory' => new LevelFactory
         ));
     
         $result = $dataBuilder->makeData(Level::ERROR, "testing", array());
@@ -413,7 +420,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         // Negative test
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
         $ex = $this->exceptionTraceArgsHelper('trace args message');
         $frames = $dataBuilder->getExceptionTrace($ex)->getFrames();
@@ -423,7 +431,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'local_vars_dump' => true
+            'local_vars_dump' => true,
+            'levelFactory' => new LevelFactory
         ));
         $expected = 'trace args message';
         $ex = $this->exceptionTraceArgsHelper($expected);
@@ -444,7 +453,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'include_error_code_context' => true,
-            'include_exception_code_context' => false
+            'include_exception_code_context' => false,
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNull($output[1]->getContext());
@@ -454,7 +464,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNull($output[1]->getContext());
@@ -465,7 +476,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'include_exception_code_context' => true
+            'include_exception_code_context' => true,
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->getExceptionTrace(new \Exception())->getFrames();
         $this->assertNotEmpty($output[1]->getContext());
@@ -477,7 +489,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'include_error_code_context' => false,
-            'include_exception_code_context' => true
+            'include_exception_code_context' => true,
+            'levelFactory' => new LevelFactory
         ));
         $testFilePath = __DIR__ . '/DataBuilderTest.php';
         $backtrace = array(
@@ -505,7 +518,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
             'include_error_code_context' => true,
-            'include_exception_code_context' => false
+            'include_exception_code_context' => false,
+            'levelFactory' => new LevelFactory
         ));
 
         $backTrace = array(
@@ -557,7 +571,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
 
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
 
         $backTrace = array(
@@ -599,7 +614,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
             'person' => array(
                 'id' => '123',
                 'email' => 'test@test.com'
-            )
+            ),
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
@@ -615,7 +631,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
                     'id' => '123',
                     'email' => 'test@test.com'
                 );
-            }
+            },
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
@@ -644,7 +661,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'root' => '/var/www/app'
+            'root' => '/var/www/app',
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('/var/www/app', $output->getServer()->getRoot());
@@ -674,7 +692,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'scrubFields' => $scrubFields
+            'scrubFields' => $scrubFields,
+            'levelFactory' => new LevelFactory
         ));
         $result = $dataBuilder->scrub($testData);
         $this->assertEquals($expected, $result, "Looks like some fields did not get scrubbed correctly.");
@@ -897,7 +916,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'scrubFields' => $scrubFields
+            'scrubFields' => $scrubFields,
+            'levelFactory' => new LevelFactory
         ));
         $result = $dataBuilder->scrub($testData);
         $this->assertEquals($expected, $result, "Looks like some fields did not get scrubbed correctly.");
@@ -961,7 +981,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'scrubFields' => array('scrubit')
+            'scrubFields' => array('scrubit'),
+            'levelFactory' => new LevelFactory
         ));
         
         $result = $dataBuilder->scrub($testData, "@");
@@ -982,7 +1003,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $requestBody = $output->getRequest()->getBody();
@@ -1041,7 +1063,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'capture_error_stacktraces' => $captureErrorStacktraces
+            'capture_error_stacktraces' => $captureErrorStacktraces,
+            'levelFactory' => new LevelFactory
         ));
         
         $result = $dataBuilder->makeData(
@@ -1065,7 +1088,8 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
             'environment' => 'tests',
-            'capture_error_stacktraces' => $captureErrorStacktraces
+            'capture_error_stacktraces' => $captureErrorStacktraces,
+            'levelFactory' => new LevelFactory
         ));
         
         $result = $dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -48,10 +48,11 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
     public function testLevel()
     {
+        $levelFactory = new LevelFactory;
         $level = Level::ERROR;
         
         $this->assertEquals(
-            Level::fromName($level),
+            $levelFactory->fromName($level),
             $this->data->setLevel($level)->getLevel()
         );
     }
@@ -148,6 +149,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
     public function testEncode()
     {
         $time = time();
+        $level = $this->mockSerialize("Rollbar\Payload\Level", "{LEVEL}");
         $body = $this->mockSerialize($this->body, "{BODY}");
         $request = $this->mockSerialize("Rollbar\Payload\Request", "{REQUEST}");
         $person = $this->mockSerialize("Rollbar\Payload\Person", "{PERSON}");
@@ -157,7 +159,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
         $data = $this->data
             ->setEnvironment("testing")
             ->setBody($body)
-            ->setLevel(Level::ERROR)
+            ->setLevel($level)
             ->setTimestamp($time)
             ->setCodeVersion("v0.17.3")
             ->setPlatform("LAMP")
@@ -177,7 +179,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains("\"environment\":\"testing\"", $encoded);
         $this->assertContains("\"body\":\"{BODY}\"", $encoded);
-        $this->assertContains("\"level\":\"error\"", $encoded);
+        $this->assertContains("\"level\":\"{LEVEL}\"", $encoded);
         $this->assertContains("\"timestamp\":$time", $encoded);
         $this->assertContains("\"code_version\":\"v0.17.3\"", $encoded);
         $this->assertContains("\"platform\":\"LAMP\"", $encoded);

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -2,6 +2,7 @@
 
 use \Mockery as m;
 use Rollbar\Payload\Data;
+use Rollbar\Payload\Level;
 
 class DataTest extends \PHPUnit_Framework_TestCase
 {
@@ -47,8 +48,12 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
     public function testLevel()
     {
-        $level = m::mock("Rollbar\Payload\Level");
-        $this->assertEquals($level, $this->data->setLevel($level)->getLevel());
+        $level = Level::ERROR;
+        
+        $this->assertEquals(
+            Level::fromName($level),
+            $this->data->setLevel($level)->getLevel()
+        );
     }
 
     public function testTimestamp()
@@ -143,7 +148,6 @@ class DataTest extends \PHPUnit_Framework_TestCase
     public function testEncode()
     {
         $time = time();
-        $level = $this->mockSerialize("Rollbar\Payload\Level", "{LEVEL}");
         $body = $this->mockSerialize($this->body, "{BODY}");
         $request = $this->mockSerialize("Rollbar\Payload\Request", "{REQUEST}");
         $person = $this->mockSerialize("Rollbar\Payload\Person", "{PERSON}");
@@ -153,7 +157,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
         $data = $this->data
             ->setEnvironment("testing")
             ->setBody($body)
-            ->setLevel($level)
+            ->setLevel(Level::ERROR)
             ->setTimestamp($time)
             ->setCodeVersion("v0.17.3")
             ->setPlatform("LAMP")
@@ -173,7 +177,7 @@ class DataTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains("\"environment\":\"testing\"", $encoded);
         $this->assertContains("\"body\":\"{BODY}\"", $encoded);
-        $this->assertContains("\"level\":\"{LEVEL}\"", $encoded);
+        $this->assertContains("\"level\":\"error\"", $encoded);
         $this->assertContains("\"timestamp\":$time", $encoded);
         $this->assertContains("\"code_version\":\"v0.17.3\"", $encoded);
         $this->assertContains("\"platform\":\"LAMP\"", $encoded);

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -26,13 +26,13 @@ class DefaultsTest extends \PHPUnit_Framework_TestCase
     public function testMessageLevel()
     {
         $this->assertEquals("warning", $this->d->messageLevel());
-        $this->assertEquals("error", $this->d->messageLevel(Level::ERROR()));
+        $this->assertEquals("error", $this->d->messageLevel(Level::ERROR));
     }
 
     public function testExceptionLevel()
     {
         $this->assertEquals("error", $this->d->exceptionLevel());
-        $this->assertEquals("warning", $this->d->exceptionLevel(Level::Warning()));
+        $this->assertEquals("warning", $this->d->exceptionLevel(Level::WARNING));
     }
 
     public function testErrorLevels()

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar;
 
-use Psr\Log\LogLevel;
+use Rollbar\Payload\Level;
 
 class FluentTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,7 +20,7 @@ class FluentTest extends \PHPUnit_Framework_TestCase
             'handler' => 'fluent',
         ), false, false, false);
         $logger = Rollbar::logger();
-        $this->assertEquals(200, $logger->log(LogLevel::INFO, 'this is a test', array())->getStatus());
+        $this->assertEquals(200, $logger->log(Level::INFO, 'this is a test', array())->getStatus());
 
         socket_close($socket);
     }

--- a/tests/LevelFactoryTest.php
+++ b/tests/LevelFactoryTest.php
@@ -1,0 +1,61 @@
+<?php namespace Rollbar;
+
+use Rollbar\Payload\Level;
+
+class LevelFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    private $levelFactory;
+    
+    public function setUp()
+    {
+        $this->levelFactory = new LevelFactory();
+    }
+    
+    /**
+     * @dataProvider isValidLevelProvider
+     */
+    public function testIsValidLevelProvider($level, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            $this->levelFactory->isValidLevel($level)
+        );
+    }
+    
+    public function isValidLevelProvider()
+    {
+        $data = $this->fromNameProvider();
+        foreach ($data as &$testParams) {
+            $testParams []= true;
+        }
+        $data []= array('test-stub', false);
+        return $data;
+    }
+    
+    /**
+     * @dataProvider fromNameProvider
+     */
+    public function testFromName($level)
+    {
+        $this->assertInstanceOf(
+            'Rollbar\Payload\Level',
+            $this->levelFactory->fromName($level)
+        );
+    }
+    
+    public function fromNameProvider()
+    {
+        return array(
+            array(Level::EMERGENCY),
+            array(Level::ALERT),
+            array(Level::CRITICAL),
+            array(Level::ERROR),
+            array(Level::WARNING),
+            array(Level::NOTICE),
+            array(Level::INFO),
+            array(Level::DEBUG),
+            array(Level::IGNORED),
+            array(Level::IGNORE),
+        );
+    }
+}

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -7,17 +7,22 @@ class LevelTest extends \PHPUnit_Framework_TestCase
 {
     public function testLevel()
     {
-        $l = Level::TEST();
-        $this->assertNull($l);
+        try {
+            $level = Level::TEST();
+            $this->fail();
+        } catch(\Exception $exception) {
+            $this->assertTrue(true);
+        }
+        
 
-        $l = Level::CRITICAL();
-        $this->assertNotNull($l);
-        $this->assertSame(Level::CRITICAL(), $l);
-        $this->assertSame(Level::critical(), $l);
+        $level = Level::CRITICAL();
+        $this->assertNotNull($level);
+        $this->assertSame(Level::CRITICAL(), $level);
+        $this->assertSame(Level::critical(), $level);
 
-        $l = Level::Info();
-        $this->assertNotNull($l);
-        $this->assertSame(Level::INFO(), $l);
-        $this->assertSame('"info"', json_encode($l->jsonSerialize()));
+        $level = Level::Info();
+        $this->assertNotNull($level);
+        $this->assertSame(Level::INFO(), $level);
+        $this->assertSame('"info"', json_encode($level->jsonSerialize()));
     }
 }

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -10,7 +10,7 @@ class LevelTest extends \PHPUnit_Framework_TestCase
         try {
             $level = Level::TEST();
             $this->fail();
-        } catch(\Exception $exception) {
+        } catch (\Exception $exception) {
             $this->assertTrue(true);
         }
         

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -5,15 +5,12 @@ use Rollbar\Payload\Level;
 
 class LevelTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException \Exception
+     */
     public function testLevel()
     {
-        try {
-            $level = Level::TEST();
-            $this->fail();
-        } catch (\Exception $exception) {
-            $this->assertTrue(true);
-        }
-        
+        $level = Level::TEST();
 
         $level = Level::CRITICAL();
         $this->assertNotNull($level);

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -34,21 +34,21 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
         try {
             throw new \Exception('test exception');
         } catch (\Exception $e) {
-            Rollbar::log(Level::error(), $e);
+            Rollbar::log(Level::ERROR, $e);
         }
         
         // Message at level 'info'
-        Rollbar::log(Level::info(), 'testing info level');
+        Rollbar::log(Level::INFO, 'testing info level');
         
         // With extra data (3rd arg) and custom payload options (4th arg)
         Rollbar::log(
-            Level::info(),
+            Level::INFO,
             'testing extra data',
             array("some_key" => "some value") // key-value additional data
         );
         
         // If you want to check if logging with Rollbar was successful
-        $response = Rollbar::log(Level::info(), 'testing wasSuccessful()');
+        $response = Rollbar::log(Level::INFO, 'testing wasSuccessful()');
         if (!$response->wasSuccessful()) {
             throw new \Exception('logging with Rollbar failed');
         }
@@ -98,17 +98,17 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
         try {
             do_something();
         } catch (\Exception $e) {
-            Rollbar::log(Level::error(), $e);
+            Rollbar::log(Level::ERROR, $e);
             // or
-            Rollbar::log(Level::error(), $e, array("my" => "extra", "data" => 42));
+            Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
     }
     
     public function testBasicUsage2()
     {
-        Rollbar::log(Level::warning(), 'could not connect to mysql server');
+        Rollbar::log(Level::WARNING, 'could not connect to mysql server');
         Rollbar::log(
-            Level::info(),
+            Level::INFO,
             'Here is a message with some additional data',
             array('x' => 10, 'code' => 'blue')
         );

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -28,6 +28,16 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
             "environment" => "testing-php"
         ));
+        $response = $l->log(Level::WARNING, "Testing PHP Notifier", array());
+        $this->assertEquals(200, $response->getStatus());
+    }
+    
+    public function testLogStaticLevel()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php"
+        ));
         $response = $l->log(Level::warning(), "Testing PHP Notifier", array());
         $this->assertEquals(200, $response->getStatus());
     }
@@ -41,7 +51,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
                 E_ERROR => 0
             )
         ));
-        $response = $l->log(Level::error(), new ErrorWrapper(E_ERROR, '', null, null, array()), array());
+        $response = $l->log(Level::ERROR, new ErrorWrapper(E_ERROR, '', null, null, array()), array());
         $this->assertEquals(0, $response->getStatus());
     }
 
@@ -52,7 +62,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             "environment" => "testing-php",
             "included_errno" => E_ERROR | E_WARNING
         ));
-        $response = $l->log(Level::error(), new ErrorWrapper(E_USER_ERROR, '', null, null, array()), array());
+        $response = $l->log(Level::ERROR, new ErrorWrapper(E_USER_ERROR, '', null, null, array()), array());
         $this->assertEquals(0, $response->getStatus());
     }
     
@@ -69,7 +79,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $config = new Config(array_replace_recursive($defaultConfig, $config));
 
         $dataBuilder = new DataBuilder($config->getConfigArray());
-        $data = $dataBuilder->makeData(Level::error(), "testing", $context);
+        $data = $dataBuilder->makeData(Level::ERROR, "testing", $context);
         $payload = new Payload($data, $config->getAccessToken());
 
         $scrubbed = $payload->jsonSerialize();

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -78,7 +78,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         
         $config = new Config(array_replace_recursive($defaultConfig, $config));
 
-        $dataBuilder = new DataBuilder($config->getConfigArray());
+        $dataBuilder = $config->getDataBuilder();
         $data = $dataBuilder->makeData(Level::ERROR, "testing", $context);
         $payload = new Payload($data, $config->getAccessToken());
 

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -25,7 +25,7 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
         try {
             throw new \Exception('test exception');
         } catch (\Exception $e) {
-            Rollbar::log(Level::error(), $e);
+            Rollbar::log(Level::ERROR, $e);
         }
         
         $this->assertTrue(true);
@@ -33,14 +33,14 @@ class RollbarTest extends \PHPUnit_Framework_TestCase
     
     public function testLogMessage()
     {
-        Rollbar::log(Level::info(), 'testing info level');
+        Rollbar::log(Level::INFO, 'testing info level');
         $this->assertTrue(true);
     }
     
     public function testLogExtraData()
     {
         Rollbar::log(
-            Level::info(),
+            Level::INFO,
             'testing extra data',
             array("some_key" => "some value") // key-value additional data
         );

--- a/tests/Truncation/FramesStrategyTest.php
+++ b/tests/Truncation/FramesStrategyTest.php
@@ -3,6 +3,7 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\DataBuilder;
+use Rollbar\LevelFactory;
 
 class FramesStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,7 +14,8 @@ class FramesStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
                     
         $strategy = new FramesStrategy($dataBuilder);

--- a/tests/Truncation/MinBodyStrategyTest.php
+++ b/tests/Truncation/MinBodyStrategyTest.php
@@ -3,6 +3,7 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\DataBuilder;
+use Rollbar\LevelFactory;
 
 class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,7 +15,8 @@ class MinBodyStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
                     
         $strategy = new MinBodyStrategy($dataBuilder);

--- a/tests/Truncation/RawStrategyTest.php
+++ b/tests/Truncation/RawStrategyTest.php
@@ -3,6 +3,7 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\DataBuilder;
+use Rollbar\LevelFactory;
 
 class RawStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +13,8 @@ class RawStrategyTest extends \PHPUnit_Framework_TestCase
         
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
 
         $strategy = new RawStrategy($dataBuilder);

--- a/tests/Truncation/StringsStrategyTest.php
+++ b/tests/Truncation/StringsStrategyTest.php
@@ -3,6 +3,7 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\DataBuilder;
+use Rollbar\LevelFactory;
 
 class StringsStrategyTest extends \PHPUnit_Framework_TestCase
 {
@@ -13,7 +14,8 @@ class StringsStrategyTest extends \PHPUnit_Framework_TestCase
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests'
+            'environment' => 'tests',
+            'levelFactory' => new LevelFactory
         ));
                     
         $strategy = new StringsStrategy($dataBuilder);


### PR DESCRIPTION
This removes most of the usage of static calls to Level class and clarifies the confusion between using `Psr\Log\Level` and `Rollbar\Payload\Level`.

https://github.com/rollbar/rollbar-php/issues/140