### PR TITLE
More query parsing

### DIFF
--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -74,6 +74,11 @@ class Scrubber implements ScrubberInterface
                     $this->scrubQueryString($query, $fields),
                     $data
                 );
+            } else {
+                parse_str($data, $parsedData);
+                if (http_build_query($parsedData) === $data) {
+                    $data = $this->scrubQueryString($data, $fields);
+                }
             }
         }
         return $data;

--- a/tests/ScrubberTest.php
+++ b/tests/ScrubberTest.php
@@ -158,6 +158,7 @@ class ScrubberTest extends BaseRollbarTest
                 'non sensitive data 3' => '4&56',
                 'non sensitive data 4' => 'a=4&56',
                 'non sensitive data 6' => '?baz&foo=bar',
+                'non sensitive data 7' => 'a=stuff&foo=superSecret',
                 'sensitive data' => '456',
                 array(
                     'non sensitive data 3' => '789',
@@ -180,6 +181,7 @@ class ScrubberTest extends BaseRollbarTest
                 'non sensitive data 3' => '4&56',
                 'non sensitive data 4' => 'a=4&56',
                 'non sensitive data 6' => '?baz=&foo=xxxxxxxx',
+                'non sensitive data 7' => 'a=stuff&foo=xxxxxxxx',
                 'sensitive data' => '********',
                 array(
                     'non sensitive data 3' => '789',


### PR DESCRIPTION
This comes from a specific issue that came up from a customer. If you post a form, the request.body can show up as a bare query string, i.e. `username=hello&password=world`, and we aren't necessarily scrubbing that properly. This will ensure that we scrub those strings, but not be too aggressive about scrubbing everything that has equal signs and ampersands. If it already is a url encoded string then we try to parse it, scrub it, and re-encode it.