### PR TITLE
feat: add psalm static analysis and fix simple issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "phpunit/phpunit": "^9",
     "mockery/mockery": "^1",
     "squizlabs/php_codesniffer": "^3.6 || 3.x-dev",
-    "phpmd/phpmd" : "^2"
+    "phpmd/phpmd" : "^2",
+    "vimeo/psalm": "^4.13"
   },
 
   "suggest": {
@@ -53,6 +54,7 @@
     "docker-run": "docker run -it -v \"${PWD}\":/opt/rollbar/rollbar-php rollbar/rollbar-php:3",
     "test": [
       "phpcs --standard=PSR2 src tests",
+      "psalm",
       "phpunit --coverage-clover build/logs/clover.xml --testsuite 'Rollbar Test Suite'"
     ],
     "fix": "phpcbf --standard=PSR2 src tests",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
     "docker-run": "docker run -it -v \"${PWD}\":/opt/rollbar/rollbar-php rollbar/rollbar-php:3",
     "test": [
       "phpcs --standard=PSR2 src tests",
-      "psalm",
       "phpunit --coverage-clover build/logs/clover.xml --testsuite 'Rollbar Test Suite'"
     ],
     "fix": "phpcbf --standard=PSR2 src tests",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="7"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>

--- a/src/Config.php
+++ b/src/Config.php
@@ -18,13 +18,6 @@ use Rollbar\TransformerInterface;
 use Rollbar\UtilitiesTrait;
 use Throwable;
 
-if (!defined('ROLLBAR_INCLUDED_ERRNO_BITMASK')) {
-    define(
-        'ROLLBAR_INCLUDED_ERRNO_BITMASK',
-        E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR
-    );
-}
-
 class Config
 {
     use UtilitiesTrait;

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1085,7 +1085,7 @@ class DataBuilder implements DataBuilderInterface
      * @var string $errfile
      * @var string $errline
      *
-     * @return Rollbar\ErrorWrapper
+     * @return array
      */
     protected function buildErrorTrace($errfile, $errline)
     {

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -22,21 +22,13 @@ class Defaults
     {
         $this->psrLevels = array(
             LogLevel::EMERGENCY => "critical",
-            "emergency" => "critical",
             LogLevel::ALERT => "critical",
-            "alert" => "critical",
             LogLevel::CRITICAL => "critical",
-            "critical" => "critical",
             LogLevel::ERROR => "error",
-            "error" => "error",
             LogLevel::WARNING => "warning",
-            "warning" => "warning",
             LogLevel::NOTICE => "info",
-            "notice" => "info",
             LogLevel::INFO => "info",
-            "info" => "info",
             LogLevel::DEBUG => "debug",
-            "debug" => "debug"
         );
         $this->errorLevels = array(
             E_ERROR => "error",

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -63,6 +63,10 @@ class Defaults
         $this->baseException = Throwable::class;
         $this->errorSampleRates = array();
         $this->exceptionSampleRates = array();
+
+        if (defined('ROLLBAR_INCLUDED_ERRNO_BITMASK')) {
+            $this->includedErrno = ROLLBAR_INCLUDED_ERRNO_BITMASK;
+        }
     }
     
     public function fromSnakeCase($option)
@@ -347,7 +351,7 @@ class Defaults
     private $maxNestingDepth = -1;
     private $errorSampleRates = array();
     private $exceptionSampleRates = array();
-    private $includedErrno = ROLLBAR_INCLUDED_ERRNO_BITMASK;
+    private $includedErrno = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
     private $includeErrorCodeContext = null;
     private $includeExceptionCodeContext = null;
     private $agentLogLocation = '/var/tmp';

--- a/src/RollbarJsHelper.php
+++ b/src/RollbarJsHelper.php
@@ -40,7 +40,7 @@ class RollbarJsHelper
      * headers_list() used to verify if nonce should be added to script
      * tags based on Content-Security-Policy
      * @param string $nonce Content-Security-Policy nonce string if exists
-     * @param strong $customJs Additional JavaScript to add at the end of
+     * @param string $customJs Additional JavaScript to add at the end of
      * RollbarJs snippet
      *
      * @return string

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -63,21 +63,13 @@ class DefaultsTest extends BaseRollbarTest
     {
         $expected = $this->defaultPsrLevels = array(
             LogLevel::EMERGENCY => "critical",
-            "emergency" => "critical",
             LogLevel::ALERT => "critical",
-            "alert" => "critical",
             LogLevel::CRITICAL => "critical",
-            "critical" => "critical",
             LogLevel::ERROR => "error",
-            "error" => "error",
             LogLevel::WARNING => "warning",
-            "warning" => "warning",
             LogLevel::NOTICE => "info",
-            "notice" => "info",
             LogLevel::INFO => "info",
-            "info" => "info",
             LogLevel::DEBUG => "debug",
-            "debug" => "debug"
         );
         $this->assertEquals($expected, $this->defaults->psrLevels());
     }

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -222,14 +222,36 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertNull($this->defaults->host());
     }
     
-    public function testIncludedErrno()
+    public function testIncludedErrnoDefault()
     {
+        $expected = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
         $this->assertEquals(
-            ROLLBAR_INCLUDED_ERRNO_BITMASK,
+            $expected,
             $this->defaults->includedErrno()
         );
     }
     
+    /**
+     * Test that a caller may set the errno to include in messages via the
+     * `ROLLBAR_INCLUDED_ERRNO_BITMASK` define. Because we don't want to set
+     * this and infect all other tests, we run this particular test in a
+     * separate process.
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testIncludedErrnoDefineOverride()
+    {
+        // unlike other tests that use `$this->defaults`, we must make our
+        // own Defaults object now, _after_ defining the bitmask: in the
+        // prior case, `$this->defaults` is constructed before the define.
+        define('ROLLBAR_INCLUDED_ERRNO_BITMASK', E_USER_WARNING);
+        $this->assertEquals(
+            E_USER_WARNING,
+            (new Defaults)->includedErrno()
+        );
+    }
+
     public function testTimeout()
     {
         $this->assertEquals(3, $this->defaults->timeout());


### PR DESCRIPTION
## Description of the change

Issue 548 reports an error that could have been detected with static analysis, however we have no static analyzer in the test suite. This PR adds [psalm][1], a fast and easy-to-use static analysis tool for PHP. Psalm identified approximately 765 issues, though 751 of them are informative.

* Of those 751 informative, 11 are of the same class of problem reported in Issue 548. To see them, run `./vendor/bin/psalm --show-info=true | grep PossiblyNullArgument`
* Of the 14 warnings and errors, 7 are fixed in this PR as they were obvious and trivial.

Subsequent PR will need to fix the 11 possibly null arguments and the 7 design related issues.

[1]:https://psalm.dev

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
