### PR TITLE
Select the proper version branch during a scheduled build

### DIFF
--- a/.github/workflows/ci-1.x.yml
+++ b/.github/workflows/ci-1.x.yml
@@ -31,6 +31,7 @@ jobs:
   # first as they're most likely to fail.
   # @seealso https://freek.dev/1546
   # @seealso https://www.dereuromark.de/2019/01/04/test-composer-dependencies-with-prefer-lowest/
+  # @seealso https://github.com/actions/starter-workflows/blob/main/ci/php.yml
   php-tests:
     strategy:
       matrix:
@@ -42,7 +43,14 @@ jobs:
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Checkout the code
+      - name: Checkout the next/1.x/main branch during scheduled builds
+        if: github.ref == 'refs/heads/master'
+        uses: actions/checkout@v2
+        with:
+          ref: 'next/1.x/main'
+
+      - name: Checkout the pushed branch
+        if: github.ref != 'refs/heads/master'
         uses: actions/checkout@v2
 
       - name: Install PHP and composer environment

--- a/.github/workflows/ci-2.x.yml
+++ b/.github/workflows/ci-2.x.yml
@@ -31,6 +31,7 @@ jobs:
   # first as they're most likely to fail.
   # @seealso https://freek.dev/1546
   # @seealso https://www.dereuromark.de/2019/01/04/test-composer-dependencies-with-prefer-lowest/
+  # @seealso https://github.com/actions/starter-workflows/blob/main/ci/php.yml
   php-tests:
     strategy:
       matrix:
@@ -66,7 +67,14 @@ jobs:
     name: PHP ${{ matrix.php }} on ${{ matrix.os }}, ${{ matrix.dependency }} dependencies preferred
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Checkout the code
+      - name: Checkout the next/2.x/main branch during scheduled builds
+        if: github.ref == 'refs/heads/master'
+        uses: actions/checkout@v2
+        with:
+          ref: 'next/2.x/main'
+
+      - name: Checkout the pushed branch
+        if: github.ref != 'refs/heads/master'
         uses: actions/checkout@v2
 
       - name: Install PHP and composer environment


### PR DESCRIPTION
## Description of the change

When a scheduled build runs, GitHub Actions behaves as:

> Scheduled workflows run on the latest commit on the default or base branch.
> -- https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#schedule

For our version branch build CI, we need the scheduled builds to use the main branch for that version -- not the master.

Note that we expect CI to fail during this PR: this PR doesn't change any behavior that fixes the fact that master is currently failing builds on PHP 8 -- that's a separate problem.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [X]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [X] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [X] Issue from task tracker has a link to this pull request 
