### PR TITLE
configuration option to disallow calling exec to get git information

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,16 @@ All of the following options can be passed as keys in the `$config` array.
 Default: `/var/www`
 </dd>
 
+<dt>allow_exec
+</dt>
+<dd>If the branch option is not set, we will attempt to call out to git to discover the branch name
+via the php `exec` function call. If you do not want to allow `exec` to be called, and therefore
+possibly to not gather this context if you do not otherwise provide it via the separate
+configuration option, then set this option to false.
+
+Default: true
+</dd>
+
 <dt>endpoint
 </dt>
 <dd>The API URL to post to. Note: the URL has to end with a trailing slash.

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -242,7 +242,11 @@ class DataBuilder implements DataBuilderInterface
         if (!isset($fromConfig)) {
             $fromConfig = $this->tryGet($config, 'branch');
         }
-        $this->serverBranch = self::$defaults->gitBranch($fromConfig);
+        $allowExec = $this->tryGet($config, 'allow_exec');
+        if (!isset($allowExec)) {
+            $allowExec = true;
+        }
+        $this->serverBranch = self::$defaults->gitBranch($fromConfig, $allowExec);
     }
 
     protected function setServerCodeVersion($config)

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -165,8 +165,8 @@ class Defaults
             E_DEPRECATED => "info",
             E_USER_DEPRECATED => "info"
         );
-        $this->defaultGitHash = self::getGitHash();
-        $this->defaultGitBranch = self::getGitBranch();
+        $this->defaultGitHash = null;
+        $this->defaultGitBranch = null;
         $this->defaultServerRoot = self::getServerRoot();
         $this->defaultPlatform = self::getPlatform();
         $this->defaultNotifier = self::getNotifier();
@@ -211,14 +211,26 @@ class Defaults
         );
     }
 
-    public function gitHash($gitHash = null)
+    public function gitHash($gitHash = null, $allowExec = true)
     {
-        return $this->utilities->coalesce($gitHash, $this->defaultGitHash);
+        if ($gitHash) {
+            return $gitHash;
+        }
+        if (!isset($this->defaultGitHash) && $allowExec) {
+            $this->defaultGitHash = self::getGitHash();
+        }
+        return $this->defaultGitHash;
     }
 
-    public function gitBranch($gitBranch = null)
+    public function gitBranch($gitBranch = null, $allowExec = true)
     {
-        return $this->utilities->coalesce($gitBranch, $this->defaultGitBranch);
+        if ($gitBranch) {
+            return $gitBranch;
+        }
+        if (!isset($this->defaultGitBranch) && $allowExec) {
+            $this->defaultGitBranch = self::getGitBranch();
+        }
+        return $this->defaultGitBranch;
     }
 
     public function serverRoot($serverRoot = null)


### PR DESCRIPTION
Fixes #220 

Added the `allow_exec` configuration option which defaults to `true` to conform to the prior behaviour. If you set it to false, you can still pass the branch via the `serverBranch` or `branch` configuration option.