### PR TITLE
Update Readme with correct Travis build status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rollbar-PHP [![Build Status](https://api.travis-ci.org/rollbar/rollbar-php.png)](https://travis-ci.org/rollbar/rollbar-php)
+# Rollbar-PHP [![Build Status](https://travis-ci.org/rollbar/rollbar-php.svg?branch=master)](https://travis-ci.org/rollbar/rollbar-php)
 
 This library detects errors and exceptions in your application and reports them to [Rollbar](https://rollbar.com) for alerts, reporting, and analysis.
 


### PR DESCRIPTION
The build status is not accurately reflecting the status of master branch consistently to different users. 
This change should hopefully reflect the master build status accurately and consistently for different users.