### PR TITLE
Support and test newer HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - hhvm
+  - hhvm-3.6
+  - hhvm-3.18
+  - hhvm-nightly
 matrix:
   include:
     - php: 5.3
@@ -22,5 +24,3 @@ script: composer test
 
 after_success:
   - vendor/bin/test-reporter
-
-  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This library detects errors and exceptions in your application and reports them to [Rollbar](https://rollbar.com) for alerts, reporting, and analysis.
 
-Supported PHP versions: 5.3, 5.4, 5.5, 5.6, 7, 7.1, 7.2 and HHVM (currently tested on 3.6.6).
+Supported PHP versions: 5.3, 5.4, 5.5, 5.6, 7, 7.1, 7.2
+Supported HHVM versions: 3.6, 3.18, 3.21, 3.24, 3.27
 
 # Setup Instructions
 


### PR DESCRIPTION
The version 3.6 being tested is very old. I believe Rollbar supports all LTS releases: https://docs.hhvm.com/hhvm/installation/release-schedule

So this updates the README and updates the CI to build against what's available in https://docs.travis-ci.com/user/reference/trusty