### PR TITLE
GitHub Issue #353: Only collect person.id by default for person tracking

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -39,6 +39,8 @@ class Config
         'logger',
         'person',
         'person_fn',
+        'capture_username',
+        'capture_email',
         'root',
         'scrub_fields',
         'scrub_whitelist',

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -49,6 +49,8 @@ class DataBuilder implements DataBuilderInterface
     protected $rawRequestBody;
     protected $localVarsDump;
     protected $captureErrorStacktraces;
+    protected $captureEmail;
+    protected $captureUsername;
     
     /**
      * @var LevelFactory
@@ -98,6 +100,20 @@ class DataBuilder implements DataBuilderInterface
         $this->setLocalVarsDump($config);
         $this->setCaptureErrorStacktraces($config);
         $this->setLevelFactory($config);
+        $this->setCaptureEmail($config);
+        $this->setCaptureUsername($config);
+    }
+    
+    protected function setCaptureEmail($config)
+    {
+        $fromConfig = isset($config['capture_email']) ? $config['capture_email'] : null;
+        $this->captureEmail = self::$defaults->captureEmail($fromConfig);
+    }
+    
+    protected function setCaptureUsername($config)
+    {
+        $fromConfig = isset($config['capture_username']) ? $config['capture_username'] : null;
+        $this->captureUsername = self::$defaults->captureUsername($fromConfig);
     }
 
     protected function setEnvironment($config)
@@ -825,12 +841,12 @@ class DataBuilder implements DataBuilderInterface
         $identifier = $personData['id'];
 
         $email = null;
-        if (isset($personData['email'])) {
+        if ($this->captureEmail && isset($personData['email'])) {
             $email = $personData['email'];
         }
 
         $username = null;
-        if (isset($personData['username'])) {
+        if ($this->captureUsername && isset($personData['username'])) {
             $username = $personData['username'];
         }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -385,11 +385,11 @@ class Defaults
     
     public function captureEmail($captureEmail = null)
     {
-        return $captureEmail ?: $this->defaultCaptureEmail;
+        return $captureEmail !== null ? $captureEmail : $this->defaultCaptureEmail;
     }
     
     public function captureUsername($captureUsername = null)
     {
-        return $captureUsername ?: $this->defaultCaptureUsername;
+        return $captureUsername !== null ? $captureUsername : $this->defaultCaptureUsername;
     }
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -147,6 +147,8 @@ class Defaults
     private $defaultIncludeExcCodeContext;
     private $defaultRawRequestBody;
     private $defaultLocalVarsDump;
+    private $defaultCaptureEmail = false;
+    private $defaultCaptureUsername = false;
     private $utilities;
 
     public function __construct($utilities)
@@ -381,5 +383,15 @@ class Defaults
     public function includeExcCodeContext($includeExcCodeContext = null)
     {
         return $includeExcCodeContext ?: $this->defaultIncludeExcCodeContext;
+    }
+    
+    public function captureEmail($captureEmail = null)
+    {
+        return $captureEmail ?: $this->defaultCaptureEmail;
+    }
+    
+    public function captureUsername($captureUsername = null)
+    {
+        return $captureUsername ?: $this->defaultCaptureUsername;
     }
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -690,12 +690,37 @@ class DataBuilderTest extends BaseRollbarTest
             'environment' => 'tests',
             'person' => array(
                 'id' => '123',
+                'username' => 'tester',
                 'email' => 'test@test.com'
             ),
             'levelFactory' => new LevelFactory,
             'utilities' => new Utilities
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        $this->assertEquals('123', $output->getPerson()->getId());
+        $this->assertNull($output->getPerson()->getUsername());
+        $this->assertNull($output->getPerson()->getEmail());
+    }
+    
+    public function testPersonCaptureEmailUsername()
+    {
+        $config = new Config(array(
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => 'tests',
+            'person' => array(
+                'id' => '123',
+                'username' => 'tester',
+                'email' => 'test@test.com'
+            ),
+            'capture_email' => true,
+            'capture_username' => true
+        ));
+        $dataBuilder = $config->getDataBuilder();
+        
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        
+        $this->assertEquals('123', $output->getPerson()->getId());
+        $this->assertEquals('tester', $output->getPerson()->getUsername());
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
     }
 
@@ -714,7 +739,7 @@ class DataBuilderTest extends BaseRollbarTest
             'utilities' => new Utilities
         ));
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
-        $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
+        $this->assertEquals('123', $output->getPerson()->getId());
     }
     
     public function testPersonFuncException()
@@ -859,7 +884,7 @@ class DataBuilderTest extends BaseRollbarTest
             'tests/DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
-        $this->assertEquals(857, $frames[count($frames)-1]->getLineno());
+        $this->assertEquals(882, $frames[count($frames)-1]->getLineno());
         $this->assertEquals('Rollbar\DataBuilderTest::testFramesOrder', $frames[count($frames)-2]->getMethod());
     }
     

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -242,4 +242,14 @@ class DefaultsTest extends BaseRollbarTest
     {
         $this->assertFalse($this->defaults->useErrorReporting());
     }
+    
+    public function testCaptureEmail()
+    {
+        $this->assertFalse($this->defaults->captureEmail());
+    }
+    
+    public function testCaptureUsername()
+    {
+        $this->assertFalse($this->defaults->captureUsername());
+    }
 }


### PR DESCRIPTION
PR addressing https://github.com/rollbar/rollbar-php/issues/353

Changes the default behavior of the SDK to not collect person's email and username by default. Adds `capture_email` and `capture_username` config options to override the new default behavior if needed.