### PR TITLE
GitHub Issue #282: move monolog handler temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,26 +250,26 @@ Rollbar::init($logger);
 Here is an example of how to use Rollbar as a handler for Monolog:
 
 ```php
-use Monolog\Logger;
 use Rollbar\Rollbar;
-use Rollbar\Payload\Level;
+use Monolog\Logger;
+use Rollbar\Monolog\Handler\RollbarHandler;
 
-$config = array('access_token' => 'POST_SERVER_ITEM_ACCESS_TOKEN');
+Rollbar::init(
+	array(
+		'access_token' => 'xxx',
+		'environment' => 'development'
+	)
+);
 
-// installs global error and exception handlers
-Rollbar::init($config);
+// create a log channel
+$log = new Logger('RollbarHandler');
+$log->pushHandler(new RollbarHandler(Rollbar::logger(), Logger::WARNING));
 
-$log = new Logger('test');
-$log->pushHandler(new \Monolog\Handler\PsrHandler(Rollbar::logger()));
-
-try {
-    throw new \Exception('exception for monolog');
-} catch (\Exception $e) {
-    $log->error($e);
-}
+// add records to the log
+$log->addWarning('Foo');
 ```
 
-*Note:* Currently `PsrHandler` incorrectly reports exception objects logged with `log` method as strings instead of objects. This will cause your `log`-reported errors to be interpretted in Rollbar as message strings. The preferred way to use Rollbar with Monolog is through `RollbarHandler` class, however, at the moment, it's outdated. Pull request [Sync RollbarHandler with the latest changes rollbar/rollbar package](https://github.com/Seldaek/monolog/pull/1042) with a fix is awaiting merging into Monolog package. This issue has been originally brought up in [Log->error($e) has different info than throw the exception and let error_reporting handle it](https://github.com/rollbar/rollbar-php/issues/275).
+*Note:* Currently there is an outstanding Pull Request [Sync RollbarHandler with the latest changes rollbar/rollbar package](https://github.com/Seldaek/monolog/pull/1042) in `Seldaek:monolog` repository with an update for our `Monolog\Handler\RollbarHandler`. Unfortunately, it has not been merged in by the maintainers yet. In meantime, we included the Monolog handler as part of our repository. We recommend using `Rollbar\Monolog\Handler\RollbarHandler` from `rollbar/rollbar-php` repo. Do *NOT* use `Monolog\Handler\RollbarHandler` from `Seldaek:monolog` repo as it is outdated.
 
 ## Configuration
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "mockery/mockery": "0.9.*",
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",
-    "monolog/monolog": "^1.12.0",
+    "monolog/monolog": "^1.23",
     "packfire/php5.3-compat": "*",
     "phpmd/phpmd" : "@stable"
   },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require": {
     "ext-curl": "*",
     "psr/log": "^1.0.1",
-    "monolog/monolog": "*"
+    "monolog/monolog": "^1.23"
   },
 
   "require-dev": {

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 /*
  * This file is part of the Monolog package.

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -39,7 +39,7 @@ class RollbarHandler extends AbstractProcessingHandler
      */
     protected $rollbarLogger;
 
-    protected $levelMap = [
+    protected $levelMap = array(
         Logger::DEBUG     => 'debug',
         Logger::INFO      => 'info',
         Logger::NOTICE    => 'info',
@@ -48,7 +48,7 @@ class RollbarHandler extends AbstractProcessingHandler
         Logger::CRITICAL  => 'critical',
         Logger::ALERT     => 'critical',
         Logger::EMERGENCY => 'critical',
-    ];
+    );
 
     /**
      * Records whether any log records have been added since the last flush of the rollbar notifier

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -83,12 +83,12 @@ class RollbarHandler extends AbstractProcessingHandler
         }
 
         $context = $record['context'];
-        $context = array_merge($context, $record['extra'], [
+        $context = array_merge($context, $record['extra'], array(
             'level' => $this->levelMap[$record['level']],
             'monolog_level' => $record['level_name'],
             'channel' => $record['channel'],
             'datetime' => $record['datetime']->format('U'),
-        ]);
+        ));
 
         if (isset($context['exception']) && $context['exception'] instanceof Throwable) {
             $exception = $context['exception'];

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollbar\Monolog\Handler;
+
+use Rollbar\RollbarLogger;
+use Throwable;
+use Monolog\Logger;
+use Monolog\Handler\AbstractProcessingHandler;
+
+/**
+ * Sends errors to Rollbar
+ *
+ * If the context data contains a `payload` key, that is used as an array
+ * of payload options to RollbarLogger's log method. 
+ *
+ * Rollbar's context info will contain the context + extra keys from the log record
+ * merged, and then on top of that a few keys:
+ *
+ *  - level (rollbar level name)
+ *  - monolog_level (monolog level name, raw level, as rollbar only has 5 but monolog 8)
+ *  - channel
+ *  - datetime (unix timestamp)
+ *
+ * @author Paul Statezny <paulstatezny@gmail.com>
+ */
+class RollbarHandler extends AbstractProcessingHandler
+{
+    /**
+     * @var RollbarLogger
+     */
+    protected $rollbarLogger;
+
+    protected $levelMap = [
+        Logger::DEBUG     => 'debug',
+        Logger::INFO      => 'info',
+        Logger::NOTICE    => 'info',
+        Logger::WARNING   => 'warning',
+        Logger::ERROR     => 'error',
+        Logger::CRITICAL  => 'critical',
+        Logger::ALERT     => 'critical',
+        Logger::EMERGENCY => 'critical',
+    ];
+
+    /**
+     * Records whether any log records have been added since the last flush of the rollbar notifier
+     *
+     * @var bool
+     */
+    private $hasRecords = false;
+
+    protected $initialized = false;
+
+    /**
+     * @param RollbarLogger   $rollbarLogger   RollbarLogger object constructed with valid token
+     * @param int             $level           The minimum logging level at which this handler will be triggered
+     * @param bool            $bubble          Whether the messages that are handled can bubble up the stack or not
+     */
+    public function __construct(RollbarLogger $rollbarLogger, $level = Logger::ERROR, $bubble = true)
+    {
+        $this->rollbarLogger = $rollbarLogger;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record)
+    {
+        if (!$this->initialized) {
+            // __destructor() doesn't get called on Fatal errors
+            register_shutdown_function(array($this, 'close'));
+            $this->initialized = true;
+        }
+
+        $context = $record['context'];
+        $context = array_merge($context, $record['extra'], [
+            'level' => $this->levelMap[$record['level']],
+            'monolog_level' => $record['level_name'],
+            'channel' => $record['channel'],
+            'datetime' => $record['datetime']->format('U'),
+        ]);
+
+        if (isset($context['exception']) && $context['exception'] instanceof Throwable) {
+            $exception = $context['exception'];
+            unset($context['exception']);
+            $toLog = $exception;
+        } else {
+            $toLog = $record['message'];
+        }
+        
+        $this->rollbarLogger->log($context['level'], $toLog, $context);
+
+        $this->hasRecords = true;
+    }
+
+    public function flush()
+    {
+        if ($this->hasRecords) {
+            $this->rollbarLogger->flush();
+            $this->hasRecords = false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+        $this->flush();
+    }
+}

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -20,7 +20,7 @@ use Monolog\Handler\AbstractProcessingHandler;
  * Sends errors to Rollbar
  *
  * If the context data contains a `payload` key, that is used as an array
- * of payload options to RollbarLogger's log method. 
+ * of payload options to RollbarLogger's log method.
  *
  * Rollbar's context info will contain the context + extra keys from the log record
  * merged, and then on top of that a few keys:

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 // @codingStandardsIgnoreFile
 
 /*

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -79,15 +79,15 @@ class RollbarHandlerTest extends TestCase
             });
     }
 
-    private function createHandler(): RollbarHandler
+    private function createHandler()
     {
         return new RollbarHandler($this->rollbarLogger, Logger::DEBUG);
     }
 
-    private function createExceptionRecord($level = Logger::DEBUG, $message = 'test', $exception = null): array
+    private function createExceptionRecord($level = Logger::DEBUG, $message = 'test', $exception = null)
     {
-        return $this->getRecord($level, $message, [
+        return $this->getRecord($level, $message, array(
             'exception' => $exception ?: new Exception(),
-        ]);
+        ));
     }
 }

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the Monolog package.
+ *
+ * (c) Jordi Boggiano <j.boggiano@seld.be>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Rollbar\Monolog\Handler;
+
+require dirname(__FILE__) . '/../../../vendor/monolog/monolog/tests/Monolog/TestCase.php';
+
+use Exception;
+use Monolog\TestCase;
+use Monolog\Logger;
+use Rollbar\Monolog\Handler\RollbarHandler;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Rollbar\RollbarLogger;
+
+/**
+ * @author Erik Johansson <erik.pm.johansson@gmail.com>
+ * @see    https://rollbar.com/docs/notifier/rollbar-php/
+ *
+ * @coversDefaultClass Monolog\Handler\RollbarHandler
+ */
+class RollbarHandlerTest extends TestCase
+{
+    /**
+     * @var MockObject
+     */
+    private $rollbarLogger;
+
+    /**
+     * @var array
+     */
+    private $reportedExceptionArguments = null;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setupRollbarLoggerMock();
+    }
+
+    /**
+     * When reporting exceptions to Rollbar the
+     * level has to be set in the payload data
+     */
+    public function testExceptionLogLevel()
+    {
+        $handler = $this->createHandler();
+
+        $handler->handle($this->createExceptionRecord(Logger::DEBUG));
+
+        $this->assertEquals('debug', $this->reportedExceptionArguments['payload']['level']);
+    }
+
+    private function setupRollbarLoggerMock()
+    {
+        $config = array(
+            'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
+            'environment' => 'test'
+        );
+        
+        $this->rollbarLogger = $this->getMockBuilder(RollbarLogger::class)
+            ->setConstructorArgs(array($config))
+            ->setMethods(array('log'))
+            ->getMock();
+
+        $this->rollbarLogger
+            ->expects($this->any())
+            ->method('log')
+            ->willReturnCallback(function ($exception, $context, $payload) {
+                $this->reportedExceptionArguments = compact('exception', 'context', 'payload');
+            });
+    }
+
+    private function createHandler(): RollbarHandler
+    {
+        return new RollbarHandler($this->rollbarLogger, Logger::DEBUG);
+    }
+
+    private function createExceptionRecord($level = Logger::DEBUG, $message = 'test', $exception = null): array
+    {
+        return $this->getRecord($level, $message, [
+            'exception' => $exception ?: new Exception(),
+        ]);
+    }
+}

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+// @codingStandardsIgnoreFile
 
 /*
  * This file is part of the Monolog package.

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -66,7 +66,7 @@ class RollbarHandlerTest extends TestCase
             'environment' => 'test'
         );
         
-        $this->rollbarLogger = $this->getMockBuilder(RollbarLogger::class)
+        $this->rollbarLogger = $this->getMockBuilder('Rollbar\RollbarLogger')
             ->setConstructorArgs(array($config))
             ->setMethods(array('log'))
             ->getMock();

--- a/tests/Monolog/Handler/RollbarHandlerTest.php
+++ b/tests/Monolog/Handler/RollbarHandlerTest.php
@@ -26,6 +26,8 @@ use Rollbar\RollbarLogger;
  * @see    https://rollbar.com/docs/notifier/rollbar-php/
  *
  * @coversDefaultClass Monolog\Handler\RollbarHandler
+ * 
+ * @requires PHP 7
  */
 class RollbarHandlerTest extends TestCase
 {

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -96,8 +96,6 @@ class RollbarTest extends BaseRollbarTest
         Rollbar::init(self::$simpleConfig);
       
         $response = Rollbar::log(Level::INFO, 'testing info level');
-        
-        var_dump($response);
       
         $this->assertTrue(true);
     }


### PR DESCRIPTION
Move the `Monolog\Handler\RollbarHandler` from `Seldaek:monolog` to here temporarily. We introduced changes to our `RollbarHandler` in the `Seldaek:monolog` repository but the Pull Request is still outstanding. It looks like it's going to take a while before maintainers have the time to merge it in.

Until then, we are moving this handler into our repo to provide Monolog support for Rollbar.

See more: https://github.com/rollbar/rollbar-php/issues/282
Original Monolog PR: https://github.com/Seldaek/monolog/pull/1042