### PR TITLE
GitHub Issue #290: User shell_exec() instead of exec()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.5
+
+- Fix sending $context argument from the log() method with exception logs.
+
 ## 1.3.4
 
 - Increase the minimum version constraint for the monolog/monolog package to support composer --prefer-minimum

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -19,10 +19,10 @@ class Defaults
     private static function getGitHash()
     {
         try {
-            if (function_exists('exec')) {
-                exec('git rev-parse --verify HEAD 2> /dev/null', $output);
+            if (function_exists('shell_exec')) {
+                $output = rtrim(shell_exec('git rev-parse --verify HEAD 2> /dev/null'));
                 if ($output) {
-                    return $output[0];
+                    return $output;
                 }
             }
             return null;
@@ -34,10 +34,10 @@ class Defaults
     private static function getGitBranch()
     {
         try {
-            if (function_exists('exec')) {
-                exec('git rev-parse --abbrev-ref HEAD 2> /dev/null', $output);
+            if (function_exists('shell_exec')) {
+                $output = rtrim(shell_exec('git rev-parse --abbrev-ref HEAD 2> /dev/null'));
                 if ($output) {
-                    return $output[0];
+                    return $output;
                 }
             }
             return null;

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -82,13 +82,13 @@ class DefaultsTest extends BaseRollbarTest
 
     public function testGitHash()
     {
-        $val = exec('git rev-parse --verify HEAD');
+        $val = rtrim(shell_exec('git rev-parse --verify HEAD'));
         $this->assertEquals($val, $this->defaults->gitHash());
     }
 
     public function testGitBranch()
     {
-        $val = exec('git rev-parse --abbrev-ref HEAD');
+        $val = rtrim(exec('git rev-parse --abbrev-ref HEAD'));
         $this->assertEquals($val, $this->defaults->gitBranch());
     }
 


### PR DESCRIPTION
Using `exec()` method is causing Avast to detect `src/Defaults.php` as a virus. Avast added the file to their whitelist but the problem still seems to exist. 

As per the suggestion in https://github.com/rollbar/rollbar-php/issues/290 I replaced `exec()` with `shell_exec()` which fixes the issue.