### PR TITLE
Split CI by library version

### DIFF
--- a/.github/workflows/ci-1.x.yml
+++ b/.github/workflows/ci-1.x.yml
@@ -18,7 +18,7 @@ on:
       - next/1.x/**
     tags:
       - v1.*
-  pull_requests:
+  pull_request:
     branches:
       - next/1.x
       - next/1.x/**

--- a/.github/workflows/ci-1.x.yml
+++ b/.github/workflows/ci-1.x.yml
@@ -14,13 +14,11 @@ name: CI for Rollbar-PHP, version 1.x
 on:
   push:
     branches:
-      - next/1.x
       - next/1.x/**
     tags:
       - v1.*
   pull_request:
     branches:
-      - next/1.x
       - next/1.x/**
   schedule:
     - cron: '42 2 * * *'

--- a/.github/workflows/ci-1.x.yml
+++ b/.github/workflows/ci-1.x.yml
@@ -1,17 +1,22 @@
-# CI checks for Rollbar-PHP, master branch.
+# CI checks for Rollbar-PHP, version 1.x
 #
 # Test with act:
 #   brew install act
 #   act -P ubuntu-latest=shivammathur/node:latest
 #
 # @see https://github.com/nektos/act/issues/329
-name: CI for Rollbar-PHP, master
+name: CI for Rollbar-PHP, version 1.x
 
-# Fire this action on pushes to main branch (master) as well as pull requests
-# (push: without any configuration assumes this). Also, run every day at 02:42
-# GMT -- this catches failures from dependencies that update indepdently.
+# Fire this action on pushes to 1.x development branch (next/1.x) as well as
+# pull requests to that same branch. Also, run every day at 02:42 GMT -- this
+# catches failures from dependencies that update independently.
 on:
   push:
+    branches:
+      - next/1.x
+  pull_requests:
+    branches:
+      - next/1.x
   schedule:
     - cron: '42 2 * * *'
 
@@ -27,13 +32,9 @@ jobs:
     strategy:
       matrix:
         # All the versions, OS, and dependency levels we want to support
-        php: [8.0]
+        php: [5.6, 5.5]
         dependency: [stable] # TODO: lowest
         os: [ubuntu]         # TODO: windows, macos
-        # Our code has paths for with- and without- XDebug, and we want to test
-        # both of them.
-        # @see https://xdebug.org/docs/all_settings#mode
-        xdebug3-mode: ["xdebug.mode=develop,coverage", "xdebug.mode=coverage"]
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest
@@ -46,7 +47,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: zend.exception_ignore_args=Off, ${{ matrix.xdebug3-mode }}
+          ini-values:
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/.github/workflows/ci-1.x.yml
+++ b/.github/workflows/ci-1.x.yml
@@ -7,16 +7,21 @@
 # @see https://github.com/nektos/act/issues/329
 name: CI for Rollbar-PHP, version 1.x
 
-# Fire this action on pushes to 1.x development branch (next/1.x) as well as
-# pull requests to that same branch. Also, run every day at 02:42 GMT -- this
-# catches failures from dependencies that update independently.
+# Fire this action on pushes to 1.x development branches (the official one, as
+# well as development branches within it -- hence the wildcard), and also 1.x
+# tags. Also, run every day at 02:42 GMT to catch failures from dependencies
+# that update independently.
 on:
   push:
     branches:
       - next/1.x
+      - next/1.x/**
+    tags:
+      - v1.*
   pull_requests:
     branches:
       - next/1.x
+      - next/1.x/**
   schedule:
     - cron: '42 2 * * *'
 

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -14,13 +14,11 @@ name: CI for Rollbar-PHP, version 2.x
 on:
   push:
     branches:
-      - next/2.x
       - next/2.x/**
     tags:
       - v2.*
   pull_request:
     branches:
-      - next/2.x
       - next/2.x/**
   schedule:
     - cron: '42 2 * * *'

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -1,17 +1,22 @@
-# CI checks for Rollbar-PHP, master branch.
+# CI checks for Rollbar-PHP, version 2.x
 #
 # Test with act:
 #   brew install act
 #   act -P ubuntu-latest=shivammathur/node:latest
 #
 # @see https://github.com/nektos/act/issues/329
-name: CI for Rollbar-PHP, master
+name: CI for Rollbar-PHP, version 2.x
 
-# Fire this action on pushes to main branch (master) as well as pull requests
-# (push: without any configuration assumes this). Also, run every day at 02:42
-# GMT -- this catches failures from dependencies that update indepdently.
+# Fire this action on pushes to 2.x development branch (next/2.x) as well as
+# pull requests to that same branch. Also, run every day at 02:42 GMT -- this
+# catches failures from dependencies that update independently.
 on:
   push:
+    branches:
+      - next/2.x
+  pull_requests:
+    branches:
+      - next/2.x
   schedule:
     - cron: '42 2 * * *'
 
@@ -27,13 +32,33 @@ jobs:
     strategy:
       matrix:
         # All the versions, OS, and dependency levels we want to support
-        php: [8.0]
+        php: [7.4, 7.3, 7.2, 7.1]
         dependency: [stable] # TODO: lowest
         os: [ubuntu]         # TODO: windows, macos
-        # Our code has paths for with- and without- XDebug, and we want to test
-        # both of them.
+        # In XDebug 2 and earlier, if XDebug extension was present, the function
+        # xdebug_get_function_stack() was unconditionally available. Now in XDebug 3
+        # that function is present only when xdebug.mode includes "develop". Our code
+        # has paths for with- and without- XDebug, and we want to test both of them.
+        # However, we require XDebug for code coverage, so before XDebug 3 there was
+        # no way to test the without-XDebug code path. Now we can, so we do.
         # @see https://xdebug.org/docs/all_settings#mode
         xdebug3-mode: ["xdebug.mode=develop,coverage", "xdebug.mode=coverage"]
+        include:
+          # 7.4 introduced an engine wide flag that disables arguments in
+          # backtraces. The default in 7.4 is On. However, we have tests that
+          # rely on arguments being available, so we turn it Off.
+          - php: 7.4
+            ini: zend.exception_ignore_args=Off
+        exclude:
+          # We only have XDebug 3 in PHP > 7.3, and the ini value will be ignored in
+          # all earlier versions. We can prune out one of them, because the result of
+          # both runs in these earlier versions are the same (because the ini directive
+          # is completely ignored, no matter its value).
+          # @see https://xdebug.org/docs/compat
+          - php: 7.2
+            xdebug3-mode: "xdebug.mode=develop,coverage"
+          - php: 7.1
+            xdebug3-mode: "xdebug.mode=develop,coverage"
 
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest
@@ -46,7 +71,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: curl
-          ini-values: zend.exception_ignore_args=Off, ${{ matrix.xdebug3-mode }}
+          ini-values: ${{ matrix.ini }}, ${{ matrix.xdebug3-mode }}
           coverage: xdebug
 
       - name: Get composer cache directory

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -7,16 +7,21 @@
 # @see https://github.com/nektos/act/issues/329
 name: CI for Rollbar-PHP, version 2.x
 
-# Fire this action on pushes to 2.x development branch (next/2.x) as well as
-# pull requests to that same branch. Also, run every day at 02:42 GMT -- this
-# catches failures from dependencies that update independently.
+# Fire this action on pushes to 2.x development branches (the official one, as
+# well as development branches within it -- hence the wildcard), and also 2.x
+# tags. Also, run every day at 02:42 GMT to catch failures from dependencies
+# that update independently.
 on:
   push:
     branches:
       - next/2.x
+      - next/2.x/**
+    tags:
+      - v2.*
   pull_requests:
     branches:
       - next/2.x
+      - next/2.x/**
   schedule:
     - cron: '42 2 * * *'
 

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -18,7 +18,7 @@ on:
       - next/2.x/**
     tags:
       - v2.*
-  pull_requests:
+  pull_request:
     branches:
       - next/2.x
       - next/2.x/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,18 @@
 # @see https://github.com/nektos/act/issues/329
 name: CI for Rollbar-PHP, master
 
-# Fire this action on pushes to main branch (master) as well as pull requests
-# (push: without any configuration assumes this). Also, run every day at 02:42
-# GMT -- this catches failures from dependencies that update indepdently.
+# Fire this action on pushes to all branches except the development branches
+# for older versions of PHP. Thus, all branches assume to target master (and
+# will be checked accordingly) unless they begin with next/. Also, run every
+# day at 02:42 GMT to catch failures from dependencies that update
+# independently.
 on:
   push:
+    branches-ignore:
+      - next/**
+  pull_requests:
+    branches-ignore:
+      - next/**
   schedule:
     - cron: '42 2 * * *'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   push:
     branches-ignore:
       - next/**
-  pull_requests:
+  pull_request:
     branches-ignore:
       - next/**
   schedule:


### PR DESCRIPTION
## Description of the change

With the wide range of features available from PHP 8.0 down to 5.5, it's becoming difficult - read "impossible" - to support all versions in the same branch while also taking advantage of modern syntactical and performance features.

So, we're splitting into 3 branches:

- 1.x, bug fixes only, is PHP 5.x
- 2.x, features and fixes, is PHP 7.x
- master and 3.x, features and fixes, is PHP 8.x

This PR adds GitHub action flows for the correct PHP versions based on the target branch pushed into.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [X]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [X] Issue from task tracker has a link to this pull request 
