### PR TITLE
Fix $scrubbedPayload missing definition

### DIFF
--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -76,7 +76,9 @@ class FluentSender implements SenderInterface
             $this->loadFluentLogger();
         }
 
-        $success = $this->fluentLogger->post($this->fluentTag, $payload->data());
+        $scrubbedPayload = $payload->data();
+        
+        $success = $this->fluentLogger->post($this->fluentTag, $scrubbedPayload);
         $status = $success ? 200 : 400;
         $info = $success ? 'OK' : 'Bad Request';
         $uuid = $scrubbedPayload['data']['uuid'];


### PR DESCRIPTION
On class FluentSender send method $scrubbedPayload is not defined and will throw error when $uuid is defined.
Changes made to define this var before its been used.