### PR TITLE
Update MinBodyStrategy.php

### DIFF
--- a/src/Truncation/MinBodyStrategy.php
+++ b/src/Truncation/MinBodyStrategy.php
@@ -34,11 +34,13 @@ class MinBodyStrategy extends AbstractStrategy
         /**
          * Limit trace frames
          */
-        $framesStrategy = new FramesStrategy($this->truncation);
-        $traceData['frames'] = $framesStrategy->selectFrames(
-            $traceData['frames'],
-            static::EXCEPTION_FRAMES_RANGE
-        );
+        if (!empty($traceData['frames'])) {
+            $framesStrategy = new FramesStrategy($this->truncation);
+            $traceData['frames'] = $framesStrategy->selectFrames(
+                $traceData['frames'],
+                static::EXCEPTION_FRAMES_RANGE
+            );
+        }
         
         return $payload;
     }


### PR DESCRIPTION
`frames` doesn't always exist, especially when reporting `Rollbar::info` etc. When the payload data is huge, MinBodyStrategy throws warnings on the assumption of `frames`