### PR TITLE
feat: remove unnecessary $isUncaught param

### DIFF
--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -57,8 +57,9 @@ class ErrorHandler extends AbstractHandler
         $exception = $this->logger()->
                             getDataBuilder()->
                             generateErrorWrapper($errno, $errstr, $errfile, $errline);
-
-        $this->logger()->log(Level::ERROR, $exception, array(), true);
+        $exception->isUncaught = true;
+        $this->logger()->log(Level::ERROR, $exception, array());
+        unset($exception->isUncaught);
 
         return false;
     }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -29,8 +29,9 @@ class ExceptionHandler extends AbstractHandler
         }
         
         $exception = $args[0];
-        
-        $this->logger()->log(Level::ERROR, $exception, array(), true);
+        $exception->isUncaught = true;
+        $this->logger()->log(Level::ERROR, $exception, array());
+        unset($exception->isUncaught);
         
         if ($this->previousHandler) {
             restore_exception_handler();

--- a/src/Handlers/FatalHandler.php
+++ b/src/Handlers/FatalHandler.php
@@ -40,8 +40,9 @@ class FatalHandler extends AbstractHandler
             $exception = $this->logger()->
                                 getDataBuilder()->
                                 generateErrorWrapper($errno, $errstr, $errfile, $errline);
-                                
-            $this->logger()->log(Level::CRITICAL, $exception, array(), true);
+            $exception->isUncaught = true;
+            $this->logger()->log(Level::CRITICAL, $exception, array());
+            unset($exception->isUncaught);
         }
     }
     

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -87,12 +87,25 @@ class Rollbar
         return self::$logger->scope($config);
     }
 
-    public static function log($level, $toLog, $extra = array(), $isUncaught = false)
+    public static function log($level, $toLog, $extra = array())
     {
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
-        return self::$logger->log($level, $toLog, (array)$extra, $isUncaught);
+        return self::$logger->log($level, $toLog, (array)$extra);
+    }
+
+    /**
+     * @since 3.0.0
+     */
+    public static function logUncaught($level, Throwable $toLog, $extra = array())
+    {
+        if (is_null(self::$logger)) {
+            return self::getNotInitializedResponse();
+        }
+        $toLog->isUncaught = true;
+        return self::$logger->log($level, $toLog, (array)$extra);
+        unset($toLog->isUncaught);
     }
     
     public static function debug($toLog, $extra = array())

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -1,5 +1,6 @@
 <?php namespace Rollbar;
 
+use Throwable;
 use Psr\Log\AbstractLogger;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
@@ -82,7 +83,7 @@ class RollbarLogger extends AbstractLogger
         return $this->config->getCustom();
     }
 
-    public function log($level, $toLog, array $context = array(), $isUncaught = false)
+    public function log($level, $toLog, array $context = array())
     {
         if ($this->disabled()) {
             $this->verboseLogger()->notice('Rollbar is disabled');
@@ -105,6 +106,7 @@ class RollbarLogger extends AbstractLogger
         $accessToken = $this->getAccessToken();
         $payload = $this->getPayload($accessToken, $level, $toLog, $context);
         
+        $isUncaught = $this->isUncaughtLogData($toLog);
         if ($this->config->checkIgnored($payload, $accessToken, $toLog, $isUncaught)) {
             $this->verboseLogger()->info('Occurrence ignored');
             $response = new Response(0, "Ignored");
@@ -254,5 +256,21 @@ class RollbarLogger extends AbstractLogger
         $encoded = new EncodedPayload($payload);
         $encoded->encode();
         return $encoded;
+    }
+
+    /**
+     * Check whether the data to log represents an uncaught error, exception,
+     * or fatal error. This works in concert with src/Handlers/, which sets
+     * the `isUncaught` property on the `Throwable` representation of data.
+     */
+    protected function isUncaughtLogData(mixed $toLog): bool
+    {
+        if (! $toLog instanceof Throwable) {
+            return false;
+        }
+        if (! isset($toLog->isUncaught)) {
+            return false;
+        }
+        return $toLog->isUncaught === true;
     }
 }

--- a/tests/TestHelpers/StdOutLogger.php
+++ b/tests/TestHelpers/StdOutLogger.php
@@ -7,7 +7,7 @@ use Psr\Log\LoggerTrait;
 
 class StdOutLogger extends RollbarLogger
 {
-    public function log($level, $message, array $context = array(), $isUncaught = false)
+    public function log($level, $toLog, array $context = array())
     {
         echo '[' . get_class($this) . ': '. $level . '] ' . $message;
     }


### PR DESCRIPTION
## Description of the change

When the application logging handles an otherwise uncaught error, exception, or fatality, the logging path enters the "uncaught" flow. The implementation for the uncaught flow went through the usual logging mechanism (PSR-3, `log()`) but appended the uncaught state value to the `log()` signature.

While not a violation of PHP LSP rules, it nonetheless could be an error when Rollbar is used as the handler, but a user-defined logger with a different `log()` API is shimmed in-front of the Rollbar logger.

For broadest compatibility, and keeping with the principal of least surprise, we remove that extra parameter and instead pass the state information as part of the exception object itself.

BREAKING CHANGE

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

* Fixes https://github.com/rollbar/rollbar-php/pull/499

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
