### PR TITLE
all of the senders should return a response

### DIFF
--- a/src/Senders/AgentSender.php
+++ b/src/Senders/AgentSender.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar\Senders;
 
+use Rollbar\Response;
 use Rollbar\Payload\Payload;
 
 class AgentSender implements SenderInterface
@@ -28,6 +29,9 @@ class AgentSender implements SenderInterface
             $this->loadAgentFile();
         }
         fwrite($this->agentLog, json_encode($scrubbedPayload) . "\n");
+
+        $uuid = $scrubbedPayload['data']['uuid'];
+        return new Response(0, "Written to agent file", $uuid);
     }
 
     /**


### PR DESCRIPTION
Fixes #232. The top level notifier assumes that calls to log which eventually call send on a sender return a response object. This is true for all of the senders except the agent. This fixes that.