### PR TITLE
GitHub Issue #171: why error_sample_rates only use for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,13 @@ Default: `'production'`
 Default: empty array, meaning all errors are reported.
 </dd>
 
+<dt>exception_sample_rates
+</dt>
+<dd>Associative array mapping exception classes to sample rates. Sample rates are ratio out of 1, e.g. 0 is "never report", 1 is "always report", and 0.1 is "report 10% of the time". Sampling is done on a per-exception basis. It also respects class inheritance meaning if Exception is at 1.0 then ExceptionSublcass is also at 1.0, unless explicitly configured otherwise. If ExceptionSubclass is set to 0.5, but Exception is at 1.0 then Exception and all its' subclasses run at 1.0, except for ExceptionSubclass and its' subclasses which run at 0.5. Names of exception classes should NOT be followed with additional `\` for global namespace, i.e. Rollbar\SampleException and NOT \Rollbar\SampleException.
+
+Default: empty array, meaning all exceptions are reported.
+</dd>
+
 <dt>fluent_host</dt>
 <dd>Either an `IPv4`, `IPv6`, or a `unix socket`.
 
@@ -575,6 +582,19 @@ $config['error_sample_rates'] = array(
     // E_USER_WARNING will take the same value, 0.5
     E_USER_NOTICE => 0.1,
     // E_STRICT and beyond will all be 0.1
+);
+?>
+```
+
+Example use of exception_sample_rates:
+
+```php
+<?php
+$config['exception_sample_rates'] = array(
+    // Exception omitted, so defaults to 1
+    
+    // SometimesException set at 0.1 so only reported 10% of the time
+    'SometimesException' => 0.1,
 );
 ?>
 ```

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ Default: empty array, meaning all errors are reported.
 
 <dt>exception_sample_rates
 </dt>
-<dd>Associative array mapping exception classes to sample rates. Sample rates are ratio out of 1, e.g. 0 is "never report", 1 is "always report", and 0.1 is "report 10% of the time". Sampling is done on a per-exception basis. It also respects class inheritance meaning if Exception is at 1.0 then ExceptionSublcass is also at 1.0, unless explicitly configured otherwise. If ExceptionSubclass is set to 0.5, but Exception is at 1.0 then Exception and all its' subclasses run at 1.0, except for ExceptionSubclass and its' subclasses which run at 0.5. Names of exception classes should NOT be followed with additional `\` for global namespace, i.e. Rollbar\SampleException and NOT \Rollbar\SampleException.
+<dd>Associative array mapping exception classes to sample rates. Sample rates are ratio out of 1, e.g. 0 is "never report", 1 is "always report", and 0.1 is "report 10% of the time". Sampling is done on a per-exception basis. It also respects class inheritance meaning if Exception is at 1.0 then ExceptionSublcass is also at 1.0, unless explicitly configured otherwise. If ExceptionSubclass is set to 0.5, but Exception is at 1.0 then Exception and all its' subclasses run at 1.0, except for ExceptionSubclass and its' subclasses which run at 0.5. Names of exception classes should NOT be prefixed with additional `\` for global namespace, i.e. Rollbar\SampleException and NOT \Rollbar\SampleException.
 
 Default: empty array, meaning all exceptions are reported.
 </dd>

--- a/src/Config.php
+++ b/src/Config.php
@@ -433,15 +433,11 @@ class Config
         }
 
         if ($toLog instanceof ErrorWrapper) {
-            
             return $this->shouldIgnoreError($toLog);
-            
         }
         
         if ($toLog instanceof \Exception) {
-            
             return $this->shouldIgnoreException($toLog);
-            
         }
         
         return false;
@@ -450,9 +446,9 @@ class Config
     /**
      * Check if the error should be ignored due to `included_errno` config,
      * `use_error_reporting` config or `error_sample_rates` config.
-     * 
+     *
      * @param \Rollbar\ErrorWrapper $toLog
-     * 
+     *
      * @return bool
      */
     protected function shouldIgnoreError(ErrorWrapper $toLog)
@@ -485,9 +481,9 @@ class Config
     /**
      * Check if the exception should be ignored due to configured exception
      * sample rates.
-     * 
+     *
      * @param \Exception $toLog
-     * 
+     *
      * @return bool
      */
     protected function shouldIgnoreException(\Exception $toLog)
@@ -506,9 +502,9 @@ class Config
     /**
      * Calculate what's the chance of logging this exception according to
      * exception sampling.
-     * 
+     *
      * @param \Exception $toLog
-     * 
+     *
      * @return float
      */
     public function exceptionSampleRate(\Exception $toLog)

--- a/src/Config.php
+++ b/src/Config.php
@@ -56,6 +56,7 @@ class Config
      */
     private $checkIgnore;
     private $error_sample_rates = array();
+    private $exception_sample_rates = array();
     private $mt_randmax;
 
     private $included_errno = ROLLBAR_INCLUDED_ERRNO_BITMASK;
@@ -76,6 +77,10 @@ class Config
 
         if (isset($configArray['error_sample_rates'])) {
             $this->error_sample_rates = $configArray['error_sample_rates'];
+        }
+        
+        if (isset($configArray['exception_sample_rates'])) {
+            $this->exception_sample_rates = $configArray['exception_sample_rates'];
         }
 
         $levels = array(E_WARNING, E_NOTICE, E_USER_ERROR, E_USER_WARNING,
@@ -407,6 +412,7 @@ class Config
         if ($this->shouldSuppress()) {
             return true;
         }
+        
         if (isset($this->checkIgnore)) {
             try {
                 if (call_user_func($this->checkIgnore, $isUncaught, $toLog, $payload)) {
@@ -417,37 +423,114 @@ class Config
                 $this->checkIgnore = null;
             }
         }
+        
         if ($this->levelTooLow($payload)) {
             return true;
         }
+        
         if (!is_null($this->filter)) {
             return $this->filter->shouldSend($payload, $accessToken);
         }
 
         if ($toLog instanceof ErrorWrapper) {
-            $errno = $toLog->errorLevel;
+            
+            return $this->shouldIgnoreError($toLog);
+            
+        }
+        
+        if ($toLog instanceof \Exception) {
+            
+            return $this->shouldIgnoreException($toLog);
+            
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Check if the error should be ignored due to `included_errno` config,
+     * `use_error_reporting` config or `error_sample_rates` config.
+     * 
+     * @param \Rollbar\ErrorWrapper $toLog
+     * 
+     * @return bool
+     */
+    protected function shouldIgnoreError(ErrorWrapper $toLog)
+    {
+        $errno = $toLog->errorLevel;
 
-            if ($this->included_errno != -1 && ($errno & $this->included_errno) != $errno) {
-                // ignore
+        if ($this->included_errno != -1 && ($errno & $this->included_errno) != $errno) {
+            // ignore
+            return true;
+        }
+
+        if ($this->use_error_reporting && ($errno & error_reporting()) != $errno) {
+            // ignore due to error_reporting level
+            return true;
+        }
+
+        if (isset($this->error_sample_rates[$errno])) {
+            // get a float in the range [0, 1)
+            // mt_rand() is inclusive, so add 1 to mt_randmax
+            $float_rand = mt_rand() / ($this->mt_randmax + 1);
+            if ($float_rand > $this->error_sample_rates[$errno]) {
+                // skip
                 return true;
-            }
-
-            if ($this->use_error_reporting && ($errno & error_reporting()) != $errno) {
-                // ignore due to error_reporting level
-                return true;
-            }
-
-            if (isset($this->error_sample_rates[$errno])) {
-                // get a float in the range [0, 1)
-                // mt_rand() is inclusive, so add 1 to mt_randmax
-                $float_rand = mt_rand() / ($this->mt_randmax + 1);
-                if ($float_rand > $this->error_sample_rates[$errno]) {
-                    // skip
-                    return true;
-                }
             }
         }
+        
         return false;
+    }
+    
+    /**
+     * Check if the exception should be ignored due to configured exception
+     * sample rates.
+     * 
+     * @param \Exception $toLog
+     * 
+     * @return bool
+     */
+    protected function shouldIgnoreException(\Exception $toLog)
+    {
+        // get a float in the range [0, 1)
+        // mt_rand() is inclusive, so add 1 to mt_randmax
+        $floatRand = mt_rand() / ($this->mt_randmax + 1);
+        if ($floatRand > $this->exceptionSampleRate($toLog)) {
+            // skip
+            return true;
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Calculate what's the chance of logging this exception according to
+     * exception sampling.
+     * 
+     * @param \Exception $toLog
+     * 
+     * @return float
+     */
+    public function exceptionSampleRate(\Exception $toLog)
+    {
+        $sampleRate = 1.0;
+        
+        $exceptionClasses = array();
+        
+        $class = get_class($toLog);
+        while ($class) {
+            $exceptionClasses []= $class;
+            $class = get_parent_class($class);
+        }
+        $exceptionClasses = array_reverse($exceptionClasses);
+        
+        foreach ($exceptionClasses as $exceptionClass) {
+            if (isset($this->exception_sample_rates["$exceptionClass"])) {
+                $sampleRate = $this->exception_sample_rates["$exceptionClass"];
+            }
+        }
+        
+        return $sampleRate;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -510,6 +510,9 @@ class Config
     public function exceptionSampleRate(\Exception $toLog)
     {
         $sampleRate = 1.0;
+        if (count($this->exception_sample_rates) == 0) {
+            return $sampleRate;
+        }
         
         $exceptionClasses = array();
         

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,6 +9,18 @@ use Rollbar\Payload\Message;
 use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
 
+class MidExceptionSampleRate extends \Exception {}
+
+class SilentExceptionSampleRate extends MidExceptionSampleRate {}
+
+class FiftyFityExceptionSampleRate extends MidExceptionSampleRate {}
+
+class FiftyFityChildExceptionSampleRate extends FiftyFityExceptionSampleRate {}
+
+class QuarterExceptionSampleRate extends FiftyFityExceptionSampleRate {}
+
+class VerboseExceptionSampleRate extends MidExceptionSampleRate {}
+
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
     private $error;
@@ -436,6 +448,54 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 E_ERROR, // "error_reporting"
                 false
             )
+        );
+    }
+    
+    /**
+     * @dataProvider providerExceptionSampleRate
+     */
+    public function testExceptionSampleRate($exception, $expected)
+    {
+        $config = new Config(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php",
+            "exception_sample_rates" => array(
+                get_class($exception) => $expected
+            )
+        ));
+        
+        $sampleRate = $config->exceptionSampleRate($exception);
+        
+        $this->assertEquals($expected, $sampleRate);
+    }
+    
+    public function providerExceptionSampleRate()
+    {
+        return array(
+            array(
+                new \Exception,
+                1.0
+            ),
+            array(
+                new SilentExceptionSampleRate,
+                0.0
+            ),
+            array(
+                new FiftyFityExceptionSampleRate,
+                0.5
+            ),
+            array(
+                new FiftyFityChildExceptionSampleRate,
+                0.5
+            ),
+            array(
+                new QuarterExceptionSampleRate,
+                0.25
+            ),
+            array(
+                new VerboseExceptionSampleRate,
+                1.0
+            ),
         );
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,17 +9,11 @@ use Rollbar\Payload\Message;
 use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
 
-class MidExceptionSampleRate extends \Exception {}
-
-class SilentExceptionSampleRate extends MidExceptionSampleRate {}
-
-class FiftyFityExceptionSampleRate extends MidExceptionSampleRate {}
-
-class FiftyFityChildExceptionSampleRate extends FiftyFityExceptionSampleRate {}
-
-class QuarterExceptionSampleRate extends FiftyFityExceptionSampleRate {}
-
-class VerboseExceptionSampleRate extends MidExceptionSampleRate {}
+use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
+use Rollbar\TestHelpers\Exceptions\FiftyFiftyExceptionSampleRate;
+use Rollbar\TestHelpers\Exceptions\FiftyFityChildExceptionSampleRate;
+use Rollbar\TestHelpers\Exceptions\QuarterExceptionSampleRate;
+use Rollbar\TestHelpers\Exceptions\VerboseExceptionSampleRate;
 
 class ConfigTest extends \PHPUnit_Framework_TestCase
 {
@@ -481,7 +475,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 0.0
             ),
             array(
-                new FiftyFityExceptionSampleRate,
+                new FiftyFiftyExceptionSampleRate,
                 0.5
             ),
             array(

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -2,8 +2,7 @@
 
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
-
-class SilentExceptionSampleRate2 extends \Exception {}
+use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
 
 class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,10 +73,10 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
             "environment" => "testing-php",
             "exception_sample_rates" => array(
-                'Rollbar\SilentExceptionSampleRate2' => 0.0
+                'Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate' => 0.0
             )
         ));
-        $response = $l->log(Level::ERROR, new SilentExceptionSampleRate2);
+        $response = $l->log(Level::ERROR, new SilentExceptionSampleRate);
         
         $this->assertEquals(0, $response->getStatus());
         

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -3,6 +3,8 @@
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 
+class SilentExceptionSampleRate extends \Exception {}
+
 class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
 {
     
@@ -64,6 +66,24 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             array()
         );
         $this->assertEquals(0, $response->getStatus());
+    }
+
+    public function testExceptionSampleRates()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "environment" => "testing-php",
+            "exception_sample_rates" => array(
+                'Rollbar\SilentExceptionSampleRate' => 0.0
+            )
+        ));
+        $response = $l->log(Level::ERROR, new SilentExceptionSampleRate);
+        
+        $this->assertEquals(0, $response->getStatus());
+        
+        $response = $l->log(Level::ERROR, new \Exception);
+        
+        $this->assertEquals(200, $response->getStatus());
     }
 
     public function testIncludedErrNo()

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -3,7 +3,7 @@
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 
-class SilentExceptionSampleRate extends \Exception {}
+class SilentExceptionSampleRate2 extends \Exception {}
 
 class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
 {
@@ -74,10 +74,10 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
             "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
             "environment" => "testing-php",
             "exception_sample_rates" => array(
-                'Rollbar\SilentExceptionSampleRate' => 0.0
+                'Rollbar\SilentExceptionSampleRate2' => 0.0
             )
         ));
-        $response = $l->log(Level::ERROR, new SilentExceptionSampleRate);
+        $response = $l->log(Level::ERROR, new SilentExceptionSampleRate2);
         
         $this->assertEquals(0, $response->getStatus());
         

--- a/tests/TestHelpers/Exceptions/FiftyFiftyExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/FiftyFiftyExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class FiftyFiftyExceptionSampleRate extends \Exception
+{
+}

--- a/tests/TestHelpers/Exceptions/FiftyFityChildExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/FiftyFityChildExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class FiftyFityChildExceptionSampleRate extends FiftyFiftyExceptionSampleRate
+{
+}

--- a/tests/TestHelpers/Exceptions/MidExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/MidExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class MidExceptionSampleRate extends \Exception
+{
+}

--- a/tests/TestHelpers/Exceptions/QuarterExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/QuarterExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class QuarterExceptionSampleRate extends FiftyFiftyExceptionSampleRate
+{
+}

--- a/tests/TestHelpers/Exceptions/SilentExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/SilentExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class SilentExceptionSampleRate extends MidExceptionSampleRate
+{
+}

--- a/tests/TestHelpers/Exceptions/VerboseExceptionSampleRate.php
+++ b/tests/TestHelpers/Exceptions/VerboseExceptionSampleRate.php
@@ -1,0 +1,5 @@
+<?php namespace Rollbar\TestHelpers\Exceptions;
+
+class VerboseExceptionSampleRate extends MidExceptionSampleRate
+{
+}


### PR DESCRIPTION
This add `exception_samples_rates` config which allows to set sampling rates for exceptions based on exception class.