### PR TITLE
Allow psr/log 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require": {
     "php": ">=8.0.0 <9.0",
     "ext-curl": "*",
-    "psr/log": "^1 || ^2 || ^3",
+    "psr/log": "^1 || ^2",
     "monolog/monolog": "^2"
   },
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require": {
     "php": ">=8.0.0 <9.0",
     "ext-curl": "*",
-    "psr/log": "^1",
+    "psr/log": "^1 || ^2 || ^3",
     "monolog/monolog": "^2"
   },
 


### PR DESCRIPTION
## Description of the change
This PR allows the installation of `psr/log` 2.0 and 3.0. It's possible to support all of those versions at once since the interfaces are used but not implemented anywhere.
Backporting is unnecessary since both 2.0 and 3.0 require PHP 8.

This PR is also a blocker for Seldaek/monolog#1564

More details are available in the new meta document: https://www.php-fig.org/psr/psr-3/meta/

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development
- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
