### PR TITLE
fix: try using __serialize when obj implements \Serializable

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -1015,10 +1015,14 @@ class DataBuilder implements DataBuilderInterface
     {
         // This check is placed first because it should return a string|null, and we want to return an array.
         if ($custom instanceof \Serializable) {
-            trigger_error("Using the Serializable interface has been deprecated.", E_USER_DEPRECATED);
             // We don't return this value instead we run it through the rest of the checks. The same is true for the
             // next check.
-            $custom = $custom->serialize();
+            if (method_exists($custom, '__serialize')) {
+                $custom = $custom->__serialize();
+            } else {
+                trigger_error("Using the Serializable interface has been deprecated.", E_USER_DEPRECATED);
+                $custom = $custom->serialize();
+            }
         } else {
             if ($custom instanceof SerializerInterface) {
                 $custom = $custom->serialize();

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -147,9 +147,13 @@ final class Utilities
             $serialized = self::circularReferenceLabel($obj);
         } else {
             if ($obj instanceof \Serializable) {
-                trigger_error("Using the Serializable interface has been deprecated.", E_USER_DEPRECATED);
                 self::markSerialized($obj, $objectHashes);
-                $serialized = $obj->serialize();
+                if (method_exists($obj, '__serialize')) {
+                    $serialized = $obj->__serialize();
+                } else {
+                    trigger_error("Using the Serializable interface has been deprecated.", E_USER_DEPRECATED);
+                    $serialized = $obj->serialize();
+                }
             } elseif ($obj instanceof SerializerInterface) {
                 self::markSerialized($obj, $objectHashes);
                 $serialized = $obj->serialize();

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,6 +12,7 @@ use Rollbar\RollbarLogger;
 use Rollbar\Defaults;
 
 use Rollbar\TestHelpers\CustomSerializable;
+use Rollbar\TestHelpers\DeprecatedSerializable;
 use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
 use Rollbar\TestHelpers\Exceptions\FiftyFiftyExceptionSampleRate;
 use Rollbar\TestHelpers\Exceptions\FiftyFityChildExceptionSampleRate;
@@ -531,7 +532,7 @@ class ConfigTest extends BaseRollbarTest
         $this->assertSame($expectedCustom, $actualCustom);
     }
 
-    public function testCustomSerializable()
+    public function testDeprecatedSerializable()
     {
         $expectedCustom = array(
             "foo" => "bar",
@@ -540,7 +541,7 @@ class ConfigTest extends BaseRollbarTest
         $config = new Config(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => $this->env,
-            "custom" => new CustomSerializable($expectedCustom),
+            "custom" => new DeprecatedSerializable($expectedCustom),
         ));
 
         // New error handler to make sure we get the deprecated notice
@@ -566,7 +567,43 @@ class ConfigTest extends BaseRollbarTest
 
         $this->assertSame($expectedCustom, $actualCustom);
     }
-    
+
+    public function testCustomSerializable()
+    {
+        $expectedCustom = array(
+            "foo" => "bar",
+            "fuzz" => "buzz"
+        );
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "custom" => new CustomSerializable($expectedCustom),
+        ));
+
+        // Make sure the deprecation notice is not sent if the object implements __serializable as it should
+        set_error_handler(function (
+            int $errno,
+            string $errstr,
+        ) : bool {
+            $this->assertStringNotContainsString("Serializable", $errstr);
+            $this->assertStringNotContainsString("deprecated", $errstr);
+            return true;
+        }, E_USER_DEPRECATED);
+
+        $result = $config->getDataBuilder()->makeData(
+            Level::INFO,
+            "Test message with custom data added dynamically.",
+            array(),
+        );
+
+        // Clear the handler, so it does not mess with other tests.
+        restore_error_handler();
+
+        $actualCustom = $result->getCustom();
+
+        $this->assertSame($expectedCustom, $actualCustom);
+    }
+
     public function testMaxItems()
     {
         $config = new Config(array(

--- a/tests/TestHelpers/CustomSerializable.php
+++ b/tests/TestHelpers/CustomSerializable.php
@@ -1,4 +1,6 @@
-<?php namespace Rollbar\TestHelpers;
+<?php
+
+namespace Rollbar\TestHelpers;
 
 class CustomSerializable implements \Serializable
 {
@@ -11,7 +13,7 @@ class CustomSerializable implements \Serializable
 
     public function serialize()
     {
-        return $this->data;
+        throw new \Exception("Not implemented");
     }
 
     public function unserialize(string $data)
@@ -21,7 +23,7 @@ class CustomSerializable implements \Serializable
 
     public function __serialize(): array
     {
-        throw new \Exception("Not implemented");
+        return $this->data;
     }
 
     public function __unserialize(array $data): void

--- a/tests/TestHelpers/DeprecatedSerializable.php
+++ b/tests/TestHelpers/DeprecatedSerializable.php
@@ -1,0 +1,21 @@
+<?php namespace Rollbar\TestHelpers;
+
+class DeprecatedSerializable implements \Serializable
+{
+    public $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    public function serialize()
+    {
+        return $this->data;
+    }
+
+    public function unserialize(string $data)
+    {
+        throw new \Exception("Not implemented");
+    }
+}


### PR DESCRIPTION
## Description of the change

The Serializable interface is now being deprecated in favour of using
the magic methods __serialize() and __unserialize().

Some packages decided to start throwing exceptions on their Serializable
implementations if the interface methods were called.

This commit tries to check if the classes that implement Serializable
are already using __serialize() and if they are, it calls that method,
instead of the interface one serialize().

If this is the case, we also hide the deprecation notice, since it seems
the client code is already preparing to drop \Serializable when the time
comes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix https://github.com/rollbar/rollbar-php-laravel/issues/136

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
