### PR TITLE
refac: remove unreachable version compare branches

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -229,9 +229,6 @@ class DataBuilder implements DataBuilderInterface
         
         if (!$this->requestBody && $this->rawRequestBody) {
             $this->requestBody = file_get_contents("php://input");
-            if (version_compare(PHP_VERSION, '5.6.0') < 0) {
-                $_SERVER['php://input'] = $this->requestBody;
-            }
         }
     }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -5,6 +5,7 @@ namespace Rollbar;
 use Monolog\Logger;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
+use Throwable;
 
 class Defaults
 {
@@ -67,7 +68,7 @@ class Defaults
         $this->serverRoot = isset($_ENV["HEROKU_APP_DIR"]) ? $_ENV["HEROKU_APP_DIR"] : null;
         $this->platform = php_uname('a');
         $this->notifier = Notifier::defaultNotifier();
-        $this->baseException = version_compare(phpversion(), '7.0', '<') ? '\Exception' : '\Throwable';
+        $this->baseException = Throwable::class;
         $this->errorSampleRates = array();
         $this->exceptionSampleRates = array();
     }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -804,9 +804,6 @@ class DataBuilderTest extends BaseRollbarTest
         $requestBody = $output->getRequest()->getBody();
         
         $this->assertEquals($streamInput, $requestBody);
-        if (version_compare(PHP_VERSION, '5.6.0') < 0) {
-            $this->assertEquals($streamInput, $_SERVER['php://input']);
-        }
         
         stream_wrapper_restore("php");
     }
@@ -892,7 +889,11 @@ class DataBuilderTest extends BaseRollbarTest
             $frames[count($frames)-1]->getFilename()
         );
         // 889 is the line number where the comment "// A" is found
-        $this->assertEquals(889, $frames[count($frames)-1]->getLineno());
+        $this->assertEquals(
+            886,
+            $frames[count($frames)-1]->getLineno(),
+            "Possible false negative: did this file change? Check the line number for line with '// A' comment"
+        );
         $this->assertEquals('Rollbar\DataBuilderTest::testFramesOrder', $frames[count($frames)-2]->getMethod());
     }
     

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -5,6 +5,7 @@ use Rollbar\Defaults;
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
+use Throwable;
 
 class DefaultsTest extends BaseRollbarTest
 {
@@ -106,11 +107,7 @@ class DefaultsTest extends BaseRollbarTest
 
     public function testBaseException()
     {
-        if (version_compare(phpversion(), '7.0', '<')) {
-            $expected = "\Exception";
-        } else {
-            $expected = "\Throwable";
-        }
+        $expected = Throwable::class;
         $base = $this->defaults->baseException();
         $this->assertEquals($expected, $base);
     }


### PR DESCRIPTION
## Description of the change

No need to support code paths for versions less than PHP 8, since this code will not install or parse on versions lower than 8.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

CH-79868

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
