### PR TITLE
feat: grandfather current static analysis failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     "docker-run": "docker run -it -v \"${PWD}\":/opt/rollbar/rollbar-php rollbar/rollbar-php:3",
     "test": [
       "phpcs --standard=PSR2 src tests",
+      "psalm --long-progress --use-baseline=psalm.baseline",
       "phpunit --coverage-clover build/logs/clover.xml --testsuite 'Rollbar Test Suite'"
     ],
     "fix": "phpcbf --standard=PSR2 src tests",

--- a/psalm.baseline
+++ b/psalm.baseline
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
+  <file src="src/Rollbar.php">
+    <AssignmentToVoid occurrences="1">
+      <code>$result</code>
+    </AssignmentToVoid>
+  </file>
+  <file src="src/RollbarLogger.php">
+    <ParamNameMismatch occurrences="1">
+      <code>$toLog</code>
+    </ParamNameMismatch>
+  </file>
+  <file src="src/Senders/FluentSender.php">
+    <UndefinedClass occurrences="2">
+      <code>FluentLogger</code>
+      <code>FluentLogger</code>
+    </UndefinedClass>
+    <UndefinedDocblockClass occurrences="3">
+      <code>$this-&gt;fluentLogger</code>
+      <code>FluentLogger</code>
+      <code>private $fluentLogger = null;</code>
+    </UndefinedDocblockClass>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm.baseline"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
## Description of the change

We want to begin using static analysis to improve the code base, but we don't want to go back through the 760+ current issues before doing so. This commit uses the Psalm baseline functionality to grandfather in the current failures and adds psalm static analysis to the test cycle. This will catch future issues in the code, while allowing for gradual remediation of historical issues.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
