### PR TITLE
Add to config minimumLevel option.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -56,7 +56,8 @@ class Config
         'include_raw_request_body',
         'local_vars_dump',
         'max_nesting_depth',
-        'max_items'
+        'max_items',
+        'minimum_level'
     );
     
     private $accessToken;

--- a/src/Config.php
+++ b/src/Config.php
@@ -57,7 +57,7 @@ class Config
         'local_vars_dump',
         'max_nesting_depth',
         'max_items',
-        'minimum_level'
+        'monolog_minimum_level'
     );
     
     private $accessToken;
@@ -89,7 +89,7 @@ class Config
      * @var FilterInterface
      */
     private $filter;
-    private $minimumLevel;
+    private $monologMinimumLevel;
     /**
      * @var ResponseHandlerInterface
      */
@@ -210,7 +210,7 @@ class Config
         $this->setAccessToken($config);
         $this->setDataBuilder($config);
         $this->setTransformer($config);
-        $this->setMinimumLevel($config);
+        $this->setMonologMinimumLevel($config);
         $this->setReportSuppressed($config);
         $this->setFilters($config);
         $this->setSender($config);
@@ -300,20 +300,20 @@ class Config
         $this->setupWithOptions($config, "transformer", $expected);
     }
 
-    private function setMinimumLevel($config)
+    private function setMonologMinimumLevel($config)
     {
-        $this->minimumLevel = 0;
-        if (empty($config['minimumLevel'])) {
-            $this->minimumLevel = 0;
-        } elseif ($config['minimumLevel'] instanceof Level) {
-            $this->minimumLevel = $config['minimumLevel']->toInt();
-        } elseif (is_string($config['minimumLevel'])) {
-            $level = $this->levelFactory->fromName($config['minimumLevel']);
+        $this->monologMinimumLevel = 0;
+        if (empty($config['monologMinimumLevel'])) {
+            $this->monologMinimumLevel = 0;
+        } elseif ($config['monologMinimumLevel'] instanceof Level) {
+            $this->monologMinimumLevel = $config['monologMinimumLevel']->toInt();
+        } elseif (is_string($config['monologMinimumLevel'])) {
+            $level = $this->levelFactory->fromName($config['monologMinimumLevel']);
             if ($level !== null) {
-                $this->minimumLevel = $level->toInt();
+                $this->monologMinimumLevel = $level->toInt();
             }
-        } elseif (is_int($config['minimumLevel'])) {
-            $this->minimumLevel = $config['minimumLevel'];
+        } elseif (is_int($config['monologMinimumLevel'])) {
+            $this->monologMinimumLevel = $config['monologMinimumLevel'];
         }
     }
 
@@ -601,6 +601,11 @@ class Config
         return $this->maxItems;
     }
 
+    public function getMonologMinimumLevel()
+    {
+        return $this->monologMinimumLevel;
+    }
+
     /**
      * @param Payload $payload
      * @param Level $level
@@ -803,7 +808,7 @@ class Config
      */
     private function levelTooLow($level)
     {
-        return $level->toInt() < $this->minimumLevel;
+        return $level->toInt() < $this->monologMinimumLevel;
     }
 
     private function shouldSuppress()

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -1,6 +1,6 @@
 <?php namespace Rollbar;
 
-use Rollbar\Utilities;
+use Monolog\Logger;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
 
@@ -313,6 +313,11 @@ class Defaults
         return $value !== null ? $value : $this->maxItems;
     }
 
+    public function minimumLevel($value = null)
+    {
+        return $value !== null ? $value : $this->minimumLevel;
+    }
+
     private $psrLevels;
     private $errorLevels;
     private $autodetectBranch = false;
@@ -358,4 +363,5 @@ class Defaults
     private $scrubFields;
     private $customTruncation = null;
     private $maxItems = 10;
+    private $minimumLevel = Logger::ERROR;
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -313,9 +313,9 @@ class Defaults
         return $value !== null ? $value : $this->maxItems;
     }
 
-    public function minimumLevel($value = null)
+    public function monologMinimumLevel($value = null)
     {
-        return $value !== null ? $value : $this->minimumLevel;
+        return $value !== null ? $value : $this->monologMinimumLevel;
     }
 
     private $psrLevels;
@@ -363,5 +363,5 @@ class Defaults
     private $scrubFields;
     private $customTruncation = null;
     private $maxItems = 10;
-    private $minimumLevel = Logger::ERROR;
+    private $monologMinimumLevel = Logger::ERROR;
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -150,19 +150,19 @@ class ConfigTest extends BaseRollbarTest
         $this->assertEquals($pPrime, $config->transform($p, "error", "message", "extra_data"));
     }
 
-    public function testMinimumLevel()
+    public function testMonologMinimumLevel()
     {
         $c = new Config(array(
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => $this->env,
-            "minimumLevel" => "warning"
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => $this->env,
+            'monologMinimumLevel' => 'warning'
         ));
         $this->runConfigTest($c);
 
-        $c->configure(array("minimumLevel" => Level::WARNING));
+        $c->configure(array('monologMinimumLevel' => Level::WARNING));
         $this->runConfigTest($c);
         
-        $c->configure(array("minimumLevel" => Level::WARNING()->toInt()));
+        $c->configure(array('monologMinimumLevel' => Level::WARNING()->toInt()));
         $this->runConfigTest($c);
     }
 


### PR DESCRIPTION
Hello everybody.

Please add the configuration property of the minimum error level.

My problem is:
I have 2 projects in one, I  have to log errors from `Error` and in another from `Info`. Therefore, I need the option to configure the level of the `class Config -> $options -> in my yml` required error level.