### PR TITLE
GitHub Issue 351: Ability to send additional runtime data

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -24,6 +24,7 @@ class Config
         'check_ignore',
         'code_version',
         'custom',
+        'custom_data_method',
         'enabled',
         'environment',
         'error_sample_rates',
@@ -104,6 +105,13 @@ class Config
     private $batchSize = 50;
 
     private $custom = array();
+    
+    /**
+     * @var callable with parameters $toLog, $contextDataMethodContext. The return
+     * value of the callable will be appended to the custom field of the item.
+     */
+    private $customDataMethod;
+    
     /**
      * @var callable
      */
@@ -224,6 +232,11 @@ class Config
         
         if (isset($config['custom_truncation'])) {
             $this->customTruncation = $config['custom_truncation'];
+        }
+        
+        $this->customDataMethod = \Rollbar\Defaults::get()->customDataMethod();
+        if (isset($config['custom_data_method'])) {
+            $this->customDataMethod = $config['custom_data_method'];
         }
     }
 

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -283,8 +283,8 @@ class DataBuilder implements DataBuilderInterface
     
     public function setCustomDataMethod($config)
     {
-        $this->customDataMethod = isset($config['custom_data_method']) ? 
-            $config['custom_data_method'] : 
+        $this->customDataMethod = isset($config['custom_data_method']) ?
+            $config['custom_data_method'] :
             \Rollbar\Defaults::get()->customDataMethod();
     }
 
@@ -957,8 +957,7 @@ class DataBuilder implements DataBuilderInterface
         }
         
         if ($customDataMethod = $this->getCustomDataMethod()) {
-            
-            $customDataMethodContext = isset($context['custom_data_method_context']) ? 
+            $customDataMethodContext = isset($context['custom_data_method_context']) ?
                 $context['custom_data_method_context'] :
                 null;
                 

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -41,6 +41,7 @@ class DataBuilder implements DataBuilderInterface
     protected $serverCodeVersion;
     protected $serverExtras;
     protected $custom;
+    protected $customDataMethod;
     protected $fingerprint;
     protected $title;
     protected $notifier;
@@ -106,6 +107,7 @@ class DataBuilder implements DataBuilderInterface
         $this->setCaptureEmail($config);
         $this->setCaptureUsername($config);
         $this->setCaptureIP($config);
+        $this->setCustomDataMethod($config);
     }
 
     protected function setCaptureIP($config)
@@ -277,6 +279,13 @@ class DataBuilder implements DataBuilderInterface
     public function setCustom($config)
     {
         $this->custom = isset($config['custom']) ? $config['custom'] : \Rollbar\Defaults::get()->custom();
+    }
+    
+    public function setCustomDataMethod($config)
+    {
+        $this->customDataMethod = isset($config['custom_data_method']) ? 
+            $config['custom_data_method'] : 
+            \Rollbar\Defaults::get()->customDataMethod();
     }
 
     protected function setFingerprint($config)
@@ -928,6 +937,11 @@ class DataBuilder implements DataBuilderInterface
     {
         return $this->custom;
     }
+    
+    public function getCustomDataMethod()
+    {
+        return $this->customDataMethod;
+    }
 
     protected function getCustomForPayload($toLog, $context)
     {
@@ -941,6 +955,19 @@ class DataBuilder implements DataBuilderInterface
         } elseif (!is_array($custom)) {
             $custom = get_object_vars($custom);
         }
+        
+        if ($customDataMethod = $this->getCustomDataMethod()) {
+            
+            $customDataMethodContext = isset($context['custom_data_method_context']) ? 
+                $context['custom_data_method_context'] :
+                null;
+                
+            $customDataMethodResult = $customDataMethod($toLog, $customDataMethodContext);
+            
+            $custom = array_merge($custom, $customDataMethodResult);
+        }
+        
+        unset($context['custom_data_method_context']);
 
         return array_replace_recursive(array(), $context, $custom);
     }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -82,6 +82,7 @@ class Defaults
         $this->data['captureErrorStacktraces'] = true;
         $this->data['checkIgnore'] = null;
         $this->data['custom'] = null;
+        $this->data['customDataMethod'] = null;
         $this->data['enabled'] = true;
         $this->data['environment'] = 'production';
         $this->data['fluentHost'] = '127.0.0.1';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -286,6 +286,33 @@ class ConfigTest extends BaseRollbarTest
         $this->assertEquals("bar", $custom["foo"]);
         $this->assertEquals("buzz", $custom["fuzz"]);
     }
+    
+    public function testCustomDataMethod()
+    {
+        $logger = new RollbarLogger(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "custom_data_method" => function($toLog, $customDataMethodContext) {
+                
+                return array(
+                    'data_from_my_custom_method' => $customDataMethodContext['foo']
+                );
+                
+            }
+        ));
+        
+        $dataBuilder = $logger->getDataBuilder();
+        
+        $result = $dataBuilder->makeData(
+            Level::ERROR,
+            new \Exception(),
+            array(
+                'custom_data_method_context' => array('foo' => 'bar')
+            )
+        )->getCustom();
+        
+        $this->assertEquals('bar', $result['data_from_my_custom_method']);
+    }
 
     public function testEndpointDefault()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -292,12 +292,11 @@ class ConfigTest extends BaseRollbarTest
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
-            "custom_data_method" => function($toLog, $customDataMethodContext) {
+            "custom_data_method" => function ($toLog, $customDataMethodContext) {
                 
                 return array(
                     'data_from_my_custom_method' => $customDataMethodContext['foo']
                 );
-                
             }
         ));
         


### PR DESCRIPTION
This PR addresses https://github.com/rollbar/rollbar-php/issues/351

Added new config option `custom_data_method` which allows for custom logic to add custom data to a Rollbar request performed on runtime when the error is being reported. Additional context data can be passed to this callable through the `$extra` or `$context` parameters of `Rollbar::log` and `RollbarLogger::log` under the `custom_data_method_context` key. This is the same feature as in the Ruby gem SDK https://docs.rollbar.com/docs/ruby#section-including-additional-runtime-data

Example of how to use this feature has been presented here: https://github.com/rollbar/rollbar-php-examples/tree/master/custom-data-method

The docs have been amended.