### PR TITLE
Remove php <7.1 support, upgrade to phpunit 7, resolve risky tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 dist: trusty
 
 php:
+  - 7.3
   - 7.2
   - 7.1
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This library detects errors and exceptions in your application and reports them to [Rollbar](https://rollbar.com) for alerts, reporting, and analysis.
 
-Supported PHP versions: 5.3, 5.4, 5.5, 5.6, 7, 7.1, 7.2
-Supported HHVM versions: 3.6, 3.18, 3.21, 3.24, 3.27
+Supported PHP versions: 7.1, 7.2, 7.3
 
 # Setup Instructions
 

--- a/composer.json
+++ b/composer.json
@@ -31,35 +31,36 @@
   },
 
   "require": {
+    "php": "^7.1",
     "ext-curl": "*",
     "psr/log": "^1",
     "monolog/monolog": "^1 || ^2"
   },
 
   "require-dev": {
-    "phpunit/phpunit": "4.8.* || ^5",
+    "phpunit/phpunit": "^7.0",
     "mockery/mockery": "0.9.*",
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",
-    "packfire/php5.3-compat": "*",
-    "phpmd/phpmd" : "@stable"
+    "phpmd/phpmd" : "@stable",
+    "composer/ca-bundle": "^1.2"
   },
 
   "suggest": {
-    "packfire/php5.3-compat": "for backward compatibility with PHP 5.3",
-    "fluent/logger": "Needed to use the 'fluent' handler for fluentd support"
+    "fluent/logger": "Needed to use the 'fluent' handler for fluentd support",
+    "composer/ca-bundle": "Use the Composer CA Bundle to manage certificate verification"
   },
 
   "scripts": {
     "test": [
-      "phpunit --coverage-clover build/logs/clover.xml --testsuite 'Rollbar Test Suite'",
+      "phpunit --coverage-clover build/logs/clover.xml --testsuite \"Rollbar Test Suite\"",
       "phpcs --standard=PSR1,PSR2 src tests"
     ],
     "fix": "phpcbf --standard=PSR1,PSR2 src tests",
     "get-js-snippet": "ROLLBAR_JS_TAG=$(curl -s https://api.github.com/repos/rollbar/rollbar.js/releases/latest | sed -n 's/\"tag_name\":.*\"\\(.*\\)\",/\\1/p' | sed 's/ *//'); curl -X GET https://raw.githubusercontent.com/rollbar/rollbar.js/$ROLLBAR_JS_TAG/dist/rollbar.snippet.js > data/rollbar.snippet.js",
     "performance": "phpunit --coverage-clover build/logs/clover.xml --testsuite 'Rollbar Performance Test Suite'"
   },
-  
+
   "config": {
     "process-timeout": 600
   }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
 	 convertErrorsToExceptions="true"
 	 convertNoticesToExceptions="true"
 	 convertWarningsToExceptions="true"
-	 stopOnFailure="false"
-	 syntaxCheck="false">
+	 stopOnFailure="false">
   <testsuites>
     <testsuite name="Rollbar Test Suite">
       <directory suffix=".php">./tests/</directory>

--- a/src/Config.php
+++ b/src/Config.php
@@ -116,7 +116,7 @@ class Config
     private $verbose;
 
     /**
-     * @var \Psr\Log\Logger $versbosity_logger The logger object used to log
+     * @var \Psr\Log\LoggerInterface $versbosity_logger The logger object used to log
      * the internal messages of the SDK. The verbosity level of the default
      * $verbosityLogger can be controlled with `verbose` config option.
      * Default: \Rollbar\VerboseLogger

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1161,7 +1161,7 @@ class DataBuilder implements DataBuilderInterface
     {
         try {
             if (function_exists('shell_exec')) {
-                $stdRedirCmd = Utilities::isWindows() ? " > NUL" : " 2> /dev/null";
+                $stdRedirCmd = Utilities::isWindows() ? " 2> NUL" : " 2> /dev/null";
                 $output = rtrim(shell_exec('git rev-parse --abbrev-ref HEAD' . $stdRedirCmd));
                 if ($output) {
                     return $output;

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -46,7 +46,7 @@ class EncodedPayload
     
     public function __toString()
     {
-        return $this->encoded();
+        return (string)$this->encoded;
     }
     
     public function encoded()

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -26,12 +26,12 @@ class RollbarLogger extends AbstractLogger
     
     public function enable()
     {
-        return $this->config->enable();
+        $this->config->enable();
     }
     
     public function disable()
     {
-        return $this->config->disable();
+        $this->config->disable();
     }
     
     public function enabled()
@@ -123,7 +123,7 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->info('Occurrence successfully logged');
         }
         
-        if ((is_a($toLog, 'Throwable') || is_a($toLog, 'Exception')) && $this->config->getRaiseOnError()) {
+        if (($toLog instanceof \Throwable) && $this->config->getRaiseOnError()) {
             throw $toLog;
         }
         
@@ -202,6 +202,7 @@ class RollbarLogger extends AbstractLogger
         return $this->config->getDataBuilder();
     }
 
+    /** @deprecated  */
     public function outputLogger()
     {
         return $this->config->outputLogger();

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -1,10 +1,13 @@
-<?php namespace Rollbar\Senders;
+<?php
+
+namespace Rollbar\Senders;
 
 /**
  * Adapted from:
  * https://github.com/segmentio/analytics-php/blob/master/lib/Segment/Consumer/Socket.php
  */
 
+use Composer\CaBundle\CaBundle;
 use Rollbar\Response;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\EncodedPayload;
@@ -50,6 +53,10 @@ class CurlSender implements SenderInterface
         if (array_key_exists('ca_cert_path', $opts)) {
             $this->caCertPath = $opts['ca_cert_path'];
         }
+
+        if (!$this->caCertPath && !ini_get('curl.cainfo') && class_exists(CaBundle::class)) {
+            $this->caCertPath = CaBundle::getBundledCaBundlePath();
+        }
     }
     
     public function getEndpoint()
@@ -72,7 +79,7 @@ class CurlSender implements SenderInterface
         curl_close($handle);
 
         $data = $payload->data();
-        $uuid = $data['data']['uuid'];
+        $uuid = $data['data']['uuid'] ?? null;
         
         return new Response($statusCode, $result, $uuid);
     }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -11,10 +11,11 @@ function microtime()
 
 class AgentTest extends Rollbar\BaseRollbarTest
 {
-    private $path = '/tmp/rollbar-php';
+    private $path;
 
     protected function setUp()
     {
+        $this->path = sys_get_temp_dir().'/rollbar-php';
         if (!file_exists($this->path)) {
             mkdir($this->path);
         }

--- a/tests/BackwardsCompatibilityConfigTest.php
+++ b/tests/BackwardsCompatibilityConfigTest.php
@@ -59,5 +59,7 @@ class BackwardsCompatibilityConfigTest extends BaseRollbarTest
                 'password' => 'my_password'
             )
         ));
+
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,6 +1,9 @@
-<?php namespace Rollbar;
+<?php
+namespace Rollbar;
 
-abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseRollbarTest extends TestCase
 {
     
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -37,7 +37,7 @@ class ConfigTest extends BaseRollbarTest
         parent::tearDown();
         m::close();
     }
-    
+
     private $env = "rollbar-php-testing";
 
     public function testAccessToken()
@@ -56,7 +56,7 @@ class ConfigTest extends BaseRollbarTest
             'environment' => $this->env
         ));
         $this->assertTrue($config->enabled());
-        
+
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env,
@@ -72,7 +72,7 @@ class ConfigTest extends BaseRollbarTest
             'environment' => $this->env
         ));
         $this->assertTrue($config->transmitting());
-        
+
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env,
@@ -88,7 +88,7 @@ class ConfigTest extends BaseRollbarTest
             'environment' => $this->env
         ));
         $this->assertFalse($config->loggingPayload());
-        
+
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env,
@@ -159,7 +159,7 @@ class ConfigTest extends BaseRollbarTest
         $this->assertInstanceOf('\Monolog\Handler\ErrorLogHandler', $handler);
         // assert the appropriate default handler level
         $this->assertEquals($config->verboseInteger(), $handler->getLevel());
-        
+
         // assert the verbosity level in the handler matches the level in the config
         $config->configure(array('verbose' => \Psr\Log\LogLevel::DEBUG));
         $handlers = $config->verboseLogger()->getHandlers();
@@ -206,7 +206,7 @@ class ConfigTest extends BaseRollbarTest
             'environment' => $this->env
         ));
         $this->assertInstanceOf('\Monolog\Logger', $config->verboseLogger());
-        
+
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env,
@@ -306,34 +306,34 @@ class ConfigTest extends BaseRollbarTest
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env
         ));
-        
+
         $this->assertPayloadNotIgnored($config, $this->prepareMockPayload(Level::DEBUG()));
-        
+
         $config->configure(array('minimum_level' => Level::WARNING()));
-        
+
         $this->assertPayloadIgnored($config, $this->prepareMockPayload(Level::DEBUG()));
         $this->assertPayloadNotIgnored($config, $this->prepareMockPayload(Level::WARNING()));
-        
+
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => $this->env,
             'minimumLevel' => Level::ERROR()
         ));
-        
+
         $this->assertPayloadIgnored($config, $this->prepareMockPayload(Level::WARNING()));
         $this->assertPayloadNotIgnored($config, $this->prepareMockPayload(Level::ERROR()));
     }
-    
+
     public function assertPayloadIgnored($config, $payload)
     {
         $this->assertTrue($config->checkIgnored($payload, null, $this->error, false));
     }
-    
+
     public function assertPayloadNotIgnored($config, $payload)
     {
         $this->assertFalse($config->checkIgnored($payload, null, $this->error, false));
     }
-    
+
     private function prepareMockPayload($level)
     {
         $data = m::mock("Rollbar\Payload\Data")
@@ -386,8 +386,10 @@ class ConfigTest extends BaseRollbarTest
             "sender" => $sender
         ));
         $c->send($p, $this->getTestAccessToken());
+        
+        $this->expectNotToPerformAssertions();
     }
-    
+
     public function testEndpoint()
     {
         $config = new Config(array(
@@ -395,7 +397,7 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "endpoint" => "http://localhost/api/1/"
         ));
-        
+
         $this->assertEquals(
             "http://localhost/api/1/item/",
             $config->getSender()->getEndpoint()
@@ -412,52 +414,52 @@ class ConfigTest extends BaseRollbarTest
                 "fuzz" => "buzz"
             )
         ));
-        
+
         $dataBuilder = $config->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::INFO,
             "Test message with custom data added dynamically.",
             array()
         );
-        
+
         $custom = $result->getCustom();
-        
+
         $this->assertEquals("bar", $custom["foo"]);
         $this->assertEquals("buzz", $custom["fuzz"]);
     }
-    
+
     public function testMaxItems()
     {
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken()
         ));
-        
+
         $this->assertEquals(Defaults::get()->maxItems(), $config->getMaxItems());
-        
+
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "max_items" => Defaults::get()->maxItems()+1
         ));
-        
+
         $this->assertEquals(Defaults::get()->maxItems()+1, $config->getMaxItems());
     }
-    
+
     public function testCustomDataMethod()
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
             "custom_data_method" => function ($toLog, $customDataMethodContext) {
-                
+
                 return array(
                     'data_from_my_custom_method' => $customDataMethodContext['foo']
                 );
             }
         ));
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::ERROR,
             new \Exception(),
@@ -465,7 +467,7 @@ class ConfigTest extends BaseRollbarTest
                 'custom_data_method_context' => array('foo' => 'bar')
             )
         )->getCustom();
-        
+
         $this->assertEquals('bar', $result['data_from_my_custom_method']);
     }
 
@@ -475,13 +477,13 @@ class ConfigTest extends BaseRollbarTest
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
-        
+
         $this->assertEquals(
             "https://api.rollbar.com/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testBaseApiUrl()
     {
         $config = new Config(array(
@@ -489,26 +491,26 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "base_api_url" => "http://localhost/api/1/"
         ));
-        
+
         $this->assertEquals(
             "http://localhost/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testBaseApiUrlDefault()
     {
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
-        
+
         $this->assertEquals(
             "https://api.rollbar.com/api/1/item/",
             $config->getSender()->getEndpoint()
         );
     }
-    
+
     public function testRaiseOnError()
     {
         $config = new Config(array(
@@ -516,7 +518,7 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "raise_on_error" => true
         ));
-        
+
         $this->assertTrue($config->getRaiseOnError());
     }
 
@@ -527,14 +529,14 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "send_message_trace" => true
         ));
-        
+
         $this->assertTrue($c->getSendMessageTrace());
-        
+
         $c = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env
         ));
-        
+
         $this->assertFalse($c->getSendMessageTrace());
     }
 
@@ -549,10 +551,10 @@ class ConfigTest extends BaseRollbarTest
             }
         ));
         $levelFactory = $config->getLevelFactory();
-        
+
         $data = new Data($this->env, new Body(new Message("test")));
         $data->setLevel($levelFactory->fromName(Level::ERROR));
-        
+
         $config->checkIgnored(
             new Payload(
                 $data,
@@ -571,7 +573,7 @@ class ConfigTest extends BaseRollbarTest
         $called = false;
         $isUncaughtPassed = null;
         $errorPassed = null;
-        
+
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
@@ -588,12 +590,12 @@ class ConfigTest extends BaseRollbarTest
                 $errorPassed = $exc;
             }
         ));
-        
+
         $levelFactory = $config->getLevelFactory();
-        
+
         $data = new Data($this->env, new Body(new Message("test")));
         $data->setLevel($levelFactory->fromName(Level::ERROR));
-        
+
         $config->checkIgnored(
             new Payload(
                 $data,
@@ -608,7 +610,7 @@ class ConfigTest extends BaseRollbarTest
         $this->assertTrue($isUncaughtPassed);
         $this->assertEquals($this->error, $errorPassed);
     }
-    
+
     public function testCaptureErrorStacktraces()
     {
         $logger = new RollbarLogger(array(
@@ -616,15 +618,15 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "capture_error_stacktraces" => false
         ));
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::ERROR,
             new \Exception(),
             array()
         );
-        
+
         $this->assertEmpty($result->getBody()->getValue()->getFrames());
     }
 
@@ -634,7 +636,7 @@ class ConfigTest extends BaseRollbarTest
     public function testUseErrorReporting($use_error_reporting, $error_reporting, $expected)
     {
         $called = false;
-        
+
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
@@ -643,24 +645,24 @@ class ConfigTest extends BaseRollbarTest
             },
             "use_error_reporting" => $use_error_reporting
         ));
-        
+
         if ($error_reporting !== null) {
             $errorReportingTemp = error_reporting();
             error_reporting($error_reporting);
         }
-        
+
         $result = $config->internalCheckIgnored(
             Level::ERROR,
             $this->error
         );
-        
+
         $this->assertEquals($expected, $result);
-        
+
         if ($error_reporting) {
             error_reporting($errorReportingTemp);
         }
     }
-    
+
     public function useErrorReportingProvider()
     {
         return array(
@@ -681,7 +683,7 @@ class ConfigTest extends BaseRollbarTest
             )
         );
     }
-    
+
     /**
      * @dataProvider providerExceptionSampleRate
      */
@@ -694,12 +696,12 @@ class ConfigTest extends BaseRollbarTest
                 get_class($exception) => $expected
             )
         ));
-        
+
         $sampleRate = $config->exceptionSampleRate($exception);
-        
+
         $this->assertEquals($expected, $sampleRate);
     }
-    
+
     public function providerExceptionSampleRate()
     {
         return array(

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -881,7 +881,7 @@ class DataBuilderTest extends BaseRollbarTest
         ));
         $frames = $dataBuilder->makeFrames(new \Exception(), false);
         $this->assertStringEndsWith(
-            'tests/DataBuilderTest.php',
+            'tests' . DIRECTORY_SEPARATOR . 'DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
         $this->assertEquals(882, $frames[count($frames)-1]->getLineno());

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -128,47 +128,47 @@ class DefaultsTest extends BaseRollbarTest
         );
         $this->assertEquals($expected, $this->defaults->scrubFields());
     }
-    
+
     public function testSendMessageTrace()
     {
         $this->assertFalse($this->defaults->sendMessageTrace());
     }
-    
+
     public function testAgentLogLocation()
     {
         $this->assertEquals('/var/tmp', $this->defaults->agentLogLocation());
     }
-    
+
     public function testAllowExec()
     {
         $this->assertEquals(true, $this->defaults->allowExec());
     }
-    
+
     public function testEndpoint()
     {
         $this->assertEquals('https://api.rollbar.com/api/1/', $this->defaults->endpoint());
     }
-    
+
     public function testCaptureErrorStacktraces()
     {
         $this->assertTrue($this->defaults->captureErrorStacktraces());
     }
-    
+
     public function testCheckIgnore()
     {
         $this->assertNull($this->defaults->checkIgnore());
     }
-    
+
     public function testCodeVersion()
     {
         $this->assertEquals("", $this->defaults->codeVersion());
     }
-    
+
     public function testCustom()
     {
         $this->assertNull($this->defaults->custom());
     }
-    
+
     public function testEnabled()
     {
         $this->assertTrue($this->defaults->enabled());
@@ -183,47 +183,47 @@ class DefaultsTest extends BaseRollbarTest
     {
         $this->assertFalse($this->defaults->logPayload());
     }
-    
+
     public function testEnvironment()
     {
         $this->assertEquals('production', $this->defaults->environment());
     }
-    
+
     public function testErrorSampleRates()
     {
         $this->assertEmpty($this->defaults->errorSampleRates());
     }
-    
+
     public function testExceptionSampleRates()
     {
         $this->assertEmpty($this->defaults->exceptionSampleRates());
     }
-    
+
     public function testFluentHost()
     {
         $this->assertEquals('127.0.0.1', $this->defaults->fluentHost());
     }
-    
+
     public function testFluentPort()
     {
         $this->assertEquals(24224, $this->defaults->fluentPort());
     }
-    
+
     public function testFluentTag()
     {
         $this->assertEquals('rollbar', $this->defaults->fluentTag());
     }
-    
+
     public function testHandler()
     {
         $this->assertEquals('blocking', $this->defaults->handler());
     }
-    
+
     public function testHost()
     {
         $this->assertNull($this->defaults->host());
     }
-    
+
     public function testIncludedErrno()
     {
         $this->assertEquals(
@@ -231,42 +231,42 @@ class DefaultsTest extends BaseRollbarTest
             $this->defaults->includedErrno()
         );
     }
-    
+
     public function testTimeout()
     {
         $this->assertEquals(3, $this->defaults->timeout());
     }
-    
+
     public function testReportSuppressed()
     {
         $this->assertFalse($this->defaults->reportSuppressed());
     }
-    
+
     public function testUseErrorReporting()
     {
         $this->assertFalse($this->defaults->useErrorReporting());
     }
-    
+
     public function testCaptureEmail()
     {
         $this->assertFalse($this->defaults->captureEmail());
     }
-    
+
     public function testCaptureUsername()
     {
         $this->assertFalse($this->defaults->captureUsername());
     }
-    
+
     public function testMaxItems()
     {
         $this->assertEquals(10, $this->defaults->maxItems());
     }
-    
+
     public function testRaiseOnError()
     {
         $this->assertEquals(false, $this->defaults->raiseOnError());
     }
-    
+
     public function testDefaultsForConfigOptions()
     {
         foreach (\Rollbar\Config::listOptions() as $option) {
@@ -287,11 +287,13 @@ class DefaultsTest extends BaseRollbarTest
             } elseif ($option == 'root') {
                 $option = 'server_root';
             }
-            
+
             $this->defaults->fromSnakeCase($option);
         }
+
+        $this->expectNotToPerformAssertions();
     }
-    
+
     public function testFromSnakeCase()
     {
         $this->assertEquals(

--- a/tests/Monolog/Handler/RollbarHandlerMonolog1Test.php
+++ b/tests/Monolog/Handler/RollbarHandlerMonolog1Test.php
@@ -16,24 +16,25 @@ if (\Monolog\Logger::API != 1) {
     return;
 }
 
-require_once dirname(__FILE__) . '/../../TestHelpers/Monolog1TestCase.php'; 
+require_once dirname(__FILE__) . '/../../TestHelpers/Monolog1TestCase.php';
 
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use Rollbar\Monolog\Monolog1TestCase;
 use Monolog\Logger;
 use Rollbar\Monolog\Handler\RollbarHandler;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
 use Rollbar\RollbarLogger;
 
 /**
  * @author Erik Johansson <erik.pm.johansson@gmail.com>
  * @see    https://rollbar.com/docs/notifier/rollbar-php/
  *
- * @coversDefaultClass Monolog\Handler\RollbarHandler
- * 
+ * @coversDefaultClass \Monolog\Handler\RollbarHandler
+ *
  * @requires PHP 7
  */
-class RollbarHandlerTest extends Monolog1TestCase
+class RollbarHandlerMonolog1Test extends Monolog1TestCase
 {
     /**
      * @var MockObject
@@ -71,7 +72,7 @@ class RollbarHandlerTest extends Monolog1TestCase
             'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
             'environment' => 'test'
         );
-        
+
         $this->rollbarLogger = $this->getMockBuilder('Rollbar\RollbarLogger')
             ->setConstructorArgs(array($config))
             ->setMethods(array('log'))

--- a/tests/Monolog/Handler/RollbarHandlerMonolog2Test.php
+++ b/tests/Monolog/Handler/RollbarHandlerMonolog2Test.php
@@ -19,22 +19,22 @@ if (\Monolog\Logger::API != 2) {
 use Exception;
 use Monolog\Test\TestCase;
 use Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
 use Rollbar\Monolog\Handler\RollbarHandler;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Rollbar\RollbarLogger;
 
 /**
  * @author Erik Johansson <erik.pm.johansson@gmail.com>
  * @see    https://rollbar.com/docs/notifier/rollbar-php/
  *
- * @coversDefaultClass Monolog\Handler\RollbarHandler
- * 
+ * @coversDefaultClass \Monolog\Handler\RollbarHandler
+ *
  * @requires PHP 7
  */
-class RollbarHandlerTest extends TestCase
+class RollbarHandlerMonolog2Test extends TestCase
 {
     /**
-     * @var MockObject
+     * @var MockObject|RollbarLogger
      */
     private $rollbarLogger;
 
@@ -69,8 +69,8 @@ class RollbarHandlerTest extends TestCase
             'access_token' => 'ad865e76e7fb496fab096ac07b1dbabb',
             'environment' => 'test'
         );
-        
-        $this->rollbarLogger = $this->getMockBuilder('Rollbar\RollbarLogger')
+
+        $this->rollbarLogger = $this->getMockBuilder(RollbarLogger::class)
             ->setConstructorArgs(array($config))
             ->setMethods(array('log'))
             ->getMock();

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -5,22 +5,22 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
     public function testEncode()
     {
         $expected = '{"foo":"bar"}';
-        
+
         $data = array(
             "foo" => "bar"
         );
-        
+
         $encoded = new EncodedPayload($data);
         $encoded->encode();
-        
+
         $this->assertEquals($expected, $encoded);
-        
+
         $expected = '{"new":"bar"}';
         $encoded->encode(array("new" => "bar"));
-        
+
         $this->assertEquals($expected, $encoded);
     }
-    
+
     /**
      * @requires PHP 5.5
      */
@@ -40,39 +40,9 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
             )
         ));
         $encoded->encode();
-        
+
         $result = json_decode($encoded->encoded(), true);
-        
-        if (defined('HHVM_VERSION')) {
-            $this->assertEmpty($result['data']['body']['exception']['trace']['frames']);
-        } else {
-            $this->assertNull($result['data']['body']['exception']['trace']['frames']);
-        }
-    }
-    
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Payload data could not be encoded to JSON format.
-     */
-    public function testEncodeMalformedDataPHP54()
-    {
-        if (version_compare(phpversion(), "5.4")) {
-            $this->markTestSkipped("PHP = 5.4");
-        }
-        
-        $encoded = new EncodedPayload(array(
-            'data' => array(
-                'body' => array(
-                    'exception' => array(
-                        'trace' => array(
-                            'frames' => fopen('/dev/null', 'r')
-                        ),
-                    ),
-                    'ecodable1' => true
-                ),
-                'ecodable2' => true
-            )
-        ));
-        $encoded->encode();
+
+        $this->assertEmpty($result['data']['body']['exception']['trace']['frames']);
     }
 }

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -35,7 +35,7 @@ class ReadmeTest extends BaseRollbarTest
 
         // Message at level 'info'
         Rollbar::log(Level::INFO, 'testing info level');
-       
+
         // With extra data (3rd arg) and custom payload options (4th arg)
         Rollbar::log(
             Level::INFO,
@@ -97,7 +97,7 @@ class ReadmeTest extends BaseRollbarTest
                 'environment' => 'test'
             )
         );
-        
+
         try {
             do_something();
         } catch (\Exception $e) {
@@ -105,7 +105,7 @@ class ReadmeTest extends BaseRollbarTest
             // or
             $result2 = Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
-        
+
         $this->assertEquals(200, $result1->getStatus());
         $this->assertEquals(200, $result2->getStatus());
     }
@@ -118,14 +118,14 @@ class ReadmeTest extends BaseRollbarTest
                 'environment' => 'test'
             )
         );
-        
+
         $result1 = Rollbar::log(Level::WARNING, 'could not connect to mysql server');
         $result2 = Rollbar::log(
             Level::INFO,
             'Here is a message with some additional data',
             array('x' => 10, 'code' => 'blue')
         );
-        
+
         $this->assertEquals(200, $result1->getStatus());
         $this->assertEquals(200, $result2->getStatus());
     }
@@ -138,12 +138,14 @@ class ReadmeTest extends BaseRollbarTest
                 'environment' => 'development'
             )
         );
-        
+
         // create a log channel
         $log = new Logger('RollbarHandler');
         $log->pushHandler(new RollbarHandler(Rollbar::logger(), Logger::WARNING));
-        
+
         // add records to the log
         $log->warning('Foo');
+
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -8,39 +8,39 @@ use Psr\Log\LogLevel as PsrLogLevel;
 
 class RollbarLoggerTest extends BaseRollbarTest
 {
-    
+
     public function setUp()
     {
         $_SESSION = array();
         parent::setUp();
     }
-    
+
     public function tearDown()
     {
         Rollbar::destroy();
         parent::tearDown();
     }
-    
+
     public function testAddCustom()
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php"
         ));
-        
+
         $logger->addCustom("foo", "bar");
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::INFO,
             "This test message should have custom data attached.",
             array()
         );
-        
+
         $customData = $result->getCustom();
         $this->assertEquals("bar", $customData["foo"]);
-        
+
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
@@ -48,21 +48,21 @@ class RollbarLoggerTest extends BaseRollbarTest
                 "baz" => "xyz"
             )
         ));
-        
+
         $logger->addCustom("foo", "bar");
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::INFO,
             "This test message should have custom data attached.",
             array()
         );
-        
+
         $customData = $result->getCustom();
         $this->assertEquals("bar", $customData["foo"]);
     }
-    
+
     public function testRemoveCustom()
     {
         $logger = new RollbarLogger(array(
@@ -73,22 +73,22 @@ class RollbarLoggerTest extends BaseRollbarTest
                 "bar" => "xyz"
             )
         ));
-        
+
         $logger->removeCustom("foo");
-        
+
         $dataBuilder = $logger->getDataBuilder();
-        
+
         $result = $dataBuilder->makeData(
             Level::INFO,
             "This test message should have custom data attached.",
             array()
         );
-        
+
         $customData = $result->getCustom();
         $this->assertFalse(isset($customData["foo"]));
         $this->assertEquals("xyz", $customData["bar"]);
     }
-    
+
     public function testGetCustom()
     {
         $logger = new RollbarLogger(array(
@@ -99,9 +99,9 @@ class RollbarLoggerTest extends BaseRollbarTest
                 "bar" => "xyz"
             )
         ));
-        
+
         $custom = $logger->getCustom();
-        
+
         $this->assertEquals("bar", $custom["foo"]);
         $this->assertEquals("xyz", $custom["bar"]);
     }
@@ -139,7 +139,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             "log_payload_logger" => $logPayloadLoggerMock
         ));
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier");
-        
+
         $this->assertEquals(200, $response->getStatus());
     }
 
@@ -165,7 +165,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             ->getMock();
 
         $handlerMock->setLevel($originalHandler->getLevel());
-        
+
         $handlerMock->expects($this->never())->method('handle');
 
         $verboseLogger->setHandlers(array($handlerMock));
@@ -196,7 +196,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         $logger->info('Internal message');
     }
-    
+
     public function testEnabled()
     {
         $logger = new RollbarLogger(array(
@@ -206,7 +206,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
         $this->assertEquals(200, $response->getStatus());
-        
+
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
@@ -269,7 +269,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(0, $response->getStatus());
         $this->assertEquals("Not transmitting (transmitting disabled in configuration)", $response->getInfo());
     }
-    
+
     public function testLogMalformedPayloadData()
     {
         $logger = new RollbarLogger(array(
@@ -277,13 +277,13 @@ class RollbarLoggerTest extends BaseRollbarTest
             "environment" => "testing-php",
             "transformer" => '\Rollbar\TestHelpers\MalformedPayloadDataTransformer'
         ));
-        
+
         $response = $logger->log(
             Level::ERROR,
             "Forced payload's data to false value.",
             array()
         );
-        
+
         $this->assertEquals(400, $response->getStatus());
     }
 
@@ -312,7 +312,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         $response = $logger->flush();
     }
-    
+
     public function testContext()
     {
         $l = new RollbarLogger(array(
@@ -328,7 +328,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         );
         $this->assertEquals(200, $response->getStatus());
     }
-    
+
     public function testLogStaticLevel()
     {
         $l = new RollbarLogger(array(
@@ -373,11 +373,11 @@ class RollbarLoggerTest extends BaseRollbarTest
             )
         ));
         $response = $l->log(Level::ERROR, new SilentExceptionSampleRate);
-        
+
         $this->assertEquals(0, $response->getStatus());
-        
+
         $response = $l->log(Level::ERROR, new \Exception);
-        
+
         $this->assertEquals(200, $response->getStatus());
     }
 
@@ -402,17 +402,17 @@ class RollbarLoggerTest extends BaseRollbarTest
         );
         $this->assertEquals(0, $response->getStatus());
     }
-    
+
     private function scrubTestHelper($config = array(), $context = array())
     {
         $scrubFields = array('sensitive');
-        
+
         $defaultConfig = array(
             'access_token' => $this->getTestAccessToken(),
             'environment' => 'tests',
             'scrub_fields' => $scrubFields
         );
-        
+
         $config = new Config(array_replace_recursive($defaultConfig, $config));
 
         $dataBuilder = $config->getDataBuilder();
@@ -423,10 +423,10 @@ class RollbarLoggerTest extends BaseRollbarTest
         $scrubber = $config->getScrubber();
 
         $result = $scrubber->scrub($scrubbed);
-        
+
         return $result;
     }
-    
+
     /**
      * @param string $dataName Human-readable name of the type of data under test
      * @param array $result The result of the code under test
@@ -441,7 +441,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $recursive = true,
         $replacement = '*'
     ) {
-    
+
         $this->assertEquals(
             str_repeat($replacement, 8),
             $result[$scrubField],
@@ -456,7 +456,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             );
         }
     }
-    
+
     public function scrubDataProvider()
     {
         return array(
@@ -472,7 +472,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             )
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -482,8 +482,8 @@ class RollbarLoggerTest extends BaseRollbarTest
         $result = $this->scrubTestHelper();
         $this->scrubTestAssert('$_GET', $result['data']['request']['GET']);
     }
-    
-    
+
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -503,14 +503,14 @@ class RollbarLoggerTest extends BaseRollbarTest
         $result = $this->scrubTestHelper();
         $this->scrubTestAssert('$_SESSION', $result['data']['request']['session']);
     }
-    
+
     public function testGetScrubbedHeaders()
     {
         $_SERVER['HTTP_CONTENT_TYPE'] = 'text/html; charset=utf-8';
         $_SERVER['HTTP_SENSITIVE'] = 'Scrub this';
-        
+
         $scrubField = 'Sensitive';
-        
+
         $result = $this->scrubTestHelper(array('scrub_fields' => array($scrubField)));
         $this->scrubTestAssert(
             'Headers',
@@ -528,15 +528,15 @@ class RollbarLoggerTest extends BaseRollbarTest
         $extras = array(
             'extraField1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(array('requestExtras' => $extras));
-        
+
         $this->scrubTestAssert(
             "Request extras",
             $result['data']['request']['extraField1']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -545,15 +545,15 @@ class RollbarLoggerTest extends BaseRollbarTest
         $extras = array(
             'extraField1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(array('serverExtras' => $extras));
-        
+
         $this->scrubTestAssert(
             "Server extras",
             $result['data']['server']['extraField1']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -567,7 +567,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             $result['data']['custom']
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -582,20 +582,20 @@ class RollbarLoggerTest extends BaseRollbarTest
                 )
             )
         );
-        
+
         $this->assertEquals(
             str_repeat('*', 8),
             $result['data']['person']['sensitive'],
             "Person did not get scrubbed."
         );
-        
+
         $this->assertNotEquals(
             str_repeat('*', 8),
             $result['data']['person']['recursive']['sensitive'],
             "Person recursive.sensitive DID get scrubbed even though it's whitelisted."
         );
     }
-    
+
     /**
      * @dataProvider scrubDataProvider
      */
@@ -604,7 +604,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $bodyContext = array(
             'context1' => $testData
         );
-        
+
         $result = $this->scrubTestHelper(
             array('custom' => $bodyContext),
             $bodyContext
@@ -615,18 +615,18 @@ class RollbarLoggerTest extends BaseRollbarTest
             $result['data']['body']['extra']['context1']
         );
     }
-    
+
     public function scrubQueryStringDataProvider()
     {
         $data = $this->scrubDataProvider();
-        
+
         foreach ($data as &$test) {
             $test[0] = http_build_query($test[0]);
         }
-        
+
         return $data;
     }
-    
+
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
@@ -634,7 +634,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['REQUEST_URI'] = "/index.php?$testData";
-        
+
         $result = $this->scrubTestHelper();
         $parsed = array();
         parse_str(parse_url($result['data']['request']['url'], PHP_URL_QUERY), $parsed);
@@ -647,18 +647,18 @@ class RollbarLoggerTest extends BaseRollbarTest
             'x' // query string is scrubbed with "x" rather than "*"
         );
     }
-    
+
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
     public function testGetRequestScrubQueryString($testData)
     {
         $_SERVER['QUERY_STRING'] = "?$testData";
-        
+
         $result = $this->scrubTestHelper();
         $parsed = array();
         parse_str($result['data']['request']['query_string'], $parsed);
-        
+
         $this->scrubTestAssert(
             "Query string",
             $parsed,
@@ -677,6 +677,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->emergency("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Alert()
@@ -688,6 +689,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->alert("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Critical()
@@ -699,6 +701,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->critical("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Error()
@@ -710,6 +713,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->error("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Warning()
@@ -721,6 +725,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->warning("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Notice()
@@ -732,6 +737,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->notice("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Info()
@@ -743,6 +749,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->info("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
 
     public function testPsr3Debug()
@@ -754,8 +761,9 @@ class RollbarLoggerTest extends BaseRollbarTest
 
         // Test that no \Psr\Log\InvalidArgumentException is thrown
         $l->debug("Testing PHP Notifier");
+        $this->expectNotToPerformAssertions();
     }
-    
+
     /**
      * @dataProvider maxItemsProvider
      */
@@ -765,19 +773,19 @@ class RollbarLoggerTest extends BaseRollbarTest
         if ($maxItemsConfig !== null) {
             $config['max_items'] = $maxItemsConfig;
         }
-        
+
         Rollbar::init($config);
         $logger = Rollbar::logger();
-        
+
         $maxItems = $maxItemsConfig === null ? Defaults::get()->maxItems() : $maxItemsConfig;
-        
+
         for ($i = 0; $i < $maxItems; $i++) {
             $response = $logger->log(Level::INFO, 'testing info level');
             $this->assertEquals(200, $response->getStatus());
         }
-      
+
         $response = $logger->log(Level::INFO, 'testing info level');
-        
+
         $this->assertEquals(0, $response->getStatus());
         $this->assertEquals(
             "Maximum number of items per request has been reached. If you " .
@@ -786,7 +794,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             $response->getInfo()
         );
     }
-    
+
     public function maxItemsProvider()
     {
         return array(
@@ -794,18 +802,17 @@ class RollbarLoggerTest extends BaseRollbarTest
             'use provided max_items' => array(3)
         );
     }
-    
-    /**
-     * @expectedException Exception
-     */
+
     public function testRaiseOnError()
     {
+        $this->expectException(\Exception::class);
+
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => 'test',
             "raise_on_error" => true
         ));
-        
+
         try {
             throw new \Exception();
         } catch (\Exception $ex) {

--- a/tests/TestHelpers/Monolog1TestCase.php
+++ b/tests/TestHelpers/Monolog1TestCase.php
@@ -19,8 +19,9 @@
 namespace Rollbar\Monolog;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-class Monolog1TestCase extends \PHPUnit_Framework_TestCase
+abstract class Monolog1TestCase extends TestCase
 {
     /**
      * @return array Record
@@ -53,7 +54,7 @@ class Monolog1TestCase extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Monolog\Formatter\FormatterInterface
+     * @return \Monolog\Formatter\FormatterInterface
      */
     protected function getIdentityFormatter()
     {

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -66,13 +66,13 @@ class UtilitiesTest extends BaseRollbarTest
 
     public function testValidateBooleanThrowsException()
     {
-        $this->setExpectedException(get_class(new \InvalidArgumentException()));
+        $this->expectException(\InvalidArgumentException::class);
         Utilities::validateBoolean(null, "foo", false);
     }
 
     public function testValidateBooleanWithInvalidBoolean()
     {
-        $this->setExpectedException(get_class(new \InvalidArgumentException()));
+        $this->expectException(\InvalidArgumentException::class);
         Utilities::validateBoolean("not a boolean");
     }
 
@@ -81,6 +81,7 @@ class UtilitiesTest extends BaseRollbarTest
         Utilities::validateBoolean(true, "foo", false);
         Utilities::validateBoolean(true);
         Utilities::validateBoolean(null);
+        $this->expectNotToPerformAssertions();
     }
 
     public function testSerializeForRollbar()
@@ -109,7 +110,7 @@ class UtilitiesTest extends BaseRollbarTest
         $this->assertArrayNotHasKey("myNullValue", $result);
         $this->assertArrayNotHasKey("my_null_value", $result);
     }
-    
+
     public function testSerializationCycleChecking()
     {
         $config = new Config(array("access_token"=>$this->getTestAccessToken()));
@@ -122,19 +123,19 @@ class UtilitiesTest extends BaseRollbarTest
             "serializedObj" => new ParentCycleCheckSerializable(),
         );
         $objectHashes = array();
-        
+
         $result = Utilities::serializeForRollbar($obj, null, $objectHashes);
-        
+
         $this->assertRegExp(
             '/<CircularReference.*/',
             $result["obj"]["value"]["child"]["value"]["parent"]
         );
-        
+
         $this->assertRegExp(
             '/<CircularReference.*/',
             $result["serializedObj"]["child"]["parent"]
         );
-        
+
         $this->assertRegExp(
             '/<CircularReference.*/',
             $result["payload"]["data"]["body"]["extra"][0]["value"]["child"]["value"]["parent"]
@@ -152,7 +153,7 @@ class UtilitiesTest extends BaseRollbarTest
                 ),
             ),
         );
-        
+
         $objectHashes = array();
         $result = Utilities::serializeForRollbar($obj, null, $objectHashes, 2);
         $this->assertArrayHasKey('one', $result);


### PR DESCRIPTION
Explicitly declares the supported PHP version and upgrades to a supported PHPUnit version. Resolves windows related issues with tests. Resolves risky test errors using PHPUnit 7 features. 

These changes seek toallow PHP 7.1+ features to be used in future PRs.