### PR TITLE
Revert "Fix Error when handling invalid reponses from rollbar in php7.4."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 dist: trusty
 
 php:
-  - 7.4     
-  - 7.3     
   - 7.2
   - 7.1
 

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -118,7 +118,7 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->error('Occurrence rejected by the SDK: ' . $response);
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
-            $this->verboseLogger()->error('Occurrence rejected by the API: ' . (isset($info['message']) ? $info['message'] : 'mesage not set'));
+            $this->verboseLogger()->error('Occurrence rejected by the API: ' . $info['message']);
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');
         }


### PR DESCRIPTION
Need to revert these changes as it seems to have broken the build. Apart from supporting php 7.4 we also need to update mockery and phpunit. That means we need to make some changes to tests as well. 

Reverts rollbar/rollbar-php#485