### PR TITLE
Fix error suppressor context detection for PHP 8 

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -178,7 +178,7 @@ class DataBuilder implements DataBuilderInterface
         $fromConfig = isset($config['local_vars_dump']) ? $config['local_vars_dump'] : null;
         $this->localVarsDump = self::$defaults->localVarsDump($fromConfig);
         if ($this->localVarsDump && !empty(ini_get('zend.exception_ignore_args'))) {
-            ini_set('zend.exception_ignore_args', 'Off');
+            ini_set('zend.exception_ignore_args', '0');
             assert(empty(ini_get('zend.exception_ignore_args')));
         }
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -381,6 +381,16 @@ class ConfigTest extends BaseRollbarTest
         }
     }
 
+    public function testReportSuppressedActuallySuppressed()
+    {
+        $config = new Config(array(
+            'report_suppressed' => false,
+            "access_token" => $this->getTestAccessToken()
+        ));
+        $this->assertFalse($config->shouldSuppress());
+        $this->assertTrue(@$config->shouldSuppress());
+    }
+
     public function testFilter()
     {
         $d = m::mock("Rollbar\Payload\Data")


### PR DESCRIPTION
## Description of the change

I upgraded PHP and Rollber client then too many errors are reported. I'm using `@` operator.
PHP 8 changed `error_reporting()` return value when it used with `@`.

https://www.php.net/manual/en/language.operators.errorcontrol.php

```php
<?php
function f() {
    echo error_reporting(), PHP_EOL;
}

error_reporting (E_ALL);
f();    // -1
@f();   // PHP7:0 / PHP8:4437
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
