### PR TITLE
GitHub Issue #265: invalid or missing instance

### DIFF
--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -37,7 +37,7 @@ class EncodedPayload
             defined('JSON_PARTIAL_OUTPUT_ON_ERROR') ? JSON_PARTIAL_OUTPUT_ON_ERROR : 0
         );
         
-        if ($this->encoded === false || $this->encoded === 'null') {
+        if ($this->encoded === false) {
             throw new \Exception("Payload data could not be encoded to JSON format.");
         }
         

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -37,7 +37,7 @@ class EncodedPayload
             defined('JSON_PARTIAL_OUTPUT_ON_ERROR') ? JSON_PARTIAL_OUTPUT_ON_ERROR : 0
         );
         
-        if ($this->encoded === false) {
+        if ($this->encoded === false || $this->encoded === null) {
             throw new \Exception("Payload data could not be encoded to JSON format.");
         }
         

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -37,7 +37,7 @@ class EncodedPayload
             defined('JSON_PARTIAL_OUTPUT_ON_ERROR') ? JSON_PARTIAL_OUTPUT_ON_ERROR : 0
         );
         
-        if ($this->encoded === false || $this->encoded === null) {
+        if ($this->encoded === false || $this->encoded === 'null') {
             throw new \Exception("Payload data could not be encoded to JSON format.");
         }
         

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -32,7 +32,8 @@ class EncodedPayload
             $this->data = $data;
         }
         
-        $this->encoded = json_encode($this->data);
+        $this->encoded = json_encode($this->data, JSON_PARTIAL_OUTPUT_ON_ERROR);
+        
         $this->size = strlen($this->encoded);
     }
     

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -32,7 +32,14 @@ class EncodedPayload
             $this->data = $data;
         }
         
-        $this->encoded = json_encode($this->data, JSON_PARTIAL_OUTPUT_ON_ERROR);
+        $this->encoded = json_encode(
+            $this->data,
+            defined('JSON_PARTIAL_OUTPUT_ON_ERROR') ? JSON_PARTIAL_OUTPUT_ON_ERROR : 0
+        );
+        
+        if ($this->encoded === false) {
+            throw new \Exception("Payload data could not be encoded to JSON format.");
+        }
         
         $this->size = strlen($this->encoded);
     }

--- a/src/Payload/Frame.php
+++ b/src/Payload/Frame.php
@@ -98,7 +98,7 @@ class Frame implements \JsonSerializable
     {
         $args = $this->args;
         if(json_encode($args) === false)
-            $args = [];
+            $args = array();
         $result = array(
             "filename" => $this->filename,
             "lineno" => $this->lineno,

--- a/src/Payload/Frame.php
+++ b/src/Payload/Frame.php
@@ -96,9 +96,6 @@ class Frame implements \JsonSerializable
 
     public function jsonSerialize()
     {
-        $args = $this->args;
-        if(json_encode($args) === false)
-            $args = array();
         $result = array(
             "filename" => $this->filename,
             "lineno" => $this->lineno,
@@ -106,7 +103,7 @@ class Frame implements \JsonSerializable
             "method" => $this->method,
             "code" => $this->code,
             "context" => $this->context,
-            "args" => $args,
+            "args" => $this->args
         );
         return $this->utilities->serializeForRollbar($result);
     }

--- a/src/Payload/Frame.php
+++ b/src/Payload/Frame.php
@@ -96,6 +96,9 @@ class Frame implements \JsonSerializable
 
     public function jsonSerialize()
     {
+        $args = $this->args;
+        if(json_encode($args) === false)
+            $args = [];
         $result = array(
             "filename" => $this->filename,
             "lineno" => $this->lineno,
@@ -103,7 +106,7 @@ class Frame implements \JsonSerializable
             "method" => $this->method,
             "code" => $this->code,
             "context" => $this->context,
-            "args" => $this->args,
+            "args" => $args,
         );
         return $this->utilities->serializeForRollbar($result);
     }

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -56,7 +56,7 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
      */
     public function testEncodeMalformedDataPHP54()
     {
-        if (version_compare(phpversion(), "5.4", "=")) {
+        if (version_compare(phpversion(), "5.4")) {
             $this->markTestSkipped("PHP = 5.4");
         }
         

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -43,7 +43,11 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
         
         $result = json_decode($encoded->encoded(), true);
         
-        $this->assertNull($result['data']['body']['exception']['trace']['frames']);
+        if (defined('HHVM_VERSION')) {
+            $this->assertEmpty($result['data']['body']['exception']['trace']['frames']);
+        } else {
+            $this->assertNull($result['data']['body']['exception']['trace']['frames']);
+        }
     }
     
     /**

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -21,6 +21,9 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
         $this->assertEquals($expected, $encoded);
     }
     
+    /**
+     * @requires PHP 5.5
+     */
     public function testEncodeMalformedData()
     {
         $encoded = new EncodedPayload(array(
@@ -41,5 +44,31 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
         $result = json_decode($encoded->encoded(), true);
         
         $this->assertNull($result['data']['body']['exception']['trace']['frames']);
+    }
+    
+    /**
+     * @expectedException \Exception
+     * @expectedExceptionMessage Payload data could not be encoded to JSON format.
+     */
+    public function testEncodeMalformedDataPHP54()
+    {
+        if (version_compare(phpversion(), "5.4", ">")) {
+            $this->markTestSkipped("PHP > 5.4");
+        }
+        
+        $encoded = new EncodedPayload(array(
+            'data' => array(
+                'body' => array(
+                    'exception' => array(
+                        'trace' => array(
+                            'frames' => fopen('/dev/null', 'r')
+                        ),
+                    ),
+                    'ecodable1' => true
+                ),
+                'ecodable2' => true
+            )
+        ));
+        $encoded->encode();
     }
 }

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -56,8 +56,8 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
      */
     public function testEncodeMalformedDataPHP54()
     {
-        if (version_compare(phpversion(), "5.4", ">")) {
-            $this->markTestSkipped("PHP > 5.4");
+        if (version_compare(phpversion(), "5.4", "=")) {
+            $this->markTestSkipped("PHP = 5.4");
         }
         
         $encoded = new EncodedPayload(array(

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -20,4 +20,26 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
         
         $this->assertEquals($expected, $encoded);
     }
+    
+    public function testEncodeMalformedData()
+    {
+        $encoded = new EncodedPayload(array(
+            'data' => array(
+                'body' => array(
+                    'exception' => array(
+                        'trace' => array(
+                            'frames' => fopen('/dev/null', 'r')
+                        ),
+                    ),
+                    'ecodable1' => true
+                ),
+                'ecodable2' => true
+            )
+        ));
+        $encoded->encode();
+        
+        $result = json_decode($encoded->encoded(), true);
+        
+        $this->assertNull($result['data']['body']['exception']['trace']['frames']);
+    }
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -119,6 +119,24 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
     
+    public function testLogMalformedPayloadData()
+    {
+        $logger = new RollbarLogger(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => "testing-php",
+            "transformer" => '\Rollbar\TestHelpers\MalformedPayloadDataTransformer',
+            "verbosity" => \Psr\Log\LogLevel::DEBUG
+        ));
+        
+        $response = $logger->log(
+            Level::ERROR,
+            "Forced payload's data to false value.",
+            array()
+        );
+        
+        $this->assertEquals(400, $response->getStatus());
+    }
+    
     /**
      * @dataProvider debugLoggerProvider
      */

--- a/tests/TestHelpers/MalformedPayloadDataTransformer.php
+++ b/tests/TestHelpers/MalformedPayloadDataTransformer.php
@@ -1,0 +1,16 @@
+<?php namespace Rollbar\TestHelpers;
+
+use \Rollbar\Payload\Payload;
+
+class MalformedPayloadDataTransformer implements \Rollbar\TransformerInterface
+{
+    public function transform(Payload $payload, $level, $toLog, $context)
+    {
+        $mock = \Mockery::mock('\Rollbar\Payload\Data')->makePartial();
+        $mock->shouldReceive("jsonSerialize")->andReturn(false);
+        $levelFactory = new \Rollbar\LevelFactory();
+        $mock->setLevel($levelFactory->fromName($level));
+        $payload->setData($mock);
+        return $payload;
+    }
+}


### PR DESCRIPTION
This PR addressed https://github.com/rollbar/rollbar-php/issues/265

If any of the data in the payload was not encodable to JSON, `json_encode` would result in `data` key of the whole payload to be `false` triggering a `400` response from the API.

Now `json_encode` will simply replace un-encodable values with `null` and still return a valid JSON for ther rest of the structure.