### PR TITLE
Support Xdebug 3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,15 @@ jobs:
           - php: 7.4
             ini: zend.exception_ignore_args=Off
         exclude:
-          # xdebug3-mode compatible only with PHP > 7.2, so exclude from earlier verions
+          # We only have XDebug 3 in PHP > 7.3, and the ini value will be ignored in
+          # all earlier versions. We can prune out one of them, because the result of
+          # both runs in these earlier versions are the same (because the ini directive
+          # is completely ignored, no matter its value).
           # @see https://xdebug.org/docs/compat
           - php: 7.2
             xdebug3-mode: "xdebug.mode=develop,coverage"
-          - php: 7.2
-            xdebug3-mode: "xdebug.mode=coverage"
           - php: 7.1
             xdebug3-mode: "xdebug.mode=develop,coverage"
-          - php: 7.1
-            xdebug3-mode: "xdebug.mode=coverage"
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           # backtraces. The default in 7.4 is On. However, we have tests that
           # rely on arguments being available, so we turn it Off.
           - php: 7.4
-            ini: zend.exception_ignore_args=Off
+            ini: zend.exception_ignore_args=Off xdebug.mode=develop,coverage
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,35 @@ jobs:
   php-tests:
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2, 7.1]
-        dependency: [stable]
-        os: [ubuntu]
+        # All the versions, OS, and dependency levels we want to support
+        php: [7.4, 7.3, 7.2, 7.1] # TODO: 8.0, 7.0, 5.6, 5.5
+        dependency: [stable]      # TODO: lowest
+        os: [ubuntu]              # TODO: windows, macos
+        # In XDebug 2 and earlier, if XDebug extension was present, the function
+        # xdebug_get_function_stack() was unconditionally available. Now in XDebug 3
+        # that function is present only when xdebug.mode includes "develop". Our code
+        # has paths for with- and without- XDebug, and we want to test both of them.
+        # However, we require XDebug for code coverage, so before XDebug 3 there was
+        # no way to test the without-XDebug code path. Now we can, so we do.
+        # @see https://xdebug.org/docs/all_settings#mode
+        xdebug3-mode: ["xdebug.mode=develop,coverage", "xdebug.mode=coverage"]
         include:
           # 7.4 introduced an engine wide flag that disables arguments in
           # backtraces. The default in 7.4 is On. However, we have tests that
           # rely on arguments being available, so we turn it Off.
           - php: 7.4
-            ini: zend.exception_ignore_args=Off, xdebug.mode=develop,coverage
+            ini: zend.exception_ignore_args=Off
+        exclude:
+          # xdebug3-mode compatible only with PHP > 7.2, so exclude from earlier verions
+          # @see https://xdebug.org/docs/compat
+          - php: 7.2
+            xdebug3-mode: "xdebug.mode=develop,coverage"
+          - php: 7.2
+            xdebug3-mode: "xdebug.mode=coverage"
+          - php: 7.1
+            xdebug3-mode: "xdebug.mode=develop,coverage"
+          - php: 7.1
+            xdebug3-mode: "xdebug.mode=coverage"
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest
@@ -47,7 +67,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: ${{ matrix.ini }}
+          ini-values: ${{ matrix.ini }}, ${{ xdebug3-mode }}
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           # backtraces. The default in 7.4 is On. However, we have tests that
           # rely on arguments being available, so we turn it Off.
           - php: 7.4
-            ini: zend.exception_ignore_args=Off xdebug.mode=develop,coverage
+            ini: zend.exception_ignore_args=Off, xdebug.mode=develop,coverage
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: ${{ matrix.ini }}, ${{ xdebug3-mode }}
+          ini-values: ${{ matrix.ini }}, ${{ matrix.xdebug3-mode }}
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1101,10 +1101,42 @@ class DataBuilder implements DataBuilderInterface
         
         return $backTrace;
     }
+
+    /**
+     * Check if this PHP install has the `xdebug_get_function_stack` function.
+     *
+     * @return bool
+     */
+    private function hasXdebugGetFunctionStack()
+    {
+        // TBD: allow the consumer to disable use of Xdebug even if it's
+        // TBD: installed in the consumer's runtime environment?
+
+        // if the function doesn't exist, we're obviously unable to use it
+        if (! function_exists('xdebug_get_function_stack')) {
+            return false;
+        }
+
+        // if the function's not provided by Xdebug, we can't guarantee an
+        // API conformance so we refuse to use it
+        $version = phpversion('xdebug');
+        if (false === $version) {
+            return false;
+        }
+
+        // in XDebug 2 and prior, existence of the function implied usability
+        if (version_compare($version, '3.0.0', '<')) {
+            return true;
+        }
+
+        // in XDebug 3 and later, the function is defined but disabled unless
+        // the xdebug mode parameter includes it
+        return -1 === strpos(ini_get('xdebug.mode'), 'develop') ? false : true;
+    }
     
     private function fetchErrorTrace()
     {
-        if (function_exists('xdebug_get_function_stack')) {
+        if ($this->hasXdebugGetFunctionStack()) {
             return array_reverse(\xdebug_get_function_stack());
         } else {
             return debug_backtrace($this->localVarsDump ? 0 : DEBUG_BACKTRACE_IGNORE_ARGS);

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1131,7 +1131,7 @@ class DataBuilder implements DataBuilderInterface
 
         // in XDebug 3 and later, the function is defined but disabled unless
         // the xdebug mode parameter includes it
-        return -1 === strpos(ini_get('xdebug.mode'), 'develop') ? false : true;
+        return false === strpos(ini_get('xdebug.mode'), 'develop') ? false : true;
     }
     
     private function fetchErrorTrace()


### PR DESCRIPTION
## Description of the change
We depend on Xdebug for code coverage in the tests, and optionally in the code for improved stack traces. Xdebug 3 was released in late November and now is in release channels, including our CI framework. In XDebug 2, the function we use (`xdebug_get_function_stack`) worked by virtue of having XDebug installed at all. In XDebug 3, a new INI setting is required to enable it, which we're not passing in CI.

As an aside, because we _require_ XDebug in tests, and XDebug 2 had no way to have both xdebug installed and the function we use disabled, there was no way to test the "no-xdebug code path" in XDebug 2. This new version of XDebug let's us also test that pathway, which add in this PR.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
