### PR TITLE
Fix broken performance tests

### DIFF
--- a/tests/Performance/TestHelpers/EncodedPayload.php
+++ b/tests/Performance/TestHelpers/EncodedPayload.php
@@ -4,7 +4,7 @@ class EncodedPayload extends \Rollbar\Payload\EncodedPayload
 {
     protected static $encodingCount = 0;
     
-    public function encode($data = null)
+    public function encode(?array $data = null): void
     {
         parent::encode($data);
         self::$encodingCount++;

--- a/tests/Truncation/StringsStrategyTest.php
+++ b/tests/Truncation/StringsStrategyTest.php
@@ -89,6 +89,23 @@ class StringsStrategyTest extends BaseRollbarTest
         
         return array($payload, $threshold);
     }
+
+    public function executeProvider()
+    {
+        $data = array();
+
+        $data["truncate nothing"] = array(
+            $this->payloadStructureProvider(str_repeat("A", 10)),
+            $this->payloadStructureProvider(str_repeat("A", 10))
+        );
+
+        $thresholds = StringsStrategy::getThresholds();
+        foreach ($thresholds as $threshold) {
+            $data['truncate strings to ' . $threshold] = $this->thresholdTestProvider($threshold);
+        }
+
+        return $data;
+    }
     
     public function payloadStructureProvider($message)
     {


### PR DESCRIPTION
## Description of the change

Performance tests are not run as part of CI, so no one noticed that these have been broken [since December, 2018][1]. I only discovered it when the performance tests did not implement the new strong type signatures. So this PR fixes the test failure because of PHP 8 changes, as well as the historic problem already in place.

[1]:https://github.com/rollbar/rollbar-php/commit/4d678fc865b5c9adfb345c6c5021ef7fc536af37#diff-1bfbcf7c4da10a80a28ea44b195ed374fa3b1bb13f435014a064a78ab3fffc22

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development: `./vendor/bin/phpunit --coverage-html build/logs/coverage/`

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
