### PR TITLE
Fix compatibility with ext-ds

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -120,7 +120,7 @@ final class Utilities
             
             if ($customKeys !== null && in_array($key, $customKeys)) {
                 $returnVal[$key] = $val;
-            } elseif (!is_null($val)) {
+            } elseif (!is_null($val) && !is_object($key)) {
                 $returnVal[$key] = $val;
             }
         }


### PR DESCRIPTION
Some ext-ds structures like [Map](https://www.php.net/manual/en/class.ds-map.php) can implement Traversable and use objects as keys. This causes `Warning: Illegal offset type` in your library.