### PR TITLE
GitHub Issue #254: Rollbar Exception Logging ignores File and Line on Exception itself

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -435,8 +435,14 @@ class DataBuilder implements DataBuilderInterface
     {
         $frames = array();
         foreach ($this->getTrace($exception) as $frameInfo) {
-            $filename = $this->utilities->coalesce($this->tryGet($frameInfo, 'file'), '<internal>');
-            $lineno = $this->utilities->coalesce($this->tryGet($frameInfo, 'line'), 0);
+            $filename = $this->tryGet($frameInfo, 'file');
+            if ($filename === null) {
+                $filename = $exception->getFile() ?: '<internal>';
+            }
+            $lineno = $this->tryGet($frameInfo, 'line');
+            if ($lineno === null) {
+                $lineno = $exception->getLine() ?: 0;
+            }
             $method = $frameInfo['function'];
             if (isset($frameInfo['class'])) {
                 $method = $frameInfo['class'] . "::" . $method;

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -815,6 +815,11 @@ class DataBuilderTest extends BaseRollbarTest
         ));
         $frames = $dataBuilder->makeFrames(new \Exception(), false);
         $this->assertEquals('<main>', $frames[count($frames)-1]->getMethod());
+        $this->assertEquals(
+            "/home/ubuntu/workspace/tests/DataBuilderTest.php",
+            $frames[count($frames)-1]->getFilename()
+        );
+        $this->assertEquals(816, $frames[count($frames)-1]->getLineno());
         $this->assertEquals('Rollbar\DataBuilderTest::testFramesOrder', $frames[count($frames)-2]->getMethod());
     }
     


### PR DESCRIPTION
Added file and line information to the last frame of the exception stack trace by fetching data from the Exception object.

Ready for review.