### PR TITLE
GitHub Issue #315: ReadmeTest class doesn't pass the tests

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -199,6 +199,15 @@ class Rollbar
         self::$logger->configure($config);
     }
     
+    /**
+     * Destroys the currently stored $logger allowing for a fresh configuration.
+     * This is especially used in testing scenarios.
+     */
+    public static function destroy()
+    {
+        self::$logger = null;
+    }
+    
     // @codingStandardsIgnoreStart
     
     /**

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -35,8 +35,9 @@ class AgentTest extends Rollbar\BaseRollbarTest
         $this->assertContains('this is a test', $line);
     }
 
-    protected function tearDown()
+    public function tearDown()
     {
+        parent::tearDown();
         $this->rrmdir($this->path);
     }
 

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -5,6 +5,11 @@ abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
     
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
     
+    public function tearDown()
+    {
+        Rollbar::destroy();
+    }
+    
     public function getTestAccessToken()
     {
         return isset($_ENV['ROLLBAR_TEST_TOKEN']) ?

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,6 +34,7 @@ class ConfigTest extends BaseRollbarTest
 
     public function tearDown()
     {
+        parent::tearDown();
         m::close();
     }
     

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -106,7 +106,7 @@ class ReadmeTest extends BaseRollbarTest
             $result2 = Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
         
-        $this->assertEquals(200, $result1->getStatus());
+        // $this->assertEquals(200, $result1->getStatus());
     }
 
     public function testBasicUsage2()

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -129,10 +129,10 @@ class ReadmeTest extends BaseRollbarTest
     public function testMonolog()
     {
         Rollbar::init(
-        	array(
-        		'access_token' => $this->getTestAccessToken(),
-        		'environment' => 'development'
-        	)
+            array(
+                'access_token' => $this->getTestAccessToken(),
+                'environment' => 'development'
+            )
         );
         
         // create a log channel

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -106,7 +106,8 @@ class ReadmeTest extends BaseRollbarTest
             $result2 = Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
         
-        // $this->assertEquals(200, $result1->getStatus());
+        $this->assertEquals(200, $result1->getStatus());
+        $this->assertEquals(200, $result2->getStatus());
     }
 
     public function testBasicUsage2()
@@ -124,6 +125,9 @@ class ReadmeTest extends BaseRollbarTest
             'Here is a message with some additional data',
             array('x' => 10, 'code' => 'blue')
         );
+        
+        $this->assertEquals(200, $result1->getStatus());
+        $this->assertEquals(200, $result2->getStatus());
     }
 
     public function testMonolog()

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -2,6 +2,8 @@
 
 use Rollbar\Rollbar;
 use Rollbar\Payload\Level;
+use Monolog\Logger;
+use Rollbar\Monolog\Handler\RollbarHandler;
 
 // used in testBasicUsage()
 function do_something()
@@ -103,6 +105,8 @@ class ReadmeTest extends BaseRollbarTest
             // or
             $result2 = Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
+        
+        $this->assertEquals(200, $result1->getStatus());
     }
 
     public function testBasicUsage2()
@@ -124,18 +128,18 @@ class ReadmeTest extends BaseRollbarTest
 
     public function testMonolog()
     {
-        $config = array('access_token' => $this->getTestAccessToken(), 'environment' => 'testing');
-
-        // installs global error and exception handlers
-        Rollbar::init($config);
-
-        $log = new \Monolog\Logger('test');
-        $log->pushHandler(new \Monolog\Handler\PsrHandler(Rollbar::logger()));
-
-        try {
-            throw new \Exception('exception for monolog');
-        } catch (\Exception $e) {
-            $log->error($e);
-        }
+        Rollbar::init(
+        	array(
+        		'access_token' => $this->getTestAccessToken(),
+        		'environment' => 'development'
+        	)
+        );
+        
+        // create a log channel
+        $log = new Logger('RollbarHandler');
+        $log->pushHandler(new RollbarHandler(Rollbar::logger(), Logger::WARNING));
+        
+        // add records to the log
+        $log->addWarning('Foo');
     }
 }

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -21,22 +21,10 @@ class RollbarTest extends BaseRollbarTest
     }
 
     private static $simpleConfig = array();
-
-    private static function clearLogger()
-    {
-        $reflLoggerProperty = new \ReflectionProperty('Rollbar\Rollbar', 'logger');
-        $reflLoggerProperty->setAccessible(true);
-        $reflLoggerProperty->setValue(null);
-    }
     
     public static function setupBeforeClass()
     {
-        self::clearLogger();
-    }
-
-    public function tearDown()
-    {
-        self::clearLogger();
+        Rollbar::destroy();
     }
     
     public function testInitWithConfig()


### PR DESCRIPTION
The tests were not properly cleaning up after each, effectively reusing the same `RollbarLogger` instance. In some cases, it resulted in unintended carrying over Rollbar configuration to the next test.

This PR adds clearing the `RollbarLogger` instance after each test leaving a clean slate each time.

In the case of `ReadmeTest` the `base_api_url` was being carried over from `BackwardsCompatibilityConfigTest`. A local dummy URL was being called rather than the actual Rollbar API resulting in `0` response status rather than expected `200`.