### PR TITLE
Replace Whitelist with Safelist

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -66,7 +66,7 @@ class Config
         'capture_email',
         'root',
         'scrub_fields',
-        'scrub_whitelist',
+        'scrub_safelist',
         'timeout',
         'transmit',
         'custom_truncation',

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -6,13 +6,13 @@ class Scrubber implements ScrubberInterface
 {
     protected static $defaults;
     protected $scrubFields;
-    protected $whitelist;
+    protected $safelist;
 
     public function __construct($config)
     {
         self::$defaults = Defaults::get();
         $this->setScrubFields($config);
-        $this->setWhitelist($config);
+        $this->setSafelist($config);
     }
 
     protected function setScrubFields($config)
@@ -29,18 +29,18 @@ class Scrubber implements ScrubberInterface
         return $this->scrubFields;
     }
 
-    protected function setWhitelist($config)
+    protected function setSafelist($config)
     {
-        $fromConfig = isset($config['scrubWhitelist']) ? $config['scrubWhitelist'] : null;
+        $fromConfig = isset($config['scrubSafelist']) ? $config['scrubSafelist'] : null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['scrub_whitelist']) ? $config['scrub_whitelist'] : null;
+            $fromConfig = isset($config['scrub_safelist']) ? $config['scrub_safelist'] : null;
         }
-        $this->whitelist = $fromConfig ? $fromConfig : array();
+        $this->safelist = $fromConfig ? $fromConfig : array();
     }
 
-    public function getWhitelist()
+    public function getSafelist()
     {
-        return $this->whitelist;
+        return $this->safelist;
     }
 
     /**
@@ -109,7 +109,7 @@ class Scrubber implements ScrubberInterface
             $parent = $path;
             $current = !$path ? $key : $path . '.' . $key;
 
-            if (in_array($current, $scrubber->getWhitelist())) {
+            if (in_array($current, $scrubber->getSafelist())) {
                 return;
             }
 

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -577,7 +577,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $result = $this->scrubTestHelper(
             array(
                 'person' => $testData,
-                'scrub_whitelist' => array(
+                'scrub_safelist' => array(
                     'data.person.recursive.sensitive'
                 )
             )
@@ -592,7 +592,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertNotEquals(
             str_repeat('*', 8),
             $result['data']['person']['recursive']['sensitive'],
-            "Person recursive.sensitive DID get scrubbed even though it's whitelisted."
+            "Person recursive.sensitive DID get scrubbed even though it's safelisted."
         );
     }
     

--- a/tests/ScrubberTest.php
+++ b/tests/ScrubberTest.php
@@ -24,23 +24,23 @@ class ScrubberTest extends BaseRollbarTest
     }
     
     /**
-     * @dataProvider scrubWhitelistProvider
+     * @dataProvider scrubSafelistProvider
      */
-    public function testScrubWhitelist($testData, $scrubFields, $whitelist, $expected)
+    public function testScrubSafelist($testData, $scrubFields, $safelist, $expected)
     {
         $scrubber = new Scrubber(array(
             'scrubFields' => $scrubFields,
-            'scrubWhitelist' => $whitelist
+            'scrubSafelist' => $safelist
         ));
         $result = $scrubber->scrub($testData);
         $this->assertEquals(
             $expected,
             $result,
-            "Looks like whitelisting is not working correctly."
+            "Looks like safelisting is not working correctly."
         );
     }
     
-    public function scrubWhitelistProvider()
+    public function scrubSafelistProvider()
     {
         return array(
             array(


### PR DESCRIPTION
This is a BREAKING CHANGE. Consumers currently relying upon `scrub_whitelist` or `setWhitelist` will need to update their code or configuration to `scrub_safelist` and `setSafelist` respectively.