### PR TITLE
GitHub Issue #144: allow passing ROLLBAR_TEST_TOKEN in phpunit arguments

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,4 +18,7 @@
       <directory suffix=".php">./src</directory>
     </whitelist>
   </filter>
+  <php>
+    <env name="ROLLBAR_TEST_TOKEN" value="ad865e76e7fb496fab096ac07b1dbabb" />
+  </php>
 </phpunit>

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -9,7 +9,7 @@ function microtime()
     return 2;
 }
 
-class AgentTest extends \PHPUnit_Framework_TestCase
+class AgentTest extends Rollbar\BaseRollbarTest
 {
     private $path = '/tmp/rollbar-php';
 
@@ -23,7 +23,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
     public function testAgent()
     {
         Rollbar\Rollbar::init(array(
-            'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
+            'access_token' => $this->getTestAccessToken(),
             'environment' => 'testing',
             'agent_log_location' => $this->path,
             'handler' => 'agent'

--- a/tests/BackwardsCompatibilityConfigTest.php
+++ b/tests/BackwardsCompatibilityConfigTest.php
@@ -2,12 +2,12 @@
 
 namespace Rollbar;
 
-class BackwardsCompatibilityConfigTest extends \PHPUnit_Framework_TestCase
+class BackwardsCompatibilityConfigTest extends BaseRollbarTest
 {
     public function testConfigValues()
     {
         Rollbar::init(array(
-            'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
+            'access_token' => $this->getTestAccessToken(),
             'agent_log_location' => '/var/log/rollbar-php',
             'base_api_url' => 'http://dev:8090/api/1/',
             'batch_size' => 50,

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,0 +1,14 @@
+<?php namespace Rollbar;
+
+abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
+{
+    
+    const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
+    
+    public function getTestAccessToken()
+    {
+        return isset($_ENV['ROLLBAR_TEST_TOKEN']) ?
+            $_ENV['ROLLBAR_TEST_TOKEN'] :
+            static::DEFAULT_ACCESS_TOKEN;
+    }
+}

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Body;
 
-class BodyTest extends \PHPUnit_Framework_TestCase
+class BodyTest extends BaseRollbarTest
 {
     public function testBodyValue()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,7 +9,7 @@ use Rollbar\Payload\Message;
 use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends BaseRollbarTest
 {
     private $error;
 
@@ -29,32 +29,31 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         m::close();
     }
-
-    private $token = "abcd1234efef5678abcd1234567890be";
+    
     private $env = "rollbar-php-testing";
 
     public function testAccessToken()
     {
         $config = new Config(array(
-            'access_token' => $this->token,
+            'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env
         ));
-        $this->assertEquals($this->token, $config->getAccessToken());
+        $this->assertEquals($this->getTestAccessToken(), $config->getAccessToken());
     }
 
     public function testAccessTokenFromEnvironment()
     {
-        $_ENV['ROLLBAR_ACCESS_TOKEN'] = $this->token;
+        $_ENV['ROLLBAR_ACCESS_TOKEN'] = $this->getTestAccessToken();
         $config = new Config(array(
             'environment' => 'testing'
         ));
-        $this->assertEquals($this->token, $config->getAccessToken());
+        $this->assertEquals($this->getTestAccessToken(), $config->getAccessToken());
     }
 
     public function testDataBuilder()
     {
         $arr = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         );
         $config = new Config($arr);
@@ -64,13 +63,13 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testExtend()
     {
         $arr = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         );
         $config = new Config($arr);
         $extended = $config->extend(array("one" => 1, "arr" => array()));
         $expected = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "one" => 1,
             "arr" => array()
@@ -81,13 +80,13 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testConfigure()
     {
         $arr = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         );
         $config = new Config($arr);
         $config->configure(array("one" => 1, "arr" => array()));
         $expected = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "one" => 1,
             "arr" => array()
@@ -99,7 +98,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         $fdb = new FakeDataBuilder(array());
         $arr = array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "dataBuilder" => $fdb
         );
@@ -120,7 +119,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             ->andReturn($pPrime)
             ->mock();
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "transformer" => $transformer
         ));
@@ -130,7 +129,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testMinimumLevel()
     {
         $c = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "minimumLevel" => "warning"
         ));
@@ -189,7 +188,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
             ->andReturn(true, false)
             ->mock();
         $c = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "filter" => $filter
         ));
@@ -202,21 +201,21 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $p = m::mock("Rollbar\Payload\Payload");
         $sender = m::mock("Rollbar\Senders\SenderInterface")
             ->shouldReceive("send")
-            ->with($p, $this->token)
+            ->with($p, $this->getTestAccessToken())
             ->once()
             ->mock();
         $c = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "sender" => $sender
         ));
-        $c->send($p, $this->token);
+        $c->send($p, $this->getTestAccessToken());
     }
     
     public function testEndpoint()
     {
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "endpoint" => "http://localhost/api/1/"
         ));
@@ -230,7 +229,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testEndpointDefault()
     {
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
         
@@ -243,7 +242,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testBaseApiUrl()
     {
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "base_api_url" => "http://localhost/api/1/"
         ));
@@ -257,7 +256,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testBaseApiUrlDefault()
     {
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
         
@@ -270,7 +269,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testSendMessageTrace()
     {
         $c = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "send_message_trace" => true
         ));
@@ -278,7 +277,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($c->getSendMessageTrace());
         
         $c = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
         
@@ -289,7 +288,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     {
         $called = false;
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "checkIgnore" => function () use (&$called) {
                 $called = true;
@@ -305,7 +304,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 $data,
                 $config->getAccessToken()
             ),
-            $this->token,
+            $this->getTestAccessToken(),
             $this->error,
             false
         );
@@ -320,7 +319,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $errorPassed = null;
         
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "checkIgnore" => function (
                 $isUncaught,
@@ -346,7 +345,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 $data,
                 $config->getAccessToken()
             ),
-            $this->token,
+            $this->getTestAccessToken(),
             $this->error,
             true
         );
@@ -359,7 +358,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
     public function testCaptureErrorStacktraces()
     {
         $logger = new RollbarLogger(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "capture_error_stacktraces" => false
         ));
@@ -383,7 +382,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
         $called = false;
         
         $config = new Config(array(
-            "access_token" => $this->token,
+            "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "checkIgnore" => function () use (&$called) {
                 $called = true;
@@ -406,7 +405,7 @@ class ConfigTest extends \PHPUnit_Framework_TestCase
                 $data,
                 $config->getAccessToken()
             ),
-            $this->token,
+            $this->getTestAccessToken(),
             $this->error,
             false
         );

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Context;
 
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends BaseRollbarTest
 {
     public function testContextPre()
     {

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -5,7 +5,7 @@ namespace Rollbar;
 use Rollbar\Payload\Level;
 use Rollbar\TestHelpers\MockPhpStream;
 
-class DataBuilderTest extends \PHPUnit_Framework_TestCase
+class DataBuilderTest extends BaseRollbarTest
 {
 
     /**
@@ -18,7 +18,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $_SESSION = array();
         
         $this->dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities
@@ -315,7 +315,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testBranchKey()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'branch' => 'test-branch',
             'levelFactory' => new LevelFactory,
@@ -329,7 +329,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCodeVersion()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'code_version' => '3.4.1',
             'levelFactory' => new LevelFactory,
@@ -342,7 +342,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testHost()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'host' => 'my host',
             'levelFactory' => new LevelFactory,
@@ -355,7 +355,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testGetMessage()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities
@@ -369,7 +369,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'send_message_trace' => true,
             'levelFactory' => new LevelFactory,
@@ -384,7 +384,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         // Negative test
         $c = new Config(array(
-            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'access_token' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'send_message_trace' => true
         ));
@@ -401,7 +401,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         // Positive test
         $c = new Config(array(
-            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'access_token' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'send_message_trace' => true,
             'local_vars_dump' => true
@@ -423,7 +423,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     {
         // Negative test
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities
@@ -437,7 +437,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         
         // Positive test
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'local_vars_dump' => true,
             'levelFactory' => new LevelFactory,
@@ -463,7 +463,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testExceptionFramesWithoutContext()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'include_error_code_context' => true,
             'include_exception_code_context' => false,
@@ -477,7 +477,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testExceptionFramesWithoutContextDefault()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities
@@ -489,7 +489,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testExceptionFramesWithContext()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'include_exception_code_context' => true,
             'levelFactory' => new LevelFactory,
@@ -504,7 +504,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $utilities = new Utilities;
         
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'include_error_code_context' => false,
             'include_exception_code_context' => true,
@@ -545,7 +545,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $testFilePath = __DIR__ . '/DataBuilderTest.php';
 
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'include_error_code_context' => true,
             'include_exception_code_context' => false,
@@ -612,7 +612,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         $utilities = new Utilities;
 
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => $utilities
@@ -661,7 +661,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testPerson()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'person' => array(
                 'id' => '123',
@@ -677,7 +677,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testPersonFunc()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'person_fn' => function () {
                 return array(
@@ -695,7 +695,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testPersonFuncException()
     {
         \Rollbar\Rollbar::init(array(
-            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'access_token' => $this->getTestAccessToken(),
             'environment' => 'tests'
         ));
         $logger = \Rollbar\Rollbar::scope(array(
@@ -715,7 +715,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testRoot()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'root' => '/var/www/app',
             'levelFactory' => new LevelFactory,
@@ -737,7 +737,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
         file_put_contents('php://input', $streamInput);
         
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities,
@@ -770,7 +770,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     ) {
     
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'capture_error_stacktraces' => $captureErrorStacktraces,
             'levelFactory' => new LevelFactory,
@@ -790,7 +790,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     public function testFramesOrder()
     {
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'include_exception_code_context' => true,
             'levelFactory' => new LevelFactory,
@@ -810,7 +810,7 @@ class DataBuilderTest extends \PHPUnit_Framework_TestCase
     ) {
     
         $dataBuilder = new DataBuilder(array(
-            'accessToken' => 'abcd1234efef5678abcd1234567890be',
+            'accessToken' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'capture_error_stacktraces' => $captureErrorStacktraces,
             'levelFactory' => new LevelFactory,

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -4,7 +4,7 @@ use \Mockery as m;
 use Rollbar\Payload\Data;
 use Rollbar\Payload\Level;
 
-class DataTest extends \PHPUnit_Framework_TestCase
+class DataTest extends BaseRollbarTest
 {
     private $body;
     private $data;

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -5,7 +5,7 @@ use Rollbar\Payload\Level;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
 
-class DefaultsTest extends \PHPUnit_Framework_TestCase
+class DefaultsTest extends BaseRollbarTest
 {
     /**
      * @var Defaults

--- a/tests/ErrorWrapperTest.php
+++ b/tests/ErrorWrapperTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\ErrorWrapper;
 
-class ErrorWrapperTest extends \PHPUnit_Framework_TestCase
+class ErrorWrapperTest extends BaseRollbarTest
 {
     public function testBacktrace()
     {

--- a/tests/ExceptionInfoTest.php
+++ b/tests/ExceptionInfoTest.php
@@ -1,6 +1,8 @@
 <?php namespace Rollbar\Payload;
 
-class ExceptionInfoTest extends \PHPUnit_Framework_TestCase
+use Rollbar;
+
+class ExceptionInfoTest extends Rollbar\BaseRollbarTest
 {
     public function testClass()
     {

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -4,7 +4,7 @@ namespace Rollbar;
 
 use Rollbar\Payload\Level;
 
-class FluentTest extends \PHPUnit_Framework_TestCase
+class FluentTest extends BaseRollbarTest
 {
 
     public function testFluent()

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Frame;
 
-class FrameTest extends \PHPUnit_Framework_TestCase
+class FrameTest extends BaseRollbarTest
 {
     private $exception;
     private $frame;

--- a/tests/LevelFactoryTest.php
+++ b/tests/LevelFactoryTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\Payload\Level;
 
-class LevelFactoryTest extends \PHPUnit_Framework_TestCase
+class LevelFactoryTest extends BaseRollbarTest
 {
     private $levelFactory;
     

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Level;
 
-class LevelTest extends \PHPUnit_Framework_TestCase
+class LevelTest extends BaseRollbarTest
 {
     /**
      * @expectedException \Exception

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,6 +1,8 @@
 <?php namespace Rollbar\Payload;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+use Rollbar;
+
+class MessageTest extends Rollbar\BaseRollbarTest
 {
     public function testBacktrace()
     {

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Notifier;
 
-class NotifierTest extends \PHPUnit_Framework_TestCase
+class NotifierTest extends BaseRollbarTest
 {
     public function testName()
     {

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -4,7 +4,7 @@ use \Mockery as m;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
 
-class PayloadTest extends \PHPUnit_Framework_TestCase
+class PayloadTest extends BaseRollbarTest
 {
     public function testPayloadData()
     {
@@ -72,7 +72,7 @@ class PayloadTest extends \PHPUnit_Framework_TestCase
 
     public function testEncode()
     {
-        $accessToken = '012345678901234567890123456789ab';
+        $accessToken = $this->getTestAccessToken();
         $data = m::mock('Rollbar\Payload\Data, \JsonSerializable')
             ->shouldReceive('jsonSerialize')
             ->andReturn(new \ArrayObject())

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Person;
 
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends BaseRollbarTest
 {
     public function testId()
     {

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -1,10 +1,5 @@
 <?php namespace Rollbar;
 
-if (!defined('ROLLBAR_TEST_TOKEN')) {
-    define('ROLLBAR_TEST_TOKEN', 'ad865e76e7fb496fab096ac07b1dbabb');
-}
-
-
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
 use Monolog\Logger;
@@ -15,7 +10,7 @@ function do_something()
     throw new \Exception();
 }
 
-class ReadmeTest extends \PHPUnit_Framework_TestCase
+class ReadmeTest extends BaseRollbarTest
 {
 
     /**
@@ -26,7 +21,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
         // installs global error and exception handlers
         Rollbar::init(
             array(
-                'access_token' => ROLLBAR_TEST_TOKEN,
+                'access_token' => $this->getTestAccessToken(),
                 'environment' => 'production'
             )
         );
@@ -64,7 +59,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
     {
         $config = array(
             // required
-            'access_token' => ROLLBAR_TEST_TOKEN,
+            'access_token' => $this->getTestAccessToken(),
             // optional - environment name. any string will do.
             'environment' => 'production',
             // optional - path to directory your code is in. used for linking stack traces.
@@ -79,7 +74,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
     {
         $config = array(
             // required
-            'access_token' => ROLLBAR_TEST_TOKEN,
+            'access_token' => $this->getTestAccessToken(),
             // optional - environment name. any string will do.
             'environment' => 'production',
             // optional - path to directory your code is in. used for linking stack traces.
@@ -116,7 +111,7 @@ class ReadmeTest extends \PHPUnit_Framework_TestCase
 
     public function testMonolog()
     {
-        $config = array('access_token' => ROLLBAR_TEST_TOKEN, 'environment' => 'testing');
+        $config = array('access_token' => $this->getTestAccessToken(), 'environment' => 'testing');
 
         // installs global error and exception handlers
         Rollbar::init($config);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -3,7 +3,7 @@
 use \Mockery as m;
 use Rollbar\Payload\Request;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends BaseRollbarTest
 {
     public function testUrl()
     {
@@ -86,7 +86,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             "data" => array(
                 "Data" => "Parameters"
             ),
-            "access_token" => "123abc"
+            "access_token" => $this->getTestAccessToken()
         );
         $this->assertEquals($post2, $request->setPost($post2)->getPost());
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\Response;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends BaseRollbarTest
 {
     public function testStatus()
     {

--- a/tests/RollbarJsHelperTest.php
+++ b/tests/RollbarJsHelperTest.php
@@ -1,6 +1,6 @@
 <?php namespace Rollbar;
 
-class JsHelperTest extends \PHPUnit_Framework_TestCase
+class JsHelperTest extends BaseRollbarTest
 {
     protected $jsHelper;
     protected $testSnippetPath;

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -3,7 +3,7 @@
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 
-class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
+class RollbarLoggerTest extends BaseRollbarTest
 {
     
     public function setUp()
@@ -14,7 +14,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testConfigure()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "accessaccesstokentokentokentoken",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
         $l->configure(array("extraData" => 15));
@@ -25,7 +25,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testLog()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
         $response = $l->log(Level::WARNING, "Testing PHP Notifier", array());
@@ -35,7 +35,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testLogStaticLevel()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
         $response = $l->log(Level::warning(), "Testing PHP Notifier", array());
@@ -45,7 +45,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testErrorSampleRates()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
             "error_sample_rates" => array(
                 E_ERROR => 0
@@ -69,7 +69,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testIncludedErrNo()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
             "included_errno" => E_ERROR | E_WARNING
         ));
@@ -93,7 +93,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
         $scrubFields = array('sensitive');
         
         $defaultConfig = array(
-            'access_token' => 'abcd1234efef5678abcd1234567890be',
+            'access_token' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'scrub_fields' => $scrubFields
         );
@@ -329,7 +329,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Emergency()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -340,7 +340,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Alert()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -351,7 +351,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Critical()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -362,7 +362,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Error()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -373,7 +373,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Warning()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -384,7 +384,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Notice()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -395,7 +395,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Info()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 
@@ -406,7 +406,7 @@ class RollbarLoggerTest extends \PHPUnit_Framework_TestCase
     public function testPsr3Debug()
     {
         $l = new RollbarLogger(array(
-            "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
+            "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
 

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -1,9 +1,5 @@
 <?php namespace Rollbar;
 
-if (!defined('ROLLBAR_TEST_TOKEN')) {
-    define('ROLLBAR_TEST_TOKEN', 'ad865e76e7fb496fab096ac07b1dbabb');
-}
-
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
 
@@ -12,13 +8,18 @@ use Rollbar\Payload\Level;
  *
  * @SuppressWarnings(PHPMD.StaticAccess)
  */
-class RollbarTest extends \PHPUnit_Framework_TestCase
+class RollbarTest extends BaseRollbarTest
 {
+    
+    public function __construct()
+    {
+        self::$simpleConfig['access_token'] = $this->getTestAccessToken();
+        self::$simpleConfig['environment'] = 'test';
+        
+        parent::__construct();
+    }
 
-    private static $simpleConfig = array(
-        'access_token' => ROLLBAR_TEST_TOKEN,
-        'environment' => 'test'
-    );
+    private static $simpleConfig = array();
 
     private static function clearLogger()
     {

--- a/tests/ScrubberTest.php
+++ b/tests/ScrubberTest.php
@@ -5,7 +5,7 @@ namespace Rollbar;
 use Rollbar\Payload\Level;
 use Rollbar\TestHelpers\MockPhpStream;
 
-class ScrubberTest extends \PHPUnit_Framework_TestCase
+class ScrubberTest extends BaseRollbarTest
 {
     public function scrubUrlDataProvider()
     {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2,7 +2,7 @@
 
 use Rollbar\Payload\Server;
 
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends BaseRollbarTest
 {
     public function testHost()
     {

--- a/tests/TraceChainTest.php
+++ b/tests/TraceChainTest.php
@@ -3,7 +3,9 @@
 use \Mockery as m;
 use Rollbar\Payload\TraceChain;
 
-class TraceChainTest extends \PHPUnit_Framework_TestCase
+use Rollbar;
+
+class TraceChainTest extends Rollbar\BaseRollbarTest
 {
     private $trace1;
     private $trace2;

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -4,7 +4,7 @@ use \Mockery as m;
 use Rollbar\Payload\Trace;
 use Rollbar\Payload\Frame;
 
-class TraceTest extends \PHPUnit_Framework_TestCase
+class TraceTest extends BaseRollbarTest
 {
     public function testTraceConstructor()
     {

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -1,6 +1,6 @@
 <?php namespace Rollbar;
 
-class UtilitiesTest extends \PHPUnit_Framework_TestCase
+class UtilitiesTest extends BaseRollbarTest
 {
     public function testCoalesce()
     {


### PR DESCRIPTION
This PR enables passing access token to phpunit through phpunit.xml for all the tests. This makes debugging much easier when switching between rollbar service accounts.