### PR TITLE
Add isUncaught to context array, remove fourth parameter to log in RollbarLogger

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -58,7 +58,7 @@ class ErrorHandler extends AbstractHandler
                             getDataBuilder()->
                             generateErrorWrapper($errno, $errstr, $errfile, $errline);
 
-        $this->logger()->log(Level::ERROR, $exception, array(), true);
+        $this->logger()->log(Level::ERROR, $exception, array('isUncaught' => true));
 
         return false;
     }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -30,7 +30,7 @@ class ExceptionHandler extends AbstractHandler
         
         $exception = $args[0];
         
-        $this->logger()->log(Level::ERROR, $exception, array(), true);
+        $this->logger()->log(Level::ERROR, $exception, array('isUncaught' => true));
         
         if ($this->previousHandler) {
             restore_exception_handler();

--- a/src/Handlers/FatalHandler.php
+++ b/src/Handlers/FatalHandler.php
@@ -41,7 +41,7 @@ class FatalHandler extends AbstractHandler
                                 getDataBuilder()->
                                 generateErrorWrapper($errno, $errstr, $errfile, $errline);
                                 
-            $this->logger()->log(Level::CRITICAL, $exception, array(), true);
+            $this->logger()->log(Level::CRITICAL, $exception, array('isUncaught' => true));
         }
     }
     

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -92,7 +92,9 @@ class Rollbar
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
-        return self::$logger->log($level, $toLog, (array)$extra, $isUncaught);
+
+        $extra['isUncaught'] = $isUncaught;
+        return self::$logger->log($level, $toLog, (array)$extra);
     }
     
     public static function debug($toLog, $extra = array())

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -74,7 +74,7 @@ class RollbarLogger extends AbstractLogger
         return $this->config->getCustom();
     }
 
-    public function log($level, $toLog, array $context = array(), $isUncaught = false)
+    public function log($level, $toLog, array $context = array())
     {
         if ($this->disabled()) {
             $this->verboseLogger()->notice('Rollbar is disabled');

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -97,7 +97,7 @@ class RollbarLogger extends AbstractLogger
         $accessToken = $this->getAccessToken();
         $payload = $this->getPayload($accessToken, $level, $toLog, $context);
 
-        $isUncaught = $context['isUncaught'] ? $context['isUncaught'] : false;
+        $isUncaught = isset($context['isUncaught']) ? $context['isUncaught'] : false;
         if ($this->config->checkIgnored($payload, $accessToken, $toLog, $isUncaught)) {
             $this->verboseLogger()->info('Occurrence ignored');
             $response = new Response(0, "Ignored");

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -96,7 +96,8 @@ class RollbarLogger extends AbstractLogger
 
         $accessToken = $this->getAccessToken();
         $payload = $this->getPayload($accessToken, $level, $toLog, $context);
-        
+
+        $isUncaught = $context['isUncaught'] ? $context['isUncaught'] : false;
         if ($this->config->checkIgnored($payload, $accessToken, $toLog, $isUncaught)) {
             $this->verboseLogger()->info('Occurrence ignored');
             $response = new Response(0, "Ignored");

--- a/tests/TestHelpers/StdOutLogger.php
+++ b/tests/TestHelpers/StdOutLogger.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerTrait;
 
 class StdOutLogger extends RollbarLogger
 {
-    public function log($level, $message, array $context = array(), $isUncaught = false)
+    public function log($level, $message, array $context = array())
     {
         echo '[' . get_class($this) . ': '. $level . '] ' . $message;
     }


### PR DESCRIPTION
## Description of the change

PSR-3's `LoggerInterface` has a method, `log`, that accepts three arguments: `$level`, `$message`, and `$context`. The `RollbarLogger` accepts four arguments, the fourth being `$isUncaught`. This PR removes that fourth argument to align with the PSR-3 method signature, and instead adds it to the `$context` array. This ensures that the logger follows the PSR-3 standard.

This would break any direct calls to `RollbarLogger` - I fixed any direct reference to this class here in the src code, but anybody consuming this code outside would need to update their code to match the new parameter structure. If this is a major concern we might be able to find a way to retrieve the fourth argument when it's passed in and throw a warning up while still adding it to context. I'd be happy to make that change if that's desired.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
