### PR TITLE
Configurable Exception Raising for rollbar.log

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -149,7 +149,8 @@ class Config
     
     /**
      * @var array An array of environments in which the exception should be
-     * reraised from the logger.
+     * reraised from the logger. See for more details: 
+     * https://github.com/rollbar/rollbar-php/issues/448
      */
     private $reraiseInEnvironments = array();
     

--- a/src/Config.php
+++ b/src/Config.php
@@ -57,7 +57,8 @@ class Config
         'local_vars_dump',
         'max_nesting_depth',
         'max_items',
-        'minimum_level'
+        'minimum_level',
+        'reraise_in_environments'
     );
     
     private $accessToken;
@@ -147,6 +148,12 @@ class Config
     private $customTruncation;
     
     /**
+     * @var array An array of environments in which the exception should be
+     * reraised from the logger.
+     */
+    private $reraiseInEnvironments = array();
+    
+    /**
      * @var int The maximum number of items reported to Rollbar within one
      * request.
      */
@@ -227,6 +234,7 @@ class Config
         $this->setResponseHandler($config);
         $this->setCheckIgnoreFunction($config);
         $this->setSendMessageTrace($config);
+        $this->setReraiseInEnvironments($config);
 
         if (isset($config['included_errno'])) {
             $this->includedErrno = $config['included_errno'];
@@ -365,6 +373,15 @@ class Config
     {
         if (array_key_exists('batched', $config)) {
             $this->batched = $config['batched'];
+        }
+    }
+    
+    private function setReraiseInEnvironments($config)
+    {
+        if (array_key_exists('reraise_in_environments', $config)) {
+            $this->reraiseInEnvironments = $config['reraise_in_environments'];
+        } else {
+            $this->reraiseInEnvironments = \Rollbar\Defaults::get()->reraiseInEnvironments();
         }
     }
 
@@ -611,6 +628,11 @@ class Config
     public function getMinimumLevel()
     {
         return $this->minimumLevel;
+    }
+    
+    public function getReraiseInEnvironments()
+    {
+        return $this->reraiseInEnvironments;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config
         'max_nesting_depth',
         'max_items',
         'minimum_level',
-        'reraise_in_environments'
+        'raise_on_error'
     );
     
     private $accessToken;
@@ -148,11 +148,11 @@ class Config
     private $customTruncation;
     
     /**
-     * @var array An array of environments in which the exception should be
-     * reraised from the logger. See for more details:
+     * @var boolean Should the SDK raise an exception after logging an error.
+     * This is useful in test and development enviroments.
      * https://github.com/rollbar/rollbar-php/issues/448
      */
-    private $reraiseInEnvironments = array();
+    private $raiseOnError = false;
     
     /**
      * @var int The maximum number of items reported to Rollbar within one
@@ -235,7 +235,7 @@ class Config
         $this->setResponseHandler($config);
         $this->setCheckIgnoreFunction($config);
         $this->setSendMessageTrace($config);
-        $this->setReraiseInEnvironments($config);
+        $this->setRaiseOnError($config);
 
         if (isset($config['included_errno'])) {
             $this->includedErrno = $config['included_errno'];
@@ -377,12 +377,12 @@ class Config
         }
     }
     
-    private function setReraiseInEnvironments($config)
+    private function setRaiseOnError($config)
     {
-        if (array_key_exists('reraise_in_environments', $config)) {
-            $this->reraiseInEnvironments = $config['reraise_in_environments'];
+        if (array_key_exists('raise_on_error', $config)) {
+            $this->raiseOnError = $config['raise_on_error'];
         } else {
-            $this->reraiseInEnvironments = \Rollbar\Defaults::get()->reraiseInEnvironments();
+            $this->raiseOnError = \Rollbar\Defaults::get()->raiseOnError();
         }
     }
 
@@ -631,18 +631,9 @@ class Config
         return $this->minimumLevel;
     }
     
-    public function getReraiseInEnvironments()
+    public function getRaiseOnError()
     {
-        return $this->reraiseInEnvironments;
-    }
-    
-    public function shouldReraise()
-    {
-        if (in_array($this->dataBuilder->getEnvironment(), $this->reraiseInEnvironments)) {
-            return true;
-        }
-        
-        return false;
+        return $this->raiseOnError;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -634,6 +634,15 @@ class Config
     {
         return $this->reraiseInEnvironments;
     }
+    
+    public function shouldReraise()
+    {
+        if (in_array($this->dataBuilder->getEnvironment(), $this->reraiseInEnvironments)) {
+            return true;
+        }
+        
+        return false;
+    }
 
     /**
      * @param Payload $payload

--- a/src/Config.php
+++ b/src/Config.php
@@ -149,7 +149,7 @@ class Config
     
     /**
      * @var array An array of environments in which the exception should be
-     * reraised from the logger. See for more details: 
+     * reraised from the logger. See for more details:
      * https://github.com/rollbar/rollbar-php/issues/448
      */
     private $reraiseInEnvironments = array();

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -388,7 +388,7 @@ class DataBuilder implements DataBuilderInterface
         return $data;
     }
 
-    protected function getEnvironment()
+    public function getEnvironment()
     {
         return $this->environment;
     }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -317,6 +317,11 @@ class Defaults
     {
         return $value !== null ? $value : $this->minimumLevel;
     }
+    
+    public function reraiseInEnvironments($value = null)
+    {
+        return $value !== null ? $value : $this->reraiseInEnvironments;
+    }
 
     private $psrLevels;
     private $errorLevels;
@@ -364,4 +369,5 @@ class Defaults
     private $customTruncation = null;
     private $maxItems = 10;
     private $minimumLevel = 0;
+    private $reraiseInEnvironments = array();
 }

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -318,9 +318,9 @@ class Defaults
         return $value !== null ? $value : $this->minimumLevel;
     }
     
-    public function reraiseInEnvironments($value = null)
+    public function raiseOnError($value = null)
     {
-        return $value !== null ? $value : $this->reraiseInEnvironments;
+        return $value !== null ? $value : $this->raiseOnError;
     }
 
     private $psrLevels;
@@ -369,5 +369,5 @@ class Defaults
     private $customTruncation = null;
     private $maxItems = 10;
     private $minimumLevel = 0;
-    private $reraiseInEnvironments = array();
+    private $raiseOnError = false;
 }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -102,6 +102,10 @@ class RollbarLogger extends AbstractLogger
         
         $this->handleResponse($payload, $response);
         
+        if (is_a($toLog, 'Exception') && $this->config->shouldReraise()) {
+            throw $toLog;
+        }
+        
         return $response;
     }
 

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -102,7 +102,7 @@ class RollbarLogger extends AbstractLogger
         
         $this->handleResponse($payload, $response);
         
-        if (is_a($toLog, 'Exception') && $this->config->shouldReraise()) {
+        if ((is_a($toLog, 'Throwable') || is_a($toLog, 'Exception')) && $this->config->getRaiseOnError()) {
             throw $toLog;
         }
         

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -359,41 +359,15 @@ class ConfigTest extends BaseRollbarTest
         );
     }
     
-    public function testReraiseInEnvironments()
+    public function testRaiseOnError()
     {
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
-            "reraise_in_environments" => array(
-                "production", "test"
-            )
+            "raise_on_error" => true
         ));
         
-        $this->assertContains('production', $config->getReraiseInEnvironments());
-        $this->assertContains('test', $config->getReraiseInEnvironments());
-    }
-    
-    public function testShouldReraise()
-    {
-        $config = new Config(array(
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => 'test'
-        ));
-        
-        $this->assertFalse($config->shouldReraise());
-        
-        $config->configure(array(
-            'reraise_in_environments' => array('test')
-        ));
-        
-        $this->assertTrue($config->shouldReraise());
-        
-        $config->configure(array(
-            'environment' => 'production',
-            'reraise_in_environments' => array('test')
-        ));
-        
-        $this->assertFalse($config->shouldReraise());
+        $this->assertTrue($config->getRaiseOnError());
     }
 
     public function testSendMessageTrace()

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -372,6 +372,29 @@ class ConfigTest extends BaseRollbarTest
         $this->assertContains('production', $config->getReraiseInEnvironments());
         $this->assertContains('test', $config->getReraiseInEnvironments());
     }
+    
+    public function testShouldReraise()
+    {
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => 'test'
+        ));
+        
+        $this->assertFalse($config->shouldReraise());
+        
+        $config->configure(array(
+            'reraise_in_environments' => array('test')
+        ));
+        
+        $this->assertTrue($config->shouldReraise());
+        
+        $config->configure(array(
+            'environment' => 'production',
+            'reraise_in_environments' => array('test')
+        ));
+        
+        $this->assertFalse($config->shouldReraise());
+    }
 
     public function testSendMessageTrace()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -358,6 +358,20 @@ class ConfigTest extends BaseRollbarTest
             $config->getSender()->getEndpoint()
         );
     }
+    
+    public function testReraiseInEnvironments()
+    {
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "reraise_in_environments" => array(
+                "production", "test"
+            )
+        ));
+        
+        $this->assertContains('production', $config->getReraiseInEnvironments());
+        $this->assertContains('test', $config->getReraiseInEnvironments());
+    }
 
     public function testSendMessageTrace()
     {

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -252,6 +252,11 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals(10, $this->defaults->maxItems());
     }
     
+    public function testReraiseInEnvironments()
+    {
+        $this->assertEquals(array(), $this->defaults->reraiseInEnvironments());
+    }
+    
     public function testDefaultsForConfigOptions()
     {
         foreach (\Rollbar\Config::listOptions() as $option) {

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -252,9 +252,9 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals(10, $this->defaults->maxItems());
     }
     
-    public function testReraiseInEnvironments()
+    public function testRaiseOnError()
     {
-        $this->assertEquals(array(), $this->defaults->reraiseInEnvironments());
+        $this->assertEquals(false, $this->defaults->raiseOnError());
     }
     
     public function testDefaultsForConfigOptions()

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -656,7 +656,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         
         try {
             throw new \Exception();
-        } catch(\Exception $ex) {
+        } catch (\Exception $ex) {
             $logger->log(Level::ERROR, $ex);
         }
     }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -640,4 +640,24 @@ class RollbarLoggerTest extends BaseRollbarTest
             'use provided max_items' => array(3)
         );
     }
+    
+    /**
+     * @expectedException Exception
+     */
+    public function testReraiseExceptions()
+    {
+        $logger = new RollbarLogger(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => 'test',
+            "reraise_in_environments" => array(
+                "test"
+            )
+        ));
+        
+        try {
+            throw new \Exception();
+        } catch(\Exception $ex) {
+            $logger->log(Level::ERROR, $ex);
+        }
+    }
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -644,14 +644,12 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @expectedException Exception
      */
-    public function testReraiseExceptions()
+    public function testRaiseOnError()
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => 'test',
-            "reraise_in_environments" => array(
-                "test"
-            )
+            "raise_on_error" => true
         ));
         
         try {


### PR DESCRIPTION
Fixes #448 

Usage:

```php
$enviroment = "test";

Rollbar::init(array(
  "access_token" => $this->getTestAccessToken(),
  "environment" => $environment,
  "raise_on_error" => $environment == "test"
));

try {
  throw new \Exception();
} catch(\Exception $ex) {
  Rollbar::log(Level::ERROR, $ex);
}
```

Above configuration will cause the exception to be reraised only in the `test` environment