### PR TITLE
Fix isset check

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -453,7 +453,7 @@ class Config
         } elseif (isset($config['report_suppressed'])) {
             $this->reportSuppressed = $config['report_suppressed'];
         }
-                
+
         if (!isset($this->reportSuppressed)) {
             $this->reportSuppressed = \Rollbar\Defaults::get()->reportSuppressed();
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -448,11 +448,12 @@ class Config
 
     private function setReportSuppressed(array $config): void
     {
-        $this->reportSuppressed = isset($config['reportSuppressed']) && $config['reportSuppressed'];
-        if (!isset($this->reportSuppressed)) {
-            $this->reportSuppressed = isset($config['report_suppressed']) && $config['report_suppressed'];
+        if (isset($config['reportSuppressed'])) {
+            $this->reportSuppressed = $config['reportSuppressed'];
+        } elseif (isset($config['report_suppressed'])) {
+            $this->reportSuppressed = $config['report_suppressed'];
         }
-        
+                
         if (!isset($this->reportSuppressed)) {
             $this->reportSuppressed = \Rollbar\Defaults::get()->reportSuppressed();
         }


### PR DESCRIPTION
```php
if (!isset($this->reportSuppressed)) {
    $this->reportSuppressed = isset($config['report_suppressed']) && $config['report_suppressed'];
}
```

The above line is never fired as ```$this->reportSuppressed = isset($config['reportSuppressed']) && $config['reportSuppressed'];``` is going to make the value set to true/false.

The code should actually check the array to see if the value isset.