### PR TITLE
GH-543-backport-1.x: Add missing transformer config option

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -65,7 +65,8 @@ class Config
         'minimum_level',
         'verbose',
         'verbose_logger',
-        'raise_on_error'
+        'raise_on_error',
+        'transformer',
     );
     
     private $accessToken;

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -271,15 +271,15 @@ class DefaultsTest extends BaseRollbarTest
     {
         foreach (\Rollbar\Config::listOptions() as $option) {
             if ($option == 'access_token' ||
+                $option == 'include_raw_request_body' ||
+                $option == 'log_payload_logger' ||
                 $option == 'logger' ||
                 $option == 'person' ||
                 $option == 'person_fn' ||
+                $option == 'proxy' ||
                 $option == 'scrub_whitelist' ||
                 $option == 'transformer' ||
-                $option == 'proxy' ||
-                $option == 'include_raw_request_body' ||
-                $option == 'verbose_logger' ||
-                $option == 'log_payload_logger') {
+                $option == 'verbose_logger') {
                 continue;
             } elseif ($option == 'base_api_url') {
                 $option = 'endpoint';

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -275,6 +275,7 @@ class DefaultsTest extends BaseRollbarTest
                 $option == 'person' ||
                 $option == 'person_fn' ||
                 $option == 'scrub_whitelist' ||
+                $option == 'transformer' ||
                 $option == 'proxy' ||
                 $option == 'include_raw_request_body' ||
                 $option == 'verbose_logger' ||


### PR DESCRIPTION
## Description of the change

#543 backport to `1.x`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#543]() 
## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
