### PR TITLE
Tracechain must implements ContentInterface to be part of Body.

### DIFF
--- a/src/Payload/TraceChain.php
+++ b/src/Payload/TraceChain.php
@@ -4,7 +4,7 @@ namespace Rollbar\Payload;
 
 use Rollbar\SerializerInterface;
 
-class TraceChain implements SerializerInterface
+class TraceChain implements ContentInterface
 {
     public function __construct(private array $traces)
     {


### PR DESCRIPTION
## Description of the change

In current release (3.1.0), When TraceChain is given to Body, an exception is given because TraceChain does not implements ContentInterface.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix https://github.com/rollbar/rollbar-php/issues/559