### PR TITLE
Replace call_user_func and func_*_args with modern equivalents

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -826,7 +826,8 @@ class Config
     {
         if (isset($this->checkIgnore)) {
             try {
-                if (call_user_func($this->checkIgnore, $isUncaught, $toLog, $payload)) {
+                $ok = ($this->checkIgnore)($isUncaught, $toLog, $payload);
+                if ($ok) {
                     $this->verboseLogger()->info('Occurrence ignored due to custom check_ignore logic');
                     return true;
                 }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -870,7 +870,7 @@ class DataBuilder implements DataBuilderInterface
         $personData = $this->person;
         if (!isset($personData) && is_callable($this->personFunc)) {
             try {
-                $personData = call_user_func($this->personFunc);
+                $personData = ($this->personFunc)();
             } catch (\Exception $exception) {
                 Rollbar::scope(array('person_fn' => null))->
                     log(Level::ERROR, $exception);

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -25,7 +25,7 @@ abstract class AbstractHandler
         return $this->registered;
     }
     
-    public function handle()
+    public function handle(...$args)
     {
         if (!$this->registered()) {
             throw new \Exception(get_class($this) . ' has not been set up.');

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -6,7 +6,6 @@ use Rollbar\Payload\Level;
 
 class ErrorHandler extends AbstractHandler
 {
-
     public function register()
     {
         $this->previousHandler = set_error_handler(array($this, 'handle'));
@@ -14,42 +13,26 @@ class ErrorHandler extends AbstractHandler
         parent::register();
     }
 
-    public function handle()
+    public function handle(...$args)
     {
-        /**
-         * Overloading methods with different parameters is not supported in PHP
-         * through language structures. This hack allows to simulate that.
-         */
-        $args = func_get_args();
+        parent::handle(...$args);
 
-        if (!isset($args[0]) || !isset($args[1])) {
+        if (count($args) < 2) {
             throw new \Exception('No $errno or $errstr to be passed to the error handler.');
         }
 
         $errno = $args[0];
         $errstr = $args[1];
-        $errfile = isset($args[2]) ? $args[2] : null;
-        $errline = isset($args[3]) ? $args[3] : null;
+        $errfile = $args[2] ?: null;
+        $errline = $args[3] ?: null;
 
-        parent::handle();
-
-        if (!is_null($this->previousHandler)) {
-            $stop_processing = call_user_func(
-                $this->previousHandler,
-                $errno,
-                $errstr,
-                $errfile,
-                $errline
-            );
-
+        if ($this->previousHandler) {
+            $stop_processing = ($this->previousHandler)($errno, $errstr, $errfile, $errline);
             if ($stop_processing) {
                 return $stop_processing;
             }
         }
 
-        if (is_null($this->logger())) {
-            return false;
-        }
         if ($this->logger()->shouldIgnoreError($errno)) {
             return false;
         }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -6,7 +6,6 @@ use Rollbar\Payload\Level;
 
 class ExceptionHandler extends AbstractHandler
 {
-    
     public function register()
     {
         $this->previousHandler = set_exception_handler(array($this, 'handle'));
@@ -14,17 +13,11 @@ class ExceptionHandler extends AbstractHandler
         parent::register();
     }
     
-    public function handle()
+    public function handle(...$args)
     {
-        parent::handle();
-        
-        /**
-         * Overloading methods with different parameters is not supported in PHP
-         * through language structures. This hack allows to simulate that.
-         */
-        $args = func_get_args();
-        
-        if (!isset($args[0])) {
+        parent::handle(...$args);
+
+        if (count($args) < 1) {
             throw new \Exception('No exception to be passed to the exception handler.');
         }
         
@@ -33,13 +26,13 @@ class ExceptionHandler extends AbstractHandler
         $this->logger()->log(Level::ERROR, $exception, array());
         unset($exception->isUncaught);
         
-        if ($this->previousHandler) {
-            restore_exception_handler();
-            call_user_func($this->previousHandler, $exception);
-            return;
+        // if there was no prior handler, then we toss that exception
+        if ($this->previousHandler === null) {
+            throw $exception;
         }
 
-
-        throw $exception;
+        // otherwise we overrode a previous handler, so restore it and call it
+        restore_exception_handler();
+        return ($this->previousHandler)($exception);
     }
 }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -33,6 +33,6 @@ class ExceptionHandler extends AbstractHandler
 
         // otherwise we overrode a previous handler, so restore it and call it
         restore_exception_handler();
-        return ($this->previousHandler)($exception);
+        ($this->previousHandler)($exception);
     }
 }

--- a/src/Handlers/FatalHandler.php
+++ b/src/Handlers/FatalHandler.php
@@ -21,14 +21,10 @@ class FatalHandler extends AbstractHandler
         parent::register();
     }
     
-    public function handle()
+    public function handle(...$args)
     {
+        parent::handle(...$args);
         
-        parent::handle();
-        
-        if (is_null($this->logger())) {
-            return;
-        }
         $lastError = error_get_last();
         
         if ($this->isFatal($lastError)) {
@@ -56,7 +52,7 @@ class FatalHandler extends AbstractHandler
     protected function isFatal($lastError)
     {
         return
-            !is_null($lastError) &&
+            null !== $lastError &&
             in_array($lastError['type'], self::$fatalErrors, true) &&
             // don't log uncaught exceptions as they were handled by exceptionHandler()
             !(isset($lastError['message']) &&


### PR DESCRIPTION
## Description of the change

The engine functions `func_*_args()` and `call_user_func*()` have [documented buggy behavior][1], in particular around stack traces and performance -- two things we care rather much about.
    
This PR replaces the use of `func_*_args()` with spread and obvious array operations, and uses lexical parsing to replace the need for `call_user_func`.
    
[1]:https://news-web.php.net/php.internals/77854


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fix CH-83298

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
