### PR TITLE
Fix incorrect array encoding in config produced by RollbarJsHelper

### DIFF
--- a/src/RollbarJsHelper.php
+++ b/src/RollbarJsHelper.php
@@ -61,7 +61,7 @@ class RollbarJsHelper
      */
     public function configJsTag()
     {
-        return "var _rollbarConfig = " . json_encode($this->config, JSON_FORCE_OBJECT) . ";";
+        return "var _rollbarConfig = " . json_encode((object)$this->config) . ";";
     }
     
     /**

--- a/tests/JsHelperTest.php
+++ b/tests/JsHelperTest.php
@@ -226,19 +226,29 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function testConfigJsTag()
+    /**
+     * @dataProvider configJsTagProvider
+     */
+    public function testConfigJsTag($config, $expectedJson)
     {
-        $config = array(
-            'config1' => 'value 1'
-        );
-        
-        $expectedJson = json_encode($config);
         $expected = "var _rollbarConfig = $expectedJson;";
         
         $helper = new RollbarJsHelper($config);
         $result = $helper->configJsTag();
         
         $this->assertEquals($expected, $result);
+    }
+    
+    public function configJsTagProvider()
+    {
+        return array(
+            array(array(), '{}'),
+            array(array('config1' => 'value 1'), '{"config1":"value 1"}'),
+            array(
+                array('hostBlackList' => array('example.com', 'badhost.com')),
+                '{"hostBlackList":["example.com","badhost.com"]}'
+            ),
+        );
     }
     
     /**


### PR DESCRIPTION
When building JS code with RollbarJsHelper and passing configuration
parameters that are arrays, those arrays in the final JS output are
incorrectly encoded as objects.