### PR TITLE
GitHub Issue #297: add enable / disable config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,6 @@ Also you will have to install a suggested package `fluent/logger`.
 All of the following options can be passed as keys in the `$config` array.
 
   <dl>
-
-<dt>enabled
-</dt>
-<dd>Enable or disable Rollbar in your project. This can be changed at runtime with `Rollbar::enable()` and `Rollbar::disable()` or through `Rollbar::configure()`.
-	
-Default: `true`
-</dd>
 	
 <dt>access_token
 </dt>
@@ -408,10 +401,25 @@ Rollbar::init($config);
 Default: `null`
 </dd>
 
+<dt>custom
+</dt>
+<dd>An array of key/value pairs which will be merged with the custom data in the final payload of
+all items sent to Rollbar. This allows for custom data to be added globally to all payloads. Any key
+in this array which is also present in the custom data passed to a log/debug/error/... call will
+have the value of the latter.
+</dd>
+
 <dt>enable_utf8_sanitization
 </dt>
 <dd>set to false, to disable running iconv on the payload, may be needed if there is invalid characters, and the payload is being destroyed
 
+Default: `true`
+</dd>
+
+<dt>enabled
+</dt>
+<dd>Enable or disable Rollbar in your project. This can be changed at runtime with `Rollbar::enable()` and `Rollbar::disable()` or through `Rollbar::configure()`.
+	
 Default: `true`
 </dd>
 
@@ -420,14 +428,6 @@ Default: `true`
 <dd>Environment name, e.g. `'production'` or `'development'`
 
 Default: `'production'`
-</dd>
-
-<dt>custom
-</dt>
-<dd>An array of key/value pairs which will be merged with the custom data in the final payload of
-all items sent to Rollbar. This allows for custom data to be added globally to all payloads. Any key
-in this array which is also present in the custom data passed to a log/debug/error/... call will
-have the value of the latter.
 </dd>
 
 <dt>error_sample_rates

--- a/README.md
+++ b/README.md
@@ -314,6 +314,14 @@ Also you will have to install a suggested package `fluent/logger`.
 All of the following options can be passed as keys in the `$config` array.
 
   <dl>
+
+<dt>enabled
+</dt>
+<dd>Enable or disable Rollbar in your project. This can be changed at runtime with `Rollbar::enable()` and `Rollbar::disable()` or through `Rollbar::configure()`.
+	
+Default: `true`
+</dd>
+	
 <dt>access_token
 </dt>
 <dd>Your project access token.

--- a/src/Config.php
+++ b/src/Config.php
@@ -14,6 +14,10 @@ class Config
 {
     private $accessToken;
     /**
+     * @var string $enabled Enable / disable Rollbar SDK.
+     */
+    private $enabled = true;
+    /**
      * @var DataBuilder
      */
     private $dataBuilder;
@@ -123,6 +127,7 @@ class Config
     {
         $this->configArray = $config;
 
+        $this->setEnabled($config);
         $this->setAccessToken($config);
         $this->setDataBuilder($config);
         $this->setTransformer($config);
@@ -154,6 +159,25 @@ class Config
         }
         $this->utilities->validateString($config['access_token'], "config['access_token']", 32, false);
         $this->accessToken = $config['access_token'];
+    }
+
+    private function setEnabled($config)
+    {
+        if (array_key_exists('enabled', $config) && $config['enabled'] === false) {
+            $this->disable();
+        } else {
+            $this->enable();
+        }
+    }
+    
+    public function enable()
+    {
+        $this->enabled = true;
+    }
+    
+    public function disable()
+    {
+        $this->enabled = false;
     }
 
     private function setDataBuilder($config)
@@ -459,6 +483,16 @@ class Config
     public function getAccessToken()
     {
         return $this->accessToken;
+    }
+
+    public function enabled()
+    {
+        return $this->enabled === true;
+    }
+    
+    public function disabled()
+    {
+        return !$this->enabled();
     }
 
     public function getSendMessageTrace()

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -49,6 +49,26 @@ class Rollbar
 
         self::$logger = isset($logger) ? $logger : new RollbarLogger($configOrLogger);
     }
+    
+    public static function enable()
+    {
+        return self::logger()->enable();
+    }
+    
+    public static function disable()
+    {
+        return self::logger()->disable();
+    }
+    
+    public static function enabled()
+    {
+        return self::logger()->enabled();
+    }
+    
+    public static function disabled()
+    {
+        return self::logger()->disabled();
+    }
 
     public static function logger()
     {
@@ -230,6 +250,11 @@ class Rollbar
     public static function getCustom()
     {
         self::$logger->getCustom();
+    }
+    
+    public static function configure($config)
+    {
+        self::$logger->configure($config);
     }
     
     // @codingStandardsIgnoreStart

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -19,6 +19,26 @@ class RollbarLogger extends AbstractLogger
         $this->truncation = new Truncation();
         $this->queue = array();
     }
+    
+    public function enable()
+    {
+        return $this->config->enable();
+    }
+    
+    public function disable()
+    {
+        return $this->config->disable();
+    }
+    
+    public function enabled()
+    {
+        return $this->config->enabled();
+    }
+    
+    public function disabled()
+    {
+        return $this->config->disabled();
+    }
 
     public function configure(array $config)
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -48,6 +48,22 @@ class ConfigTest extends BaseRollbarTest
         $this->assertEquals($this->getTestAccessToken(), $config->getAccessToken());
     }
 
+    public function testEnabled()
+    {
+        $config = new Config(array(
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => $this->env
+        ));
+        $this->assertTrue($config->enabled());
+        
+        $config = new Config(array(
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => $this->env,
+            'enabled' => false
+        ));
+        $this->assertFalse($config->enabled());
+    }
+
     public function testAccessTokenFromEnvironment()
     {
         $_ENV['ROLLBAR_ACCESS_TOKEN'] = $this->getTestAccessToken();

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -1,6 +1,7 @@
 <?php namespace Rollbar;
 
 use Rollbar\Rollbar;
+use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
 
 /**
@@ -228,5 +229,48 @@ class RollbarTest extends BaseRollbarTest
         Rollbar::exceptionHandler(new \Exception());
         $handler = set_exception_handler('Rollbar\Rollbar::exceptionHandler');
         $this->assertEquals('testExceptionHandler', $handler[1]);
+    }
+    
+    public function testConfigure()
+    {
+        Rollbar::init(self::$simpleConfig);
+        
+        // functionality under test
+        Rollbar::configure(array(
+            'environment' => $expected
+        ));
+        
+        // assertion
+        $logger = Rollbar::logger();
+        $dataBuilder = $logger->getDataBuilder();
+        $data = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        $payload = new Payload($data, self::$simpleConfig['access_token']);
+        
+        $this->assertEquals($expected, $payload->getData()->getEnvironment());
+        
+    }
+    
+    public function testEnable()
+    {
+        Rollbar::init(self::$simpleConfig);
+        $this->assertTrue(Rollbar::enabled());
+        
+        Rollbar::disable();
+        $this->assertTrue(Rollbar::disabled());
+        
+        Rollbar::enable();
+        $this->assertTrue(Rollbar::enabled());
+        
+        Rollbar::init(array_merge(
+            self::$simpleConfig,
+            array('enabled' => false)
+        ));
+        $this->assertTrue(Rollbar::disabled());
+        
+        Rollbar::configure(array('enabled' => true));
+        $this->assertTrue(Rollbar::enabled());
+        
+        Rollbar::configure(array('enabled' => false));
+        $this->assertTrue(Rollbar::disabled());
     }
 }


### PR DESCRIPTION
In response to @and-megan request https://github.com/rollbar/rollbar-php/issues/297 I added `::enable()`, `::disable()`, `::configure()` to Rollbar class. This supports easily enabling / disabling Rollbar at runtime.