### PR TITLE
Allow users to specify a max nesting level

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -55,6 +55,7 @@ class Config
         'send_message_trace',
         'include_raw_request_body',
         'local_vars_dump',
+        'max_nesting_depth',
         'verbosity'
     );
     
@@ -104,6 +105,8 @@ class Config
 
     private $batched = false;
     private $batchSize = 50;
+
+    private $maxNestingDepth = 10;
 
     private $custom = array();
     
@@ -216,6 +219,7 @@ class Config
         $this->setScrubber($config);
         $this->setBatched($config);
         $this->setBatchSize($config);
+        $this->setMaxNestingDepth($config);
         $this->setCustom($config);
         $this->setResponseHandler($config);
         $this->setCheckIgnoreFunction($config);
@@ -359,6 +363,13 @@ class Config
     {
         if (array_key_exists('batch_size', $config)) {
             $this->batchSize = $config['batch_size'];
+        }
+    }
+
+    private function setMaxNestingDepth($config)
+    {
+        if (array_key_exists('max_nesting_depth', $config)) {
+            $this->maxNestingDepth = $config['max_nesting_depth'];
         }
     }
 
@@ -585,6 +596,11 @@ class Config
     public function getBatchSize()
     {
         return $this->batchSize;
+    }
+
+    public function getMaxNestingDepth()
+    {
+        return $this->maxNestingDepth;
     }
 
     /**

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -303,6 +303,11 @@ class Defaults
         return $value !== null ? $value : $this->customTruncation;
     }
 
+    public function maxNestingDepth($value = null)
+    {
+        return $value !== null ? $value : $this->maxNestingDepth;
+    }
+
     private $psrLevels;
     private $errorLevels;
     private $autodetectBranch = false;
@@ -317,6 +322,7 @@ class Defaults
     private $includeExcCodeContext = false;
     private $rawRequestBody = false;
     private $localVarsDump = true;
+    private $maxNestingDepth = -1;
     private $errorSampleRates = array();
     private $exceptionSampleRates = array();
     private $includedErrno = ROLLBAR_INCLUDED_ERRNO_BITMASK;

--- a/src/Payload/Payload.php
+++ b/src/Payload/Payload.php
@@ -41,13 +41,13 @@ class Payload implements \Serializable
         return $this;
     }
 
-    public function serialize()
+    public function serialize($maxDepth = -1)
     {
         $result = array(
             "data" => $this->data,
             "access_token" => $this->accessToken,
         );
-        return $this->utilities->serializeForRollbar($result);
+        return $this->utilities->serializeForRollbar($result, null, $maxDepth);
     }
     
     public function unserialize($serialized)

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -91,7 +91,7 @@ class RollbarLogger extends AbstractLogger
         if ($this->config->checkIgnored($payload, $accessToken, $toLog, $isUncaught)) {
             $response = new Response(0, "Ignored");
         } else {
-            $serialized = $payload->serialize();
+            $serialized = $payload->serialize($this->config->getMaxNestingDepth());
             $scrubbed = $this->scrub($serialized);
             $encoded = $this->encode($scrubbed);
             $truncated = $this->truncate($encoded);

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -78,7 +78,7 @@ final class Utilities
     ) {
         $returnVal = array();
         if ($maxDepth > 0 && $depth > $maxDepth) {
-            return $returnVal;
+            return null;
         }
         foreach ($obj as $key => $val) {
             if ($val instanceof \Serializable) {

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -72,15 +72,19 @@ final class Utilities
 
     public static function serializeForRollbar(
         $obj,
-        array $customKeys = null
+        array $customKeys = null,
+        $maxDepth = -1,
+        $depth = 0
     ) {
         $returnVal = array();
-
+        if ($maxDepth > 0 && $depth > $maxDepth) {
+            return $returnVal;
+        }
         foreach ($obj as $key => $val) {
             if ($val instanceof \Serializable) {
                 $val = $val->serialize();
             } elseif (is_array($val)) {
-                $val = self::serializeForRollbar($val);
+                $val = self::serializeForRollbar($val, null, $maxDepth, $depth+1);
             } elseif (is_object($val)) {
                 $val = array(
                     'class' => get_class($val),

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -105,32 +105,32 @@ class UtilitiesTest extends BaseRollbarTest
         $this->assertArrayNotHasKey("my_null_value", $result);
     }
 
-	public function testSerializeForRollbarNestingLevels()
-	{
-		$obj = array(
-			"one" => array(
-				'two' => array(
-					'three' => array(
-						'four' => array(1, 2),
-					),
-				),
-			),
-		);
-		$result = Utilities::serializeForRollbar($obj, null, 2);
-		$this->assertArrayHasKey('one', $result);
-		$this->assertArrayHasKey('two', $result['one']);
-		$this->assertArrayNotHasKey('three', $result['one']['two']);
+    public function testSerializeForRollbarNestingLevels()
+    {
+        $obj = array(
+            "one" => array(
+                'two' => array(
+                    'three' => array(
+                        'four' => array(1, 2),
+                    ),
+                ),
+            ),
+        );
+        $result = Utilities::serializeForRollbar($obj, null, 2);
+        $this->assertArrayHasKey('one', $result);
+        $this->assertArrayHasKey('two', $result['one']);
+        $this->assertArrayNotHasKey('three', $result['one']['two']);
 
-		$result = Utilities::serializeForRollbar($obj, null, 3);
-		$this->assertArrayHasKey('one', $result);
-		$this->assertArrayHasKey('two', $result['one']);
-		$this->assertArrayHasKey('three', $result['one']['two']);
-		$this->assertArrayNotHasKey('four', $result['one']['two']['three']);
+        $result = Utilities::serializeForRollbar($obj, null, 3);
+        $this->assertArrayHasKey('one', $result);
+        $this->assertArrayHasKey('two', $result['one']);
+        $this->assertArrayHasKey('three', $result['one']['two']);
+        $this->assertArrayNotHasKey('four', $result['one']['two']['three']);
 
-		$result = Utilities::serializeForRollbar($obj);
-		$this->assertArrayHasKey('one', $result);
-		$this->assertArrayHasKey('two', $result['one']);
-		$this->assertArrayHasKey('three', $result['one']['two']);
-		$this->assertArrayHasKey('four', $result['one']['two']['three']);
-	}
+        $result = Utilities::serializeForRollbar($obj);
+        $this->assertArrayHasKey('one', $result);
+        $this->assertArrayHasKey('two', $result['one']);
+        $this->assertArrayHasKey('three', $result['one']['two']);
+        $this->assertArrayHasKey('four', $result['one']['two']['three']);
+    }
 }

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -104,4 +104,33 @@ class UtilitiesTest extends BaseRollbarTest
         $this->assertArrayNotHasKey("myNullValue", $result);
         $this->assertArrayNotHasKey("my_null_value", $result);
     }
+
+	public function testSerializeForRollbarNestingLevels()
+	{
+		$obj = array(
+			"one" => array(
+				'two' => array(
+					'three' => array(
+						'four' => array(1, 2),
+					),
+				),
+			),
+		);
+		$result = Utilities::serializeForRollbar($obj, null, 2);
+		$this->assertArrayHasKey('one', $result);
+		$this->assertArrayHasKey('two', $result['one']);
+		$this->assertArrayNotHasKey('three', $result['one']['two']);
+
+		$result = Utilities::serializeForRollbar($obj, null, 3);
+		$this->assertArrayHasKey('one', $result);
+		$this->assertArrayHasKey('two', $result['one']);
+		$this->assertArrayHasKey('three', $result['one']['two']);
+		$this->assertArrayNotHasKey('four', $result['one']['two']['three']);
+
+		$result = Utilities::serializeForRollbar($obj);
+		$this->assertArrayHasKey('one', $result);
+		$this->assertArrayHasKey('two', $result['one']);
+		$this->assertArrayHasKey('three', $result['one']['two']);
+		$this->assertArrayHasKey('four', $result['one']['two']['three']);
+	}
 }


### PR DESCRIPTION
Solves Issue #410

This PR keeps default behavior unchanged, which is to recurse through all data. By setting a `max_nesting_depth` in the configuration, you can limit number of levels that will be traversed.