### PR TITLE
Fix for issue 265.

### DIFF
--- a/src/Payload/Frame.php
+++ b/src/Payload/Frame.php
@@ -96,6 +96,9 @@ class Frame implements \JsonSerializable
 
     public function jsonSerialize()
     {
+        $args = $this->args;
+        if(json_encode($args) === false)
+            $args = [];
         $result = array(
             "filename" => $this->filename,
             "lineno" => $this->lineno,
@@ -103,7 +106,7 @@ class Frame implements \JsonSerializable
             "method" => $this->method,
             "code" => $this->code,
             "context" => $this->context,
-            "args" => $this->args,
+            "args" => $args,
         );
         return $this->utilities->serializeForRollbar($result);
     }


### PR DESCRIPTION
See https://github.com/rollbar/rollbar-php/issues/265

Do not embed frame's arguments if they can't be json encoded.