### PR TITLE
Revert 666a1a2

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -450,11 +450,11 @@ class Config
     private function setReportSuppressed(array $config): void
     {
         $this->reportSuppressed = isset($config['reportSuppressed']) && $config['reportSuppressed'];
-        if (!isset($this->reportSuppressed)) {
+        if (!$this->reportSuppressed) {
             $this->reportSuppressed = isset($config['report_suppressed']) && $config['report_suppressed'];
         }
         
-        if (!isset($this->reportSuppressed)) {
+        if (!$this->reportSuppressed) {
             $this->reportSuppressed = \Rollbar\Defaults::get()->reportSuppressed();
         }
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -449,12 +449,11 @@ class Config
 
     private function setReportSuppressed(array $config): void
     {
-        if (isset($config['reportSuppressed'])) {
-            $this->reportSuppressed = $config['reportSuppressed'];
-        } elseif (isset($config['report_suppressed'])) {
-            $this->reportSuppressed = $config['report_suppressed'];
+        $this->reportSuppressed = isset($config['reportSuppressed']) && $config['reportSuppressed'];
+        if (!isset($this->reportSuppressed)) {
+            $this->reportSuppressed = isset($config['report_suppressed']) && $config['report_suppressed'];
         }
-
+        
         if (!isset($this->reportSuppressed)) {
             $this->reportSuppressed = \Rollbar\Defaults::get()->reportSuppressed();
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1001,7 +1001,7 @@ class Config
         return $level->toInt() < $this->minimumLevel;
     }
 
-    private function shouldSuppress(): bool
+    public function shouldSuppress(): bool
     {
         return error_reporting() === 0 && !$this->reportSuppressed;
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -347,9 +347,37 @@ class ConfigTest extends BaseRollbarTest
         return new Payload($data, $this->getTestAccessToken());
     }
 
-    public function testReportSuppressed()
+    /**
+     * Test the shouldSuppress method, which is driven by the configuration
+     * given and the value of the PHP engine's error_reporting() setting.
+     *
+     *            - error reporting value
+     *            |  - configuration key
+     *            |  |                   - configuration value
+     *            |  |                   |      - shouldSuppress() result
+     *            v  v                   v      v
+     * @testWith [0, "reportSuppressed", false, true]
+     *           [0, "reportSuppressed", true,  false]
+     *           [1, "reportSuppressed", false, false]
+     *           [0, "report_suppressed", false, true]
+     *           [0, "report_suppressed", true,  false]
+     *           [1, "report_suppressed", false, false]
+     */
+    public function testReportSuppressed($errorReporting, $configKey, $configValue, $shouldSuppressExpect)
     {
-        $this->assertTrue(true, "Don't know how to unit test this. PRs welcome");
+        $oldErrorReporting = error_reporting($errorReporting);
+        try {
+            $config = new Config(array(
+                $configKey => $configValue
+            ));
+            $this->assertSame(
+                $shouldSuppressExpect,
+                $config->shouldSuppress(),
+                'shouldSuppress() did not return the expected value for the error_reporting and configuration given'
+            );
+        } finally {
+            error_reporting($oldErrorReporting);
+        }
     }
 
     public function testFilter()


### PR DESCRIPTION
## Description of the change

Reverts commit 666a1a2, which altered the expected type of the `reportSuppressed` internal variable from `boolean` to the type of the user-supplied configuration value. Additionally, this allowed for potential malicious value injection, as the value of the configuration key was not checked.

Then, adds a test that exposes the bug associated with PR #539.

Finally, fixes said bug.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
