### PR TITLE
Increase memory limits for php5.3 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   include:
     - php: 5.3
       dist: precise
+      env: COMPOSER_MEMORY_LIMIT=-1
 
 sudo: false
 


### PR DESCRIPTION
fix #451