### PR TITLE
use the configuration array directly, don't nest it under options

### DIFF
--- a/src/RollbarJsHelper.php
+++ b/src/RollbarJsHelper.php
@@ -56,8 +56,7 @@ class RollbarJsHelper
      */
     public function configJsTag()
     {
-        $config = isset($this->config['options']) ? $this->config['options'] : new \stdClass();
-        return "var _rollbarConfig = " . json_encode($config) . ";";
+        return "var _rollbarConfig = " . json_encode($this->config, JSON_FORCE_OBJECT) . ";";
     }
     
     /**

--- a/tests/RollbarJsHelperTest.php
+++ b/tests/RollbarJsHelperTest.php
@@ -229,12 +229,10 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
     public function testConfigJsTag()
     {
         $config = array(
-            'options' => array(
-                'config1' => 'value 1'
-            )
+            'config1' => 'value 1'
         );
         
-        $expectedJson = json_encode($config['options']);
+        $expectedJson = json_encode($config);
         $expected = "var _rollbarConfig = $expectedJson;";
         
         $helper = new RollbarJsHelper($config);
@@ -281,9 +279,7 @@ class JsHelperTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 array(
-                    'options' => array(
-                        'foo' => 'bar'
-                    )
+                    'foo' => 'bar'
                 ),
                 array(),
                 null,


### PR DESCRIPTION
Fixes #221 
The docs are the desired API so make the code match the docs