### PR TITLE
GitHub Issue #259: Remove shiftFunction for exception stack traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,13 +521,6 @@ Default: `('passwd', 'password', 'secret', 'confirm_password', 'password_confirm
 <dd>Array of fields that you do NOT to be scrubbed even if they match entries in scrub_fields. Entries should be provided in associative array dot notation, i.e. `data.person.username`.
 </dd>
 
-<dt>shift_function
-</dt>
-<dd>Whether to shift function names in stack traces down one frame, so that the function name correctly reflects the context of each frame.
-
-Default: `true`
-</dd>
-
 <dt>timeout
 </dt>
 <dd>Request timeout for posting to rollbar, in seconds.

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -45,7 +45,6 @@ class DataBuilder implements DataBuilderInterface
     protected $baseException;
     protected $includeCodeContext;
     protected $includeExcCodeContext;
-    protected $shiftFunction;
     protected $sendMessageTrace;
     protected $rawRequestBody;
     protected $localVarsDump;
@@ -99,11 +98,6 @@ class DataBuilder implements DataBuilderInterface
         $this->setLocalVarsDump($config);
         $this->setCaptureErrorStacktraces($config);
         $this->setLevelFactory($config);
-
-        $this->shiftFunction = $this->tryGet($config, 'shift_function');
-        if (!isset($this->shiftFunction)) {
-            $this->shiftFunction = true;
-        }
     }
 
     protected function tryGet($array, $key)
@@ -462,13 +456,6 @@ class DataBuilder implements DataBuilderInterface
             }
 
             $frames[] = $frame;
-        }
-
-        if ($this->shiftFunction && count($frames) > 0) {
-            for ($i = count($frames) - 1; $i > 0; $i--) {
-                $frames[$i]->setMethod($frames[$i - 1]->getMethod());
-            }
-            $frames[0]->setMethod('<main>');
         }
         
         $frames = array_reverse($frames);

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -983,10 +983,7 @@ class DataBuilder implements DataBuilderInterface
     public function generateErrorWrapper($errno, $errstr, $errfile, $errline)
     {
         if ($this->captureErrorStacktraces) {
-            $backTrace = array_slice(
-                debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS),
-                2
-            );
+            $backTrace = debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS));
         } else {
             $backTrace = array();
         }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -970,7 +970,7 @@ class DataBuilder implements DataBuilderInterface
     public function generateErrorWrapper($errno, $errstr, $errfile, $errline)
     {
         if ($this->captureErrorStacktraces) {
-            $backTrace = debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS));
+            $backTrace = debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS);
         } else {
             $backTrace = array();
         }

--- a/tests/BackwardsCompatibilityConfigTest.php
+++ b/tests/BackwardsCompatibilityConfigTest.php
@@ -50,7 +50,6 @@ class BackwardsCompatibilityConfigTest extends BaseRollbarTest
             },
             'root' => '/Users/brian/www/app',
             'scrub_fields' => array('test'),
-            'shift_function' => false,
             'timeout' => 10,
             'report_suppressed' => true,
             'use_error_reporting' => true,

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -842,14 +842,14 @@ class DataBuilderTest extends BaseRollbarTest
         $result = $dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
         $frames = $result->getBacktrace();
         
-        $this->assertEquals($expected, count($frames) === 0);
+        $this->assertEquals($expected, count($frames));
     }
     
     public function captureErrorStacktracesProvider()
     {
         return array(
-            array(false,true),
-            array(true, false)
+            array(false,0),
+            array(true, 12)
         );
     }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -814,13 +814,12 @@ class DataBuilderTest extends BaseRollbarTest
             'utilities' => new Utilities
         ));
         $frames = $dataBuilder->makeFrames(new \Exception(), false);
-        $this->assertEquals('<main>', $frames[count($frames)-1]->getMethod());
         $this->assertStringEndsWith(
             'tests/DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
         $this->assertEquals(816, $frames[count($frames)-1]->getLineno());
-        $this->assertEquals('Rollbar\DataBuilderTest::testFramesOrder', $frames[count($frames)-2]->getMethod());
+        $this->assertEquals('Rollbar\DataBuilderTest::testFramesOrder', $frames[count($frames)-1]->getMethod());
     }
     
     /**
@@ -842,14 +841,14 @@ class DataBuilderTest extends BaseRollbarTest
         $result = $dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
         $frames = $result->getBacktrace();
         
-        $this->assertEquals($expected, count($frames));
+        $this->assertEquals($expected, count($frames) == 0);
     }
     
     public function captureErrorStacktracesProvider()
     {
         return array(
-            array(false,0),
-            array(true, 12)
+            array(false,true),
+            array(true,false)
         );
     }
 }


### PR DESCRIPTION
* remove cutting off backtraces at Rollbar internals - it was hiding essential information in some cases
* remove `shiftFunction` configuration which was causing inaccurate function names in the traces
* extensive testing of exception stack traces and error back traces