### PR TITLE
fix: Unqualified Throwable refers to wrong namespace

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -107,8 +107,9 @@ class Rollbar
             return self::getNotInitializedResponse();
         }
         $toLog->isUncaught = true;
-        return self::$logger->log($level, $toLog, (array)$extra);
+        $result = self::$logger->log($level, $toLog, (array)$extra);
         unset($toLog->isUncaught);
+        return $result;
     }
     
     public static function debug($toLog, $extra = array())

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -6,6 +6,7 @@ use Rollbar\Payload\Level;
 use Rollbar\Handlers\FatalHandler;
 use Rollbar\Handlers\ErrorHandler;
 use Rollbar\Handlers\ExceptionHandler;
+use Throwable;
 
 class Rollbar
 {

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -112,6 +112,19 @@ class RollbarTest extends BaseRollbarTest
             $extra['some_key']
         );
     }
+
+    public function testLogUncaught()
+    {
+        Rollbar::init(self::$simpleConfig);
+      
+        try {
+            throw new \Exception('test exception');
+        } catch (\Exception $e) {
+            Rollbar::logUncaught(Level::ERROR, $e);
+        }
+        
+        $this->assertTrue(true);
+    }
     
     public function testDebug()
     {


### PR DESCRIPTION
## Description of the change

I found that `Rollbar::logUncaught`, added in 3.0, has an invalid signature — the unqualified `Throwable` refers to the nonexistent `Rollbar\Throwable`. This PR fixes that.

I also found an apparent mistake in that same method, where there was an unreachable statement after `return`. I moved the `return` after that statement. Please let me know if that should not be in this same PR. (In a separate commit)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None — I'm reporting the bug and providing the fix in one go.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
