### PR TITLE
Fix Error when handling invalid reponses from rollbar in php7.4.

### DIFF
--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -118,7 +118,7 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->error('Occurrence rejected by the SDK: ' . $response);
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
-            $this->verboseLogger()->error('Occurrence rejected by the API: ' . $info['message']);
+            $this->verboseLogger()->error('Occurrence rejected by the API: ' . (isset($info['message']) ? $info['message'] : 'mesage not set'));
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');
         }


### PR DESCRIPTION
Mitigating Array-style access of non-arrays in php 7.4

Prevents ErrorException: Trying to access array offset on value of type null.