### PR TITLE
Safer parse_str() usage

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -178,7 +178,7 @@ class DataBuilder implements DataBuilderInterface
         $fromConfig = isset($config['local_vars_dump']) ? $config['local_vars_dump'] : null;
         $this->localVarsDump = self::$defaults->localVarsDump($fromConfig);
         if ($this->localVarsDump && !empty(ini_get('zend.exception_ignore_args'))) {
-            ini_set('zend.exception_ignore_args', 'Off');
+            ini_set('zend.exception_ignore_args', '0');
             assert(empty(ini_get('zend.exception_ignore_args')));
         }
     }

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -630,7 +630,8 @@ class DataBuilder implements DataBuilderInterface
             $postData = array();
             $body = $request->getBody();
             if ($body !== null) {
-                parse_str($body, $postData);
+                // PHP reports warning if parse_str() detects more than max_input_vars items.
+                @parse_str($body, $postData);
             }
             $request->setPost($postData);
         }

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -80,7 +80,8 @@ class Scrubber implements ScrubberInterface
                     $data
                 );
             } else {
-                parse_str($data, $parsedData);
+                // PHP reports warning if parse_str() detects more than max_input_vars items.
+                @parse_str($data, $parsedData);
                 if (http_build_query($parsedData) === $data) {
                     $data = $this->scrubQueryString($data, $fields);
                 }
@@ -131,7 +132,8 @@ class Scrubber implements ScrubberInterface
 
     protected function scrubQueryString($query, $fields, $replacement = 'xxxxxxxx')
     {
-        parse_str($query, $parsed);
+        // PHP reports warning if parse_str() detects more than max_input_vars items.
+        @parse_str($query, $parsed);
         $scrubbed = $this->internalScrub($parsed, $fields, $replacement, '');
         return http_build_query($scrubbed);
     }


### PR DESCRIPTION
## Description of the change

`parse_str()` reports warning if parsed items exceeded over than`max_input_vars`. Rollbar Logger logs this internal error instead of user errors.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
