### PR TITLE
Possibility to define custom scrubber

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,7 @@ class Config
         'capture_username',
         'capture_email',
         'root',
+        'scrubber',
         'scrub_fields',
         'scrub_safelist',
         'timeout',


### PR DESCRIPTION
## Description of the change

In current implementation scrubbing fields is not flexible.
Sometimes we need to scrub particular cookie value without erasing all cookies, like suggested here: #477
So, why can't we add an option to define custom scrubber, especially when all the code has been written before? :slightly_smiling_face: 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix #477
