### PR TITLE
Fixed Person ID not cast to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.2] - 2022-03-30
+This release is a patch to fix a regression in functionality that was introduced
+in v3.0.0.
+### Fixed
+* Fixed https://github.com/rollbar/rollbar-php-laravel/issues/134 Person ID not 
+  cast to string by @danielmorell in #562
+
+## [3.1.1] - 2022-03-11
+This release is a patch to fix a bug in the TraceChain class that was introduced 
+in v3.1.0.
+### Fixed
+* Tracechain must implements ContentInterface to be part of Body. by @stephpy 
+  in #560
+
+## [3.1.0] - 2022-03-09
+Aside from some needed maintenance and bug fixes, this release resolves some 
+issues needed to support PHP 8.1. It also updates our support for `psr/log` to 
+v2! The other significant update is the addition of the `transformer` option.
+
+One of the important changes is in what types can be passed to `custom` argument 
+in `Rollbar\Rollbar::init()`. Passing in an object or class instance that does 
+not implement the new `Rollbar\SerializerInterface` has been deprecated. This 
+helps us ensure any custom values in your payload are serializable, and they can 
+be sent to Rollbar serves without error.
+### Added
+- Added transformer option by @danielroehrig in #543
+- Allow `psr/log` v2 by @Jean85 in #536
+- Added psalm static analysis by @bishopb in #550, and #551
+- Added `Rollbar\SerializerInterface` to describe serialization behavior @danielmorell in #558
+### Fixed
+- Fixed `report_suppressed` isset check by @trsteel88 and @bishopb in #539, and $546.
+- Fixed missed cleanup of synthetic member variable by @bishopb in #547
+- Fixed possibly null argument by @bishopb in #552
+- Fixed deprecation warnings on PHP 8.1 @danielmorell in #558
+### Changed
+* Update PR template by @bxsx in #549
+
 ## [3.0.0] - 2021-06-28
 ### Changed
 - The new configuration option `scrub_safelist` replaces the deprecated
@@ -550,7 +587,10 @@ however this is for convenience only and the methods that have changed have been
 - Error handler function (`report_php_error`) now always returns false, so that the default php error handler still runs. This is a breaking change if your code relied on the old behavior where the error handler did *not* ever halt script execution.
 
 
-[Unreleased]: https://github.com/rollbar/rollbar-php/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/rollbar/rollbar-php/compare/v3.1.2...HEAD
+[3.1.2]: https://github.com/rollbar/rollbar-php/compare/v3.1.1...v3.1.2
+[3.1.1]: https://github.com/rollbar/rollbar-php/compare/v3.1.0...v3.1.1
+[3.1.0]: https://github.com/rollbar/rollbar-php/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/rollbar/rollbar-php/compare/v3.0.0-RC2...v3.0.0
 [3.0.0-RC2]: https://github.com/rollbar/rollbar-php/compare/v3.0.0-RC1...v3.0.0-RC2
 [3.0.0-RC1]: https://github.com/rollbar/rollbar-php/compare/v2.1.0...v3.0.0-RC1

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -900,7 +900,7 @@ class DataBuilder implements DataBuilderInterface
             return null;
         }
 
-        $identifier = $personData['id'];
+        $identifier = (string)$personData['id'];
 
         $email = null;
         if ($this->captureEmail && isset($personData['email'])) {

--- a/src/Payload/Notifier.php
+++ b/src/Payload/Notifier.php
@@ -8,7 +8,7 @@ use Rollbar\UtilitiesTrait;
 class Notifier implements SerializerInterface
 {
     const NAME = "rollbar-php";
-    const VERSION = "3.0.0";
+    const VERSION = "3.1.2";
 
     use UtilitiesTrait;
 

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -762,6 +762,25 @@ class DataBuilderTest extends BaseRollbarTest
         $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('123', $output->getPerson()->getId());
     }
+
+    public function testPersonIntID()
+    {
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => $this->getTestAccessToken(),
+            'environment' => 'tests',
+            'person' => array(
+                'id' => 123,
+                'username' => 'tester',
+                'email' => 'test@test.com'
+            ),
+            'levelFactory' => new LevelFactory,
+            'utilities' => new Utilities
+        ));
+        $output = $dataBuilder->makeData(Level::ERROR, "testing", array());
+        $this->assertEquals('123', $output->getPerson()->getId());
+        $this->assertNull($output->getPerson()->getUsername());
+        $this->assertNull($output->getPerson()->getEmail());
+    }
     
     public function testPersonFuncException()
     {
@@ -904,7 +923,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
         // 900 is the line number where the comment "// A" is found
         $this->assertEquals(
-            900,
+            919,
             $frames[count($frames)-1]->getLineno(),
             "Possible false negative: did this file change? Check the line number for line with '// A' comment"
         );


### PR DESCRIPTION
## Description of the change

This resolves https://github.com/rollbar/rollbar-php-laravel/issues/134. It simply casts the ID to a `string` before it is passed to the `Person` constructor as [suggested by](https://github.com/rollbar/rollbar-php-laravel/issues/134#issuecomment-1083503507) @matt-h.

I have also added a new test to make sure we don't have a regression of this in the future.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix https://github.com/rollbar/rollbar-php-laravel/issues/134

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
