### PR TITLE
GitHub Issue #227: Add curl_error() to check for log submission failures

### DIFF
--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -53,12 +53,10 @@ class CurlSender implements SenderInterface
         $this->setCurlOptions($handle, $scrubbedPayload, $accessToken);
         $result = curl_exec($handle);
         $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
-
-        if ($result === false) {
-            $result = curl_error($handle);
-        } else {
-            $result = json_decode($result, true);
-        }
+        
+        $result = $result === false ?
+                    curl_error($handle) :
+                    json_decode($result, true);
         
         curl_close($handle);
 

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -1,7 +1,7 @@
 <?php namespace Rollbar\Senders;
 
 /**
- * A lot of this class is ripped off from Segment:
+ * Adapted from:
  * https://github.com/segmentio/analytics-php/blob/master/lib/Segment/Consumer/Socket.php
  */
 

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -54,10 +54,17 @@ class CurlSender implements SenderInterface
         $result = curl_exec($handle);
         $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
 
+        if ($result === false) {
+            $result = curl_error($handle);
+        } else {
+            $result = json_decode($result, true);
+        }
+        
         curl_close($handle);
 
         $uuid = $scrubbedPayload['data']['uuid'];
-        return new Response($statusCode, json_decode($result, true), $uuid);
+        
+        return new Response($statusCode, $result, $uuid);
     }
 
     public function setCurlOptions($handle, $scrubbedPayload, $accessToken)

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -15,9 +15,15 @@ class CurlSenderTest extends BaseRollbarTest
             "endpoint" => "fake-endpoint"
         ));
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
-        $this->assertEquals(
-            "Could not resolve host: fake-endpointitem",
-            $response->getInfo()
+        
+        $this->assertTrue(
+            in_array(
+                $response->getInfo(),
+                array(
+                    "Couldn't resolve host 'fake-endpointitem'", // hack for PHP 5.3
+                    "Could not resolve host: fake-endpointitem"
+                )
+            )
         );
     }
 }

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Rollbar;
+
+use Rollbar\Payload\Level;
+
+class CurlSenderTest extends BaseRollbarTest
+{
+    
+    public function testCurlError()
+    {
+        $l = new RollbarLogger(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => "testing-php",
+            "endpoint" => "fake-endpoint"
+        ));
+        $response = $l->log(Level::WARNING, "Testing PHP Notifier", array());
+        $this->assertEquals(
+            "Could not resolve host: fake-endpointitem",
+            $response->getInfo()
+        );
+    }
+}

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -9,12 +9,12 @@ class CurlSenderTest extends BaseRollbarTest
     
     public function testCurlError()
     {
-        $l = new RollbarLogger(array(
+        $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
             "endpoint" => "fake-endpoint"
         ));
-        $response = $l->log(Level::WARNING, "Testing PHP Notifier", array());
+        $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
         $this->assertEquals(
             "Could not resolve host: fake-endpointitem",
             $response->getInfo()


### PR DESCRIPTION
This PR injects result of curl_error() into the Response object in case of curl request problems.

Ready for review.