### PR TITLE
Remove throwable anachronism

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -833,7 +833,7 @@ class Config
                     $this->verboseLogger()->info('Occurrence ignored due to custom check_ignore logic');
                     return true;
                 }
-            } catch (\Exception $exception) {
+            } catch (Throwable $exception) {
                 $this->verboseLogger()->error(
                     'Exception occurred in the custom checkIgnore logic:' . $exception->getMessage()
                 );

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -16,6 +16,7 @@ use Rollbar\Payload\TraceChain;
 use Rollbar\Payload\ExceptionInfo;
 use Rollbar\Rollbar;
 use Rollbar\Exceptions\PersonFuncException;
+use Throwable;
 
 class DataBuilder implements DataBuilderInterface
 {
@@ -364,11 +365,11 @@ class DataBuilder implements DataBuilderInterface
 
     /**
      * @param string $level
-     * @param \Exception | \Throwable | string $toLog
+     * @param Throwable|string $toLog
      * @param $context
      * @return Data
      */
-    public function makeData($level, $toLog, $context)
+    public function makeData(string $level, Throwable|string $toLog, array $context): Data
     {
         $env = $this->getEnvironment();
         $body = $this->getBody($toLog, $context);
@@ -415,10 +416,10 @@ class DataBuilder implements DataBuilderInterface
     }
 
     /**
-     * @param \Throwable|\Exception $exc
+     * @param Throwable $exc
      * @return Trace|TraceChain
      */
-    public function getExceptionTrace($exc)
+    public function getExceptionTrace(Throwable $exc): Trace|TraceChain
     {
         $chain = array();
         $chain[] = $this->makeTrace($exc, $this->includeExcCodeContext);
@@ -442,12 +443,12 @@ class DataBuilder implements DataBuilderInterface
     }
 
     /**
-     * @param \Throwable|\Exception $exception
-     * @param Boolean $includeContext whether or not to include context
-     * @param string $classOverride
+     * @param Throwable $exception
+     * @param bool $includeContext whether or not to include context
+     * @param string|null $classOverride
      * @return Trace
      */
-    public function makeTrace($exception, $includeContext, $classOverride = null)
+    public function makeTrace(Throwable $exception, bool $includeContext, ?string $classOverride = null): Trace
     {
         if ($this->captureErrorStacktraces) {
             $frames = $this->makeFrames($exception, $includeContext);

--- a/src/DataBuilderInterface.php
+++ b/src/DataBuilderInterface.php
@@ -2,7 +2,10 @@
 
 namespace Rollbar;
 
+use Rollbar\Payload\Data;
+use Throwable;
+
 interface DataBuilderInterface
 {
-    public function makeData($level, $toLog, $context);
+    public function makeData(string $level, Throwable|string $toLog, array $context): Data;
 }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -147,7 +147,7 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->info('Occurrence successfully logged');
         }
         
-        if ((is_a($toLog, 'Throwable') || is_a($toLog, 'Exception')) && $this->config->getRaiseOnError()) {
+        if ($toLog instanceof Throwable && $this->config->getRaiseOnError()) {
             throw $toLog;
         }
         

--- a/tests/FakeDataBuilder.php
+++ b/tests/FakeDataBuilder.php
@@ -1,6 +1,10 @@
 <?php namespace Rollbar;
 
 use Rollbar\DataBuilderInterface;
+use Rollbar\Payload\Body;
+use Rollbar\Payload\Data;
+use Rollbar\Payload\Message;
+use Throwable;
 
 class FakeDataBuilder implements DataBuilderInterface
 {
@@ -12,9 +16,11 @@ class FakeDataBuilder implements DataBuilderInterface
         self::$args[] = $arr;
     }
 
-    public function makeData($level, $toLog, $context)
+    public function makeData(string $level, Throwable|string $toLog, array $context): Data
     {
         self::$logged[] = array($level, $toLog, $context);
+
+        return new Data('test', new Body(new Message('test')));
     }
     
     public function setCustom()


### PR DESCRIPTION
## Description of the change

Since 3.0 now only supports PHP 8+, we can rely on `Throwable` as a base class for `Exception`. Anywhere we have BC logic catching one or the other should catch only `Throwable`.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Part of the CH-79868 series.

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
