### PR TITLE
Add support for php 7.3 and 7.4 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 dist: trusty
 
 php:
+  - 7.4
+  - 7.3
   - 7.2
   - 7.1
 

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,6 @@
   },
   
   "config": {
-    "process-timeout": 600,
+    "process-timeout": 600
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "4.8.* || ^8",
+    "phpunit/phpunit": "4.8.* || 6.5.* || ^8",
     "mockery/mockery": "1.*",
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",
@@ -61,6 +61,9 @@
   },
   
   "config": {
-    "process-timeout": 600
+    "process-timeout": 600,
+    "platform": {
+      "php": "7.1"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "4.8.* || ^5",
-    "mockery/mockery": "0.9.*",
+    "phpunit/phpunit": "4.8.* || ^8",
+    "mockery/mockery": "1.*",
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",
     "packfire/php5.3-compat": "*",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "4.8.* || 6.5.* || ^8",
+    "phpunit/phpunit": "4.8.* || 5.7.* || ^8",
     "mockery/mockery": "1.*",
     "squizlabs/php_codesniffer": "2.*",
     "codeclimate/php-test-reporter": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,5 @@
   
   "config": {
     "process-timeout": 600,
-    "platform": {
-      "php": "7.1"
-    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,8 +6,7 @@
 	 convertErrorsToExceptions="true"
 	 convertNoticesToExceptions="true"
 	 convertWarningsToExceptions="true"
-	 stopOnFailure="false"
-	 syntaxCheck="false">
+	 stopOnFailure="false">
   <testsuites>
     <testsuite name="Rollbar Test Suite">
       <directory suffix=".php">./tests/</directory>

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1135,7 +1135,7 @@ class DataBuilder implements DataBuilderInterface
             if ($fatalHandlerMethod ||
                  $fatalHandlerClassAndFunction ||
                  $errorHandlerMethod ||
-                 $errorHandlerClassAndFunction ) {
+                 $errorHandlerClassAndFunction) {
                 return array_slice($backTrace, $index+1);
             }
         }

--- a/src/Monolog/Handler/RollbarHandler.php
+++ b/src/Monolog/Handler/RollbarHandler.php
@@ -2,14 +2,14 @@
 
 /*
  * !!! DEPRECATED AS OF 8/4/2018 !!!
- * 
+ *
  * Please, do not use this class anymore to use Rollbar with Monolog anymore.
  * The Monolog library includes a dedicated handler now here:
  * https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/RollbarHandler.php
  *
  * Using Monolog's handler is the recommended approach when using Rollbar
  * with Monolog.
- * 
+ *
  * This file is part of the Monolog package.
  *
  * (c) Jordi Boggiano <j.boggiano@seld.be>

--- a/src/Payload/EncodedPayload.php
+++ b/src/Payload/EncodedPayload.php
@@ -46,7 +46,7 @@ class EncodedPayload
     
     public function __toString()
     {
-        return $this->encoded();
+        return (string)$this->encoded();
     }
     
     public function encoded()

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -118,7 +118,8 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->error('Occurrence rejected by the SDK: ' . $response);
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
-            $this->verboseLogger()->error('Occurrence rejected by the API: ' . (isset($info['message']) ? $info['message'] : 'mesage not set'));
+            $this->verboseLogger()->error('Occurrence rejected by the API: ' . (isset($info['message']) ?
+                    $info['message'] : 'mesage not set'));
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');
         }

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -72,7 +72,7 @@ class CurlSender implements SenderInterface
         curl_close($handle);
 
         $data = $payload->data();
-        $uuid = $data['data']['uuid'];
+        $uuid = $data['data']['uuid'] ?? null;
         
         return new Response($statusCode, $result, $uuid);
     }

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -13,7 +13,7 @@ class AgentTest extends Rollbar\BaseRollbarTest
 {
     private $path = '/tmp/rollbar-php';
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!file_exists($this->path)) {
             mkdir($this->path);
@@ -35,7 +35,7 @@ class AgentTest extends Rollbar\BaseRollbarTest
         $this->assertContains('this is a test', $line);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->rrmdir($this->path);

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,8 +1,7 @@
 <?php namespace Rollbar;
 
-abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
+abstract class BaseRollbarTest extends \PHPUnit\Framework\TestCase
 {
-    
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
     
     public function tearDown(): void

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,11 +1,13 @@
 <?php namespace Rollbar;
 
-abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseRollbarTest extends TestCase
 {
     
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
     
-    public function tearDown()
+    public function tearDown(): void
     {
         Rollbar::destroy();
         parent::tearDown();

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,7 +1,10 @@
 <?php namespace Rollbar;
 
-abstract class BaseRollbarTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseRollbarTest extends TestCase
 {
+
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
     
     public function tearDown(): void

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -1,8 +1,6 @@
 <?php namespace Rollbar;
 
-use PHPUnit\Framework\TestCase;
-
-abstract class BaseRollbarTest extends TestCase
+abstract class BaseRollbarTest extends \PHPUnit_Framework_TestCase
 {
     
     const DEFAULT_ACCESS_TOKEN = 'ad865e76e7fb496fab096ac07b1dbabb';
@@ -12,7 +10,7 @@ abstract class BaseRollbarTest extends TestCase
         Rollbar::destroy();
         parent::tearDown();
     }
-    
+
     public function getTestAccessToken()
     {
         return isset($_ENV['ROLLBAR_TEST_TOKEN']) ?

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -97,32 +97,32 @@ class ConfigTest extends BaseRollbarTest
         $this->assertTrue($config->loggingPayload());
     }
 
-    public function testLoggingPayload()
-    {
-        $logPayloadLoggerMock = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
-        $logPayloadLoggerMock->expects($this->once())
-                        ->method('debug')
-                        ->with(
-                            $this->matchesRegularExpression(
-                                '/Sending payload with .*:\n\{"data":/'
-                            )
-                        );
-        $senderMock = $this->getMockBuilder('\Rollbar\Senders\SenderInterface')
-                        ->getMock();
-        $senderMock->method('send')->willReturn(true);
-
-        $payload = new \Rollbar\Payload\EncodedPayload(array('data'=>array()));
-        $payload->encode();
-
-        $config = new Config(array(
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "log_payload" => true,
-            "log_payload_logger" => $logPayloadLoggerMock,
-            "sender" => $senderMock
-        ));
-        $config->send($payload, $this->getTestAccessToken());
-    }
+//    public function testLoggingPayload()
+//    {
+//        $logPayloadLoggerMock = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+//        $logPayloadLoggerMock->expects($this->once())
+//                        ->method('debug')
+//                        ->with(
+//                            $this->matchesRegularExpression(
+//                                '/Sending payload with .*:\n\{"data":/'
+//                            )
+//                        );
+//        $senderMock = $this->getMockBuilder('\Rollbar\Senders\SenderInterface')
+//                        ->getMock();
+//        $senderMock->method('send')->willReturn(true);
+//
+//        $payload = new \Rollbar\Payload\EncodedPayload(array('data'=>array()));
+//        $payload->encode();
+//
+//        $config = new Config(array(
+//            "access_token" => $this->getTestAccessToken(),
+//            "environment" => "testing-php",
+//            "log_payload" => true,
+//            "log_payload_logger" => $logPayloadLoggerMock,
+//            "sender" => $senderMock
+//        ));
+//        $config->send($payload, $this->getTestAccessToken());
+//    }
 
     public function testConfigureLogPayloadLogger()
     {
@@ -167,24 +167,24 @@ class ConfigTest extends BaseRollbarTest
         $this->assertEquals($config->verboseInteger(), $handler->getLevel());
     }
 
-    public function testVerboseInfo()
-    {
-        $config = new Config(array(
-            'access_token' => $this->getTestAccessToken(),
-            'environment' => $this->env,
-            'verbose' => \Psr\Log\LogLevel::INFO
-        ));
-
-        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
-            ->setMethods(array('handle'))
-            ->getMock();
-
-        $handlerMock->expects($this->once())->method('handle');
-
-        $config->verboseLogger()->setHandlers(array($handlerMock));
-
-        $config->verboseLogger()->info('Test trace');
-    }
+//    public function testVerboseInfo()
+//    {
+//        $config = new Config(array(
+//            'access_token' => $this->getTestAccessToken(),
+//            'environment' => $this->env,
+//            'verbose' => \Psr\Log\LogLevel::INFO
+//        ));
+//
+//        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
+//            ->setMethods(array('handle'))
+//            ->getMock();
+//
+//        $handlerMock->expects($this->once())->method('handle');
+//
+//        $config->verboseLogger()->setHandlers(array($handlerMock));
+//
+//        $config->verboseLogger()->info('Test trace');
+//    }
 
     public function testVerboseInteger()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -30,6 +30,7 @@ class ConfigTest extends BaseRollbarTest
             null,
             new Utilities
         );
+        parent::setUp();
     }
 
     public function tearDown(): void
@@ -97,32 +98,32 @@ class ConfigTest extends BaseRollbarTest
         $this->assertTrue($config->loggingPayload());
     }
 
-//    public function testLoggingPayload()
-//    {
-//        $logPayloadLoggerMock = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
-//        $logPayloadLoggerMock->expects($this->once())
-//                        ->method('debug')
-//                        ->with(
-//                            $this->matchesRegularExpression(
-//                                '/Sending payload with .*:\n\{"data":/'
-//                            )
-//                        );
-//        $senderMock = $this->getMockBuilder('\Rollbar\Senders\SenderInterface')
-//                        ->getMock();
-//        $senderMock->method('send')->willReturn(true);
-//
-//        $payload = new \Rollbar\Payload\EncodedPayload(array('data'=>array()));
-//        $payload->encode();
-//
-//        $config = new Config(array(
-//            "access_token" => $this->getTestAccessToken(),
-//            "environment" => "testing-php",
-//            "log_payload" => true,
-//            "log_payload_logger" => $logPayloadLoggerMock,
-//            "sender" => $senderMock
-//        ));
-//        $config->send($payload, $this->getTestAccessToken());
-//    }
+    public function testLoggingPayload()
+    {
+        $logPayloadLoggerMock = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+        $logPayloadLoggerMock->expects($this->once())
+                        ->method('debug')
+                        ->with(
+                            $this->matchesRegularExpression(
+                                '/Sending payload with .*:\n\{"data":/'
+                            )
+                        );
+        $senderMock = $this->getMockBuilder('\Rollbar\Senders\SenderInterface')
+                        ->getMock();
+        $senderMock->method('send')->willReturn(true);
+
+        $payload = new \Rollbar\Payload\EncodedPayload(array('data'=>array()));
+        $payload->encode();
+
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => "testing-php",
+            "log_payload" => true,
+            "log_payload_logger" => $logPayloadLoggerMock,
+            "sender" => $senderMock
+        ));
+        $config->send($payload, $this->getTestAccessToken());
+    }
 
     public function testConfigureLogPayloadLogger()
     {
@@ -167,24 +168,24 @@ class ConfigTest extends BaseRollbarTest
         $this->assertEquals($config->verboseInteger(), $handler->getLevel());
     }
 
-//    public function testVerboseInfo()
-//    {
-//        $config = new Config(array(
-//            'access_token' => $this->getTestAccessToken(),
-//            'environment' => $this->env,
-//            'verbose' => \Psr\Log\LogLevel::INFO
-//        ));
-//
-//        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
-//            ->setMethods(array('handle'))
-//            ->getMock();
-//
-//        $handlerMock->expects($this->once())->method('handle');
-//
-//        $config->verboseLogger()->setHandlers(array($handlerMock));
-//
-//        $config->verboseLogger()->info('Test trace');
-//    }
+    public function testVerboseInfo()
+    {
+        $config = new Config(array(
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => $this->env,
+            'verbose' => \Psr\Log\LogLevel::INFO
+        ));
+
+        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
+            ->setMethods(array('handle'))
+            ->getMock();
+
+        $handlerMock->expects($this->once())->method('handle');
+
+        $config->verboseLogger()->setHandlers(array($handlerMock));
+
+        $config->verboseLogger()->info('Test trace');
+    }
 
     public function testVerboseInteger()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -20,7 +20,7 @@ class ConfigTest extends BaseRollbarTest
 {
     private $error;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->error = new ErrorWrapper(
             E_ERROR,
@@ -32,7 +32,7 @@ class ConfigTest extends BaseRollbarTest
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         m::close();

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -15,13 +15,14 @@ class CurlSenderTest extends BaseRollbarTest
             "endpoint" => "fake-endpoint"
         ));
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
-        
+
         $this->assertTrue(
             in_array(
                 $response->getInfo(),
                 array(
                     "Couldn't resolve host 'fake-endpointitem'", // hack for PHP 5.3
                     "Could not resolve host: fake-endpointitem",
+                    "Could not resolve: fake-endpointitem (Domain name not found)",
                     "Empty reply from server"
                 )
             )

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -13,7 +13,7 @@ class DataBuilderTest extends BaseRollbarTest
      */
     private $dataBuilder;
 
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = array();
         

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -9,7 +9,7 @@ class DataTest extends BaseRollbarTest
     private $body;
     private $data;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->body = m::mock("Rollbar\Payload\Body");
         $this->data = new Data("test", $this->body);

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -12,7 +12,7 @@ class DefaultsTest extends BaseRollbarTest
      */
     private $defaults;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->defaults = new Defaults(new Utilities());
     }

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -8,7 +8,7 @@ class FrameTest extends BaseRollbarTest
     private $exception;
     private $frame;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->exception = m::mock("Rollbar\Payload\ExceptionInfo");
         $this->frame = new Frame("tests/FrameTest.php", $this->exception);

--- a/tests/LevelFactoryTest.php
+++ b/tests/LevelFactoryTest.php
@@ -6,7 +6,7 @@ class LevelFactoryTest extends BaseRollbarTest
 {
     private $levelFactory;
     
-    public function setUp()
+    public function setUp(): void
     {
         $this->levelFactory = new LevelFactory();
     }

--- a/tests/Monolog/Handler/RollbarHandlerMonolog1Test.php
+++ b/tests/Monolog/Handler/RollbarHandlerMonolog1Test.php
@@ -45,7 +45,7 @@ class RollbarHandlerTest extends Monolog1TestCase
      */
     private $reportedExceptionArguments = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Monolog/Handler/RollbarHandlerMonolog2Test.php
+++ b/tests/Monolog/Handler/RollbarHandlerMonolog2Test.php
@@ -43,7 +43,7 @@ class RollbarHandlerTest extends TestCase
      */
     private $reportedExceptionArguments = null;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Performance/TruncationTest.php
+++ b/tests/Performance/TruncationTest.php
@@ -16,7 +16,7 @@ use \Rollbar\BaseRollbarTest;
 class TruncationTest extends BaseRollbarTest
 {
     
-    public function setUp()
+    public function setUp(): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));
         $this->truncate = new Truncation($config);

--- a/tests/RollbarJsHelperTest.php
+++ b/tests/RollbarJsHelperTest.php
@@ -5,7 +5,7 @@ class JsHelperTest extends BaseRollbarTest
     protected $jsHelper;
     protected $testSnippetPath;
     
-    public function setUp()
+    public function setUp(): void
     {
         $this->jsHelper = new RollbarJsHelper(array());
         $this->testSnippetPath = realpath(__DIR__ . "/../data/rollbar.snippet.js");

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -9,13 +9,13 @@ use Psr\Log\LogLevel as PsrLogLevel;
 class RollbarLoggerTest extends BaseRollbarTest
 {
     
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = array();
         parent::setUp();
     }
     
-    public function tearDown()
+    public function tearDown(): void
     {
         Rollbar::destroy();
         parent::tearDown();

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -12,7 +12,7 @@ use Rollbar\Payload\Level;
 class RollbarTest extends BaseRollbarTest
 {
     
-    public function setUp()
+    public function setUp(): void
     {
         self::$simpleConfig['access_token'] = $this->getTestAccessToken();
         self::$simpleConfig['environment'] = 'test';
@@ -20,7 +20,7 @@ class RollbarTest extends BaseRollbarTest
 
     private static $simpleConfig = array();
     
-    public static function setupBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         Rollbar::destroy();
     }

--- a/tests/TestHelpers/Monolog1TestCase.php
+++ b/tests/TestHelpers/Monolog1TestCase.php
@@ -19,9 +19,8 @@
 namespace Rollbar\Monolog;
 
 use Monolog\Logger;
-use PHPUnit\Framework\TestCase;
 
-abstract class Monolog1TestCase extends TestCase
+class Monolog1TestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * @return array Record

--- a/tests/TestHelpers/Monolog1TestCase.php
+++ b/tests/TestHelpers/Monolog1TestCase.php
@@ -21,7 +21,7 @@ namespace Rollbar\Monolog;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 
-class Monolog1TestCase extends TestCase
+abstract class Monolog1TestCase extends TestCase
 {
     /**
      * @return array Record

--- a/tests/TestHelpers/Monolog1TestCase.php
+++ b/tests/TestHelpers/Monolog1TestCase.php
@@ -19,8 +19,9 @@
 namespace Rollbar\Monolog;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 
-class Monolog1TestCase extends \PHPUnit_Framework_TestCase
+class Monolog1TestCase extends TestCase
 {
     /**
      * @return array Record

--- a/tests/TraceChainTest.php
+++ b/tests/TraceChainTest.php
@@ -10,7 +10,7 @@ class TraceChainTest extends Rollbar\BaseRollbarTest
     private $trace1;
     private $trace2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->trace1 = m::mock("Rollbar\Payload\Trace");
         $this->trace2 = m::mock("Rollbar\Payload\Trace");

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -74,12 +74,12 @@ class TruncationTest extends BaseRollbarTest
         foreach ($frames as $key => $data) {
             $frames[$key] = $stringValue;
         }
-        
-        $frames = &$framesTestData['truncate middle using trace_chain key'][0]['data']['body']['trace_chain']['frames'];
+
+        $frames = &$framesTestData['truncate middle using trace_chain key'][0]['data']['body']['trace_chain'][0]['frames'];
         foreach ($frames as $key => $data) {
             $frames[$key] = $stringValue;
         }
-        
+
         $data = array_merge(
             $stringsTest->executeTruncateNothingProvider(),
             $stringsTest->executearrayProvider(),

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -75,7 +75,8 @@ class TruncationTest extends BaseRollbarTest
             $frames[$key] = $stringValue;
         }
 
-        $frames = &$framesTestData['truncate middle using trace_chain key'][0]['data']['body']['trace_chain'][0]['frames'];
+        $frames_body = &$framesTestData['truncate middle using trace_chain key'][0]['data']['body'];
+        $frames = $frames_body['trace_chain'][0]['frames'];
         foreach ($frames as $key => $data) {
             $frames[$key] = $stringValue;
         }

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -9,7 +9,7 @@ use \Rollbar\Payload\EncodedPayload;
 class TruncationTest extends BaseRollbarTest
 {
     
-    public function setUp()
+    public function setUp(): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));
         $this->truncate = new \Rollbar\Truncation\Truncation($config);

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -66,13 +66,13 @@ class UtilitiesTest extends BaseRollbarTest
 
     public function testValidateBooleanThrowsException()
     {
-        $this->setExpectedException(get_class(new \InvalidArgumentException()));
+        $this->expectException(get_class(new \InvalidArgumentException()));
         Utilities::validateBoolean(null, "foo", false);
     }
 
     public function testValidateBooleanWithInvalidBoolean()
     {
-        $this->setExpectedException(get_class(new \InvalidArgumentException()));
+        $this->expectException(get_class(new \InvalidArgumentException()));
         Utilities::validateBoolean("not a boolean");
     }
 

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -66,13 +66,13 @@ class UtilitiesTest extends BaseRollbarTest
 
     public function testValidateBooleanThrowsException()
     {
-        $this->expectException(get_class(new \InvalidArgumentException()));
+        $this->setExpectedException(get_class(new \InvalidArgumentException()));
         Utilities::validateBoolean(null, "foo", false);
     }
 
     public function testValidateBooleanWithInvalidBoolean()
     {
-        $this->expectException(get_class(new \InvalidArgumentException()));
+        $this->setExpectedException(get_class(new \InvalidArgumentException()));
         Utilities::validateBoolean("not a boolean");
     }
 

--- a/tests/VerboseTest.php
+++ b/tests/VerboseTest.php
@@ -358,7 +358,6 @@ class VerbosityTest extends BaseRollbarTest
         $errorReporting = \error_reporting();
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -401,7 +400,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -436,7 +434,6 @@ class VerbosityTest extends BaseRollbarTest
         $errorReporting = \error_reporting();
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -478,7 +475,6 @@ class VerbosityTest extends BaseRollbarTest
         $errorReporting = \error_reporting();
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -521,7 +517,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -556,7 +551,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -591,7 +585,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -639,7 +632,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -674,7 +666,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -712,7 +703,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -747,7 +737,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -782,7 +771,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config) {
             // logic under test
@@ -817,7 +805,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $config,
             function () use ($config, $unitTest) {
             // logic under test
@@ -855,7 +842,6 @@ class VerbosityTest extends BaseRollbarTest
         ));
 
         $this->configurableObjectVerbosityTest(
-
             $rollbarLogger,
             function () use ($rollbarLogger) {
             // logic under test

--- a/tests/VerboseTest.php
+++ b/tests/VerboseTest.php
@@ -26,7 +26,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function setUp()
+    public function setUp(): void
     {
         $_SESSION = array();
         parent::setUp();
@@ -38,7 +38,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->verboseHandlerMock = null;
         Rollbar::destroy();


### PR DESCRIPTION
This includes changes posted by @icsahn-rollbar in #488 
It fixes the failure in Travis jobs at various places. It also fixes minor code formatting issues.

Notably:
PHP 7.1 requires PHPUnit 5.2.7.
syntaxCheck is deprecated 
update phpunit and mockery to latest.