### PR TITLE
Out of the box support for Symfony 2.x and 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,39 @@ Rollbar::init(array(
 ?>
 ```
 
+### For Symfony Users with Monolog
+
+
+Setup the handler in your `config.yml` and `services.yml`
+
+```
+parameters:
+
+    rollbar:
+        access_token: "POST_SERVER_ITEM_ACCESS_TOKEN"
+        environment: "%kernel.environment%"
+        minimum_level: DEBUG
+
+
+services:
+
+    rollbar_handler:
+        factory: 'Rollbar\RollbarHandlerFactory:create'
+        arguments: [@rollbar]
+
+```
+
+Now configure Monolog to use the handler in your application `config.yml`
+
+```
+monolog:
+    handlers:
+        ...
+        rollbar:
+            type: service
+            id: rollbar_handler
+```
+
 ## Integration with Rollbar.js
 
 In case you want to report your JavaScript errors using [Rollbar.js](https://github.com/rollbar/rollbar.js), you can configure the SDK to enable Rollbar.js on your site. Example:

--- a/src/RollbarHandlerFactory.php
+++ b/src/RollbarHandlerFactory.php
@@ -16,6 +16,7 @@ class RollbarHandlerFactory
      * @param array $config
      *
      * @return PsrHandler
+     * @SuppressWarnings(PHPMD.StaticAccess) Static access intended.
      */
     public static function create(array $config)
     {

--- a/src/RollbarHandlerFactory.php
+++ b/src/RollbarHandlerFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rollbar;
+
+use Monolog\Handler\PsrHandler;
+
+/**
+ * Creates a PsrHandler for Monolog
+ */
+class RollbarHandlerFactory
+{
+
+    /**
+     * Factory Method. Can be used for service creation.
+     *
+     * @param array $config
+     *
+     * @return PsrHandler
+     */
+    public static function create(array $config)
+    {
+        Rollbar::init($config);
+
+        return new PsrHandler(Rollbar::logger());
+    }
+}

--- a/tests/RollbarHandlerFactoryTest.php
+++ b/tests/RollbarHandlerFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Rollbar;
+
+/**
+ * Usage of static method RollbarHandlerFactory::create() is intended here.
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess)
+ */
+class RollbarHandlerFactoryTest extends BaseRollbarTest
+{
+    public function __construct()
+    {
+        self::$simpleConfig['access_token'] = $this->getTestAccessToken();
+        self::$simpleConfig['environment'] = 'test';
+
+        parent::__construct();
+    }
+
+    private static $simpleConfig = array();
+
+    public function testInitWithConfig()
+    {
+        $handler = RollbarHandlerFactory::create(self::$simpleConfig);
+
+        $this->assertInstanceOf('Monolog\Handler\PsrHandler', $handler);
+    }
+}


### PR DESCRIPTION
RollbarHandlerFactory for easy integration into Symfony 2.x and 3.x.

Also updated the README.md with an example.
So no additional Bundles are required to integrate into Symfony.