### PR TITLE
fix: missed cleanup of synthetic member variable

### DIFF
--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -6,6 +6,7 @@ use Rollbar\Payload\Level;
 use Rollbar\Handlers\FatalHandler;
 use Rollbar\Handlers\ErrorHandler;
 use Rollbar\Handlers\ExceptionHandler;
+use Throwable;
 
 class Rollbar
 {
@@ -106,8 +107,9 @@ class Rollbar
             return self::getNotInitializedResponse();
         }
         $toLog->isUncaught = true;
-        return self::$logger->log($level, $toLog, (array)$extra);
+        $result = self::$logger->log($level, $toLog, (array)$extra);
         unset($toLog->isUncaught);
+        return $result;
     }
     
     public static function debug($toLog, $extra = array())

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -276,8 +276,10 @@ class RollbarLogger extends AbstractLogger
      * Check whether the data to log represents an uncaught error, exception,
      * or fatal error. This works in concert with src/Handlers/, which sets
      * the `isUncaught` property on the `Throwable` representation of data.
+     *
+     * @since 3.0.1
      */
-    protected function isUncaughtLogData(mixed $toLog): bool
+    public function isUncaughtLogData(mixed $toLog): bool
     {
         if (! $toLog instanceof Throwable) {
             return false;

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -251,4 +251,23 @@ class RollbarTest extends BaseRollbarTest
         Rollbar::configure(array('enabled' => false));
         $this->assertTrue(Rollbar::disabled());
     }
+
+    public function testLogUncaughtUnsetLogger()
+    {
+        $sut = new Rollbar;
+        $result = $sut->logUncaught('level', new \Exception);
+        $expected = new Response(0, "Rollbar Not Initialized");
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testLogUncaught()
+    {
+        $sut = new Rollbar;
+        Rollbar::init(self::$simpleConfig);
+        $logger = Rollbar::logger();
+        $toLog = new \Exception;
+        $result = Rollbar::logUncaught(Level::ERROR, $toLog);
+        $this->assertEquals(200, $result->getStatus());
+        $this->assertObjectNotHasAttribute('uncaught', $toLog);
+    }
 }


### PR DESCRIPTION
## Description of the change

Release 3.0.0 added a `logUncaught` method to bypass the need to extend the PSR-defined `log` method. That implementation tagged the incoming object as "uncaught" and passed it through to the log method, which then checked for that tagging. However, `logUncaught` signature was incorrect and the pass through was not properly cleaning up the tagging and there weren't sufficient test coverage explicitly on the mechanism.

This elaboration on PR #534 adds that coverage.

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

[PR #534](https://github.com/rollbar/rollbar-php/pull/534)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
