### PR TITLE
support for monolog ^2.0 as well as ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require": {
     "ext-curl": "*",
     "psr/log": "^1",
-    "monolog/monolog": "^1"
+    "monolog/monolog": "^1|^2"
   },
 
   "require-dev": {


### PR DESCRIPTION
bonus: allows rollbar-php-laravel to support Laravel 6.0 without having to downgrade monolog explicitly to ^1.0 in your app