### PR TITLE
Fixed E_NOTICE: Undefined property: Rollbar\Defaults::$defaultGitBranch

### DIFF
--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -131,10 +131,16 @@ class Defaults
         if ($gitBranch) {
             return $gitBranch;
         }
-        if (!isset($this->defaultGitBranch) && $allowExec) {
-            $this->defaultGitBranch = self::getGitBranch();
+        if ($allowExec) {
+            static $cachedValue;
+            static $hasExecuted = false;
+            if (!$hasExecuted) {
+                $cachedValue = self::getGitBranch();
+                $hasExecuted = true;
+            }
+            return $cachedValue;
         }
-        return $this->defaultGitBranch;
+        return null;
     }
     
     private static function getGitBranch()

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -86,6 +86,17 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals($val, $this->defaults->gitBranch());
     }
 
+    public function testGitBranchExplicit()
+    {
+        $val = 'some-branch';
+        $this->assertEquals($val, $this->defaults->gitBranch($val));
+    }
+
+    public function testGitBranchNoExec()
+    {
+        $this->assertEquals(null, $this->defaults->gitBranch(null, false));
+    }
+
     public function testServerRoot()
     {
         $_ENV["HEROKU_APP_DIR"] = "abc123";


### PR DESCRIPTION
When `'allow_exec'` is set to `false`, `E_NOTICE` errors are generated with every request due to `$this->defaultGitBranch` variable not being defined because of false condition.

This change implements more robust value caching that is used only when `$allowExec` parameter is set to `true`, which is a less suprising behavior.