### PR TITLE
fix tests by getting rid of isolation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,6 @@
 	 convertErrorsToExceptions="true"
 	 convertNoticesToExceptions="true"
 	 convertWarningsToExceptions="true"
-	 processIsolation="true"
 	 stopOnFailure="false"
 	 syntaxCheck="false">
   <testsuites>

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -625,12 +625,13 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         \Rollbar\Rollbar::init(array(
             'access_token' => 'abcd1234efef5678abcd1234567890be',
-            'environment' => 'tests',
+            'environment' => 'tests'
+        ));
+        $logger = \Rollbar\Rollbar::scope(array(
             'person_fn' => function () {
                 throw new \Exception("Exception from person_fn");
             }
         ));
-        $logger = \Rollbar\Rollbar::logger();
         
         try {
             $logger->log(Level::fromName('error'), "testing exceptions in person_fn", array());

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -14,12 +14,13 @@ class FluentTest extends \PHPUnit_Framework_TestCase
 
         Rollbar::init(array(
             'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
-            'environment' => 'testing',
+            'environment' => 'testing'
+        ), false, false, false);
+        $logger = Rollbar::scope(array(
             'fluent_host' => $address,
             'fluent_port' => $port,
-            'handler' => 'fluent',
-        ), false, false, false);
-        $logger = Rollbar::logger();
+            'handler' => 'fluent'
+          ));
         $this->assertEquals(200, $logger->log(LogLevel::INFO, 'this is a test', array())->getStatus());
 
         socket_close($socket);


### PR DESCRIPTION
We do not need process isolation to get rid of the log spew and test interdependencies, we just need to change the tests slightly. This also dramatically speeds up tests.