### PR TITLE
fix: missing URL encoding of UUID in occurrences

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -37,7 +37,7 @@ class Response
         if (!$this->wasSuccessful()) {
             return null;
         }
-        return "https://rollbar.com/occurrence/uuid/?uuid=" . $this->uuid;
+        return "https://rollbar.com/occurrence/uuid/?uuid=" . urlencode($this->uuid);
     }
 
     public function __toString()

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -32,10 +32,13 @@ class ResponseTest extends BaseRollbarTest
         $this->assertFalse($response->wasSuccessful());
     }
 
-    public function testUrl()
+    /**
+     * @testWith ["abc123", "https://rollbar.com/occurrence/uuid/?uuid=abc123"]
+     *           ["a bar", "https://rollbar.com/occurrence/uuid/?uuid=a+bar"]
+     */
+    public function testUrl(string $uuid, string $expectedOccurrenceUrl)
     {
-        $expected = "https://rollbar.com/occurrence/uuid/?uuid=abc123";
-        $response = new Response(200, "fake", "abc123");
-        $this->assertEquals($expected, $response->getOccurrenceUrl());
+        $response = new Response(200, "fake", $uuid);
+        $this->assertEquals($expectedOccurrenceUrl, $response->getOccurrenceUrl());
     }
 }


### PR DESCRIPTION
## Description of the change

A URI should always be encoded, even when the expectation is that only conforming characters will be sent. In particular, the input for UUID comes from `src/DataBuilder.php` for both Agent and Fluent sender, and that is a UUID v4 value -- all characters of which conform to [RFC 3986][1]. A future code change might change that to a non-conforming string, or a consuming library might call the method directly with a non-conforming value. Be safe.

[1]:https://datatracker.ietf.org/doc/html/rfc3986

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
