### PR TITLE
fix: typo in output error message

### DIFF
--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -141,8 +141,9 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->error('Occurrence rejected by the SDK: ' . $response);
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
-            $this->verboseLogger()->error('Occurrence rejected by the API: ' . (isset($info['message']) ?
-                    $info['message'] : 'mesage not set'));
+            $this->verboseLogger()->error(
+                'Occurrence rejected by the API: ' . ($info['message'] ?? 'message not set')
+            );
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');
         }


### PR DESCRIPTION
## Description of the change

In the event the API rejected an occurrence during a `log()` call,
and no message was available, a default message containing a
misspelled word - "mesage" - would be emitted in the log. This
change updates the spelling to "message".

This is a breaking change: any tool grepping/searching for the
original misspelling will need to be updated.

BREAKING CHANGE

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
