### PR TITLE
GitHub Issue #350: PHP Interface, log() method isn't handling fingerprint as documented

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -361,7 +361,7 @@ class DataBuilder implements DataBuilderInterface
             ->setPerson($this->getPerson())
             ->setServer($this->getServer())
             ->setCustom($this->getCustomForPayload($toLog, $context))
-            ->setFingerprint($this->getFingerprint())
+            ->setFingerprint($this->getFingerprint($context))
             ->setTitle($this->getTitle())
             ->setUuid($this->getUuid())
             ->setNotifier($this->getNotifier());
@@ -965,9 +965,9 @@ class DataBuilder implements DataBuilderInterface
         unset($this->custom[$key]);
     }
 
-    protected function getFingerprint()
+    protected function getFingerprint($context)
     {
-        return $this->fingerprint;
+        return isset($context['fingerprint']) ? $context['fingerprint'] : $this->fingerprint;
     }
 
     protected function getTitle()


### PR DESCRIPTION
Addresses https://github.com/rollbar/rollbar-php/issues/350. The per-message custom fingerprinting got lost in changes to the `$context` parameter at some point. This PR brings it back.