### PR TITLE
GitHub Issue #312: Add a config option to make the SDK verbose

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
 
   "require": {
     "ext-curl": "*",
-    "psr/log": "^1.0.1"
+    "psr/log": "^1.0.1",
+    "monolog/monolog": "*"
   },
 
   "require-dev": {

--- a/src/Config.php
+++ b/src/Config.php
@@ -73,9 +73,17 @@ class Config
     
     /**
      * @var boolean Should debug_backtrace() data be sent with string messages
-     * sent through RollbarLogger::log()
+     * sent through RollbarLogger::log().
      */
     private $sendMessageTrace = false;
+    
+    /**
+     * @var string (One of the \Psr\Log\LogLevel constants) How much debugging 
+     * info should be recorded in the Rollbar debug log file.
+     * ($rollbarLogger->getDebugLogFile() => commonly /tmp/rollbar.log.
+     * Default: Psr\Log\LogLevel::ERROR
+     */
+    private $verbosity = \Psr\Log\LogLevel::ERROR;
 
     public function __construct(array $configArray)
     {
@@ -142,6 +150,7 @@ class Config
         $this->setResponseHandler($config);
         $this->setCheckIgnoreFunction($config);
         $this->setSendMessageTrace($config);
+        $this->setVerbosity($config);
 
         if (isset($config['included_errno'])) {
             $this->included_errno = $config['included_errno'];
@@ -360,6 +369,20 @@ class Config
         }
 
         $this->sendMessageTrace = $config['send_message_trace'];
+    }
+    
+    private function setVerbosity($config)
+    {
+        if (!isset($config['verbosity'])) {
+            return;
+        }
+
+        $this->verbosity = $config['verbosity'];
+    }
+    
+    public function getVerbosity()
+    {
+        return $this->verbosity;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -78,9 +78,9 @@ class Config
     private $sendMessageTrace = false;
     
     /**
-     * @var string (One of the \Psr\Log\LogLevel constants) How much debugging 
+     * @var string (One of the \Psr\Log\LogLevel constants) How much debugging
      * info should be recorded in the Rollbar debug log file.
-     * ($rollbarLogger->getDebugLogFile() => commonly /tmp/rollbar.log.
+     * ($rollbarLogger->getDebugLogFile() => commonly /tmp/rollbar.debug.log.
      * Default: Psr\Log\LogLevel::ERROR
      */
     private $verbosity = \Psr\Log\LogLevel::ERROR;

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -16,7 +16,6 @@ class ExceptionHandler extends AbstractHandler
     
     public function handle()
     {
-        
         parent::handle();
         
         /**
@@ -32,11 +31,13 @@ class ExceptionHandler extends AbstractHandler
         $exception = $args[0];
         
         $this->logger()->log(Level::ERROR, $exception, array(), true);
+        
         if ($this->previousHandler) {
             restore_exception_handler();
             call_user_func($this->previousHandler, $exception);
             return;
         }
+
 
         throw $exception;
     }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -23,10 +23,10 @@ class RollbarLogger extends AbstractLogger
         $this->truncation = new Truncation();
         $this->queue = array();
         
-        $this->debugLogFile = sys_get_temp_dir() . '/rollbar.log';
+        $this->debugLogFile = sys_get_temp_dir() . '/rollbar.debug.log';
         $this->debugLogger = new MonologLogger("RollbarDebugLogger");
         $this->debugLogger->pushHandler(new StreamHandler(
-            $this->debugLogFile, 
+            $this->debugLogFile,
             $this->config->getVerbosity()
         ));
     }
@@ -99,10 +99,10 @@ class RollbarLogger extends AbstractLogger
             $toSend = $this->truncate($toSend);
             
             $this->debugLogger->info(
-                "Payload scrubbed and ready to send to Rollbar API endpoint: ".
-                $this->config->getSender()->getEndpoint()
+                "Payload scrubbed and ready to send to ".
+                $this->config->getSender()->toString()
             );
-            $this->debugLogger->debug(print_r($toSend, true));
+            $this->debugLogger->debug(json_encode($toSend, true));
             
             $response = $this->send($toSend, $accessToken);
             

--- a/src/Senders/AgentSender.php
+++ b/src/Senders/AgentSender.php
@@ -60,4 +60,9 @@ class AgentSender implements SenderInterface
         $filename = $this->agentLogLocation . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar';
         $this->agentLog = fopen($filename, 'a');
     }
+    
+    public function toString()
+    {
+        return "agent log: " . $this->agentLogLocation;
+    }
 }

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -171,4 +171,9 @@ class CurlSender implements SenderInterface
         }
         $this->maybeSendMoreBatchRequests($accessToken);
     }
+    
+    public function toString()
+    {
+        return "Rollbar API endpoint: " . $this->getEndpoint();
+    }
 }

--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -103,4 +103,10 @@ class FluentSender implements SenderInterface
     {
         $this->fluentLogger = new FluentLogger($this->fluentHost, $this->fluentPort);
     }
+    
+    public function toString()
+    {
+        return "fluentd " . $this->fluentHost . ":" . $this->fluentPort .
+                " tag: " . $this->fluentTag;
+    }
 }

--- a/src/Senders/SenderInterface.php
+++ b/src/Senders/SenderInterface.php
@@ -7,4 +7,5 @@ interface SenderInterface
     public function send($scrubbedPayload, $accessToken);
     public function sendBatch($batch, $accessToken);
     public function wait($accessToken, $max);
+    public function toString();
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -248,6 +248,19 @@ class ConfigTest extends BaseRollbarTest
             $config->getSender()->getEndpoint()
         );
     }
+    
+    public function testVerbosity()
+    {
+        $expected = 3;
+        
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "verbosity" => $expected
+        ));
+        
+        $this->assertEquals($expected, $config->getVerbosity());
+    }
 
     public function testCustom()
     {

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -66,12 +66,10 @@ class ExceptionHandlerTest extends BaseRollbarTest
         $handler->$method();
     }
     
-    /**
-     * @expectedException \Exception
-     */
     public function testHandle()
     {
-        set_exception_handler(null);
+        set_exception_handler(function () {
+        });
         
         $logger = $this->getMockBuilder('Rollbar\\RollbarLogger')
                         ->setConstructorArgs(array(self::$simpleConfig))

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -149,7 +149,6 @@ class RollbarLoggerTest extends BaseRollbarTest
         }
         
         @\unlink($logger->getDebugLogFile());
-        
     }
     
     public function debugLoggerProvider()

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -3,6 +3,7 @@
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
+use Psr\Log\LogLevel as PsrLogLevel;
 
 class RollbarLoggerTest extends BaseRollbarTest
 {
@@ -116,6 +117,103 @@ class RollbarLoggerTest extends BaseRollbarTest
         ));
         $response = $l->log(Level::WARNING, "Testing PHP Notifier", array());
         $this->assertEquals(200, $response->getStatus());
+    }
+    
+    /**
+     * @dataProvider debugLoggerProvider
+     */
+    public function testDebugLogger($expected, $verbosity)
+    {
+        $logger = new RollbarLogger(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => "testing-php",
+            "verbosity" => $verbosity
+        ));
+        
+        @\unlink($logger->getDebugLogFile());
+        
+        $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
+        
+        $result = @\file_get_contents($logger->getDebugLogFile()) ?: "";
+        
+        if (isset($expected['regexp'])) {
+            foreach ($expected['regexp'] as $regexp) {
+                $this->assertRegExp($regexp, $result);
+            }
+        }
+        
+        if (isset($expected['notRegExp'])) {
+            foreach ($expected['notRegExp'] as $regexp) {
+                $this->assertNotRegExp($regexp, $result);
+            }
+        }
+        
+        @\unlink($logger->getDebugLogFile());
+        
+    }
+    
+    public function debugLoggerProvider()
+    {
+        return array(
+            array(
+                array(
+                    'notRegExp' => array(
+                        
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.DEBUG:'.
+                        '/',
+                        
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.INFO:'.
+                        '/'
+                        
+                    )
+                ),
+                PsrLogLevel::ERROR // verbosity
+            ),
+            array(
+                array(
+                    'regexp' => array(
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.INFO: '.
+                        '.*'.
+                        '\[\] \[\]'.
+                        '/'
+                    ),
+                    'notRegExp' => array(
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.DEBUG:'.
+                        '/'
+                    )
+                ),
+                PsrLogLevel::INFO // verbosity
+            ),
+            array(
+                array(
+                    'regexp' => array(
+                        
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.INFO: '.
+                        '.*'.
+                        '\[\] \[\]'.
+                        '/',
+                        
+                        '/'.
+                        '\[[0-9]*-[0-9]*-[0-9]* [0-9]*:[0-9]*:[0-9]*\] '.
+                        'RollbarDebugLogger.DEBUG: '.
+                        '.*'.
+                        '\[\] \[\]'.
+                        '/'
+                    )
+                ),
+                PsrLogLevel::DEBUG // verbosity
+            )
+        );
     }
     
     public function testContext()


### PR DESCRIPTION
This PR adds `verbosity` config option that can be used to easily diagnose payloads sent and responses received from the Rollbar API.