### PR TITLE
Respect the result of any user-defined error handling

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -6,14 +6,14 @@ use Rollbar\Payload\Level;
 
 class ErrorHandler extends AbstractHandler
 {
-    
+
     public function register()
     {
         $this->previousHandler = set_error_handler(array($this, 'handle'));
-        
+
         parent::register();
     }
-    
+
     public function handle()
     {
         /**
@@ -21,18 +21,32 @@ class ErrorHandler extends AbstractHandler
          * through language structures. This hack allows to simulate that.
          */
         $args = func_get_args();
-        
+
         if (!isset($args[0]) || !isset($args[1])) {
             throw new \Exception('No $errno or $errstr to be passed to the error handler.');
         }
-        
+
         $errno = $args[0];
         $errstr = $args[1];
         $errfile = isset($args[2]) ? $args[2] : null;
         $errline = isset($args[3]) ? $args[3] : null;
-        
+
         parent::handle();
-        
+
+        if (!is_null($this->previous_handler)) {
+            $stop_processing = call_user_func(
+                $this->previous_handler,
+                $errno,
+                $errstr,
+                $errfile,
+                $errline
+            );
+
+            if ($stop_processing) {
+                return $stop_processing;
+            }
+        }
+
         if (is_null($this->logger())) {
             return false;
         }
@@ -45,17 +59,7 @@ class ErrorHandler extends AbstractHandler
                             generateErrorWrapper($errno, $errstr, $errfile, $errline);
 
         $this->logger()->log(Level::ERROR, $exception, array(), true);
-        
-        if ($this->previousHandler !== null) {
-            call_user_func(
-                $this->previousHandler,
-                $errno,
-                $errstr,
-                $errfile,
-                $errline
-            );
-        }
-        
+
         return false;
     }
 }

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -33,9 +33,9 @@ class ErrorHandler extends AbstractHandler
 
         parent::handle();
 
-        if (!is_null($this->previous_handler)) {
+        if (!is_null($this->previousHandler)) {
             $stop_processing = call_user_func(
-                $this->previous_handler,
+                $this->previousHandler,
                 $errno,
                 $errstr,
                 $errfile,


### PR DESCRIPTION
## Current Situation

Currently the ErrorHandler will call any user-defined `set_error_handler` after Rollbar has processed all if its needs. However, if Rollbar decides to stop handling the error (if no logger is registered or the error is below the logger's base level) then the user's error handler is never called.

## Proposed Solution

The proposed solution will first call the user-defined `set_error_handler`. If the user's function returns a truthy value then Rollbar stops handling the error. A returned truthy value tells PHP to stop handling the error and is a way for user-defined error handlers to circumvent PHP's default methods.

With this solution, any user-defined error handlers can suppress error messages and Rollbar won't pass them upstream.

## Impetus

This PR comes from efforts to suppress a [known warning](https://core.trac.wordpress.org/ticket/44979) triggered by WordPress in a PHP 7.2 environment. Our custom error handler to keep a harmless warning from flooding client sites is being ignored by Rollbar's error handler.