### PR TITLE
Add transformer option

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -82,7 +82,7 @@ class Config
         'verbose',
         'verbose_logger',
         'raise_on_error',
-		'transformer'
+        'transformer',
     );
 
     private string $accessToken;


### PR DESCRIPTION
## Description of the change
Simply added the transformer option as it seems to be supported and is missing. We needed it to name a transfomer in Symfony through a yaml file.