### PR TITLE
feat: php 8 language level mitigations, add typehints for tests

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -17,6 +17,9 @@ use Rollbar\Senders\SenderInterface;
 use Rollbar\TransformerInterface;
 use Rollbar\UtilitiesTrait;
 use Throwable;
+use Rollbar\ResponseHandlerInterface;
+use Rollbar\Senders\FluentSender;
+use Rollbar\FilterInterface;
 
 class Config
 {
@@ -425,7 +428,7 @@ class Config
     {
         $this->minimumLevel = \Rollbar\Defaults::get()->minimumLevel();
 
-        $override = array_key_exists('minimum_level', $config) ? $config['minimum_level'] : null;
+        $override = $config['minimum_level'] ?? null;
         $override = array_key_exists('minimumLevel', $config) ? $config['minimumLevel'] : $override;
 
         if ($override instanceof Level) {
@@ -454,7 +457,7 @@ class Config
 
     private function setFilters(array $config): void
     {
-        $this->setupWithOptions($config, "filter", "Rollbar\FilterInterface");
+        $this->setupWithOptions($config, "filter", FilterInterface::class);
     }
 
     private function setSender(array $config): void
@@ -606,7 +609,7 @@ class Config
         if (!isset($config['handler']) || $config['handler'] != 'fluent') {
             return $default;
         }
-        $default = "Rollbar\Senders\FluentSender";
+        $default = FluentSender::class;
 
         if (isset($config['fluent_host'])) {
             $config['senderOptions']['fluentHost'] = $config['fluent_host'];
@@ -625,7 +628,7 @@ class Config
 
     private function setResponseHandler(array $config): void
     {
-        $this->setupWithOptions($config, "responseHandler", "Rollbar\ResponseHandlerInterface");
+        $this->setupWithOptions($config, "responseHandler", ResponseHandlerInterface::class);
     }
 
     private function setCheckIgnoreFunction(array $config): void
@@ -694,9 +697,7 @@ class Config
             if ($passWholeConfig) {
                 $options = $config;
             } else {
-                $options = isset($config[$keyName . "Options"]) ?
-                            $config[$keyName . "Options"] :
-                            array();
+                $options = $config[$keyName . "Options"] ?? array();
             }
             $this->$keyName = new $class($options);
         } else {

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -114,109 +114,109 @@ class DataBuilder implements DataBuilderInterface
 
     protected function setCaptureIP($config)
     {
-        $fromConfig = isset($config['capture_ip']) ? $config['capture_ip'] : null;
+        $fromConfig = $config['capture_ip'] ?? null;
         $this->captureIP = self::$defaults->captureIP($fromConfig);
     }
     
     protected function setCaptureEmail($config)
     {
-        $fromConfig = isset($config['capture_email']) ? $config['capture_email'] : null;
+        $fromConfig = $config['capture_email'] ?? null;
         $this->captureEmail = self::$defaults->captureEmail($fromConfig);
     }
     
     protected function setCaptureUsername($config)
     {
-        $fromConfig = isset($config['capture_username']) ? $config['capture_username'] : null;
+        $fromConfig = $config['capture_username'] ?? null;
         $this->captureUsername = self::$defaults->captureUsername($fromConfig);
     }
 
     protected function setEnvironment($config)
     {
-        $fromConfig = isset($config['environment']) ? $config['environment'] : self::$defaults->get()->environment();
+        $fromConfig = $config['environment'] ?? self::$defaults->get()->environment();
         $this->utilities->validateString($fromConfig, "config['environment']", null, false);
         $this->environment = $fromConfig;
     }
 
     protected function setDefaultMessageLevel($config)
     {
-        $fromConfig = isset($config['messageLevel']) ? $config['messageLevel'] : null;
+        $fromConfig = $config['messageLevel'] ?? null;
         $this->messageLevel = self::$defaults->messageLevel($fromConfig);
     }
 
     protected function setDefaultExceptionLevel($config)
     {
-        $fromConfig = isset($config['exceptionLevel']) ? $config['exceptionLevel'] : null;
+        $fromConfig = $config['exceptionLevel'] ?? null;
         $this->exceptionLevel = self::$defaults->exceptionLevel($fromConfig);
     }
 
     protected function setDefaultPsrLevels($config)
     {
-        $fromConfig = isset($config['psrLevels']) ? $config['psrLevels'] : null;
+        $fromConfig = $config['psrLevels'] ?? null;
         $this->psrLevels = self::$defaults->psrLevels($fromConfig);
     }
 
     protected function setErrorLevels($config)
     {
-        $fromConfig = isset($config['errorLevels']) ? $config['errorLevels'] : null;
+        $fromConfig = $config['errorLevels'] ?? null;
         $this->errorLevels = self::$defaults->errorLevels($fromConfig);
     }
 
     protected function setSendMessageTrace($config)
     {
-        $fromConfig = isset($config['send_message_trace']) ? $config['send_message_trace'] : null;
+        $fromConfig = $config['send_message_trace'] ?? null;
         $this->sendMessageTrace = self::$defaults->sendMessageTrace($fromConfig);
     }
     
     protected function setRawRequestBody($config)
     {
-        $fromConfig = isset($config['include_raw_request_body']) ? $config['include_raw_request_body'] : null;
+        $fromConfig = $config['include_raw_request_body'] ?? null;
         $this->rawRequestBody = self::$defaults->rawRequestBody($fromConfig);
     }
 
     protected function setLocalVarsDump($config)
     {
-        $fromConfig = isset($config['local_vars_dump']) ? $config['local_vars_dump'] : null;
+        $fromConfig = $config['local_vars_dump'] ?? null;
         $this->localVarsDump = self::$defaults->localVarsDump($fromConfig);
         if ($this->localVarsDump && !empty(ini_get('zend.exception_ignore_args'))) {
             ini_set('zend.exception_ignore_args', 'Off');
-            assert(empty(ini_get('zend.exception_ignore_args')));
+            assert(empty(ini_get('zend.exception_ignore_args')) ||  ini_get('zend.exception_ignore_args') === "Off");
         }
     }
     
     protected function setCaptureErrorStacktraces($config)
     {
-        $fromConfig = isset($config['capture_error_stacktraces']) ? $config['capture_error_stacktraces'] : null;
+        $fromConfig = $config['capture_error_stacktraces'] ?? null;
         $this->captureErrorStacktraces = self::$defaults->captureErrorStacktraces($fromConfig);
     }
 
     protected function setCodeVersion($config)
     {
-        $fromConfig = isset($config['codeVersion']) ? $config['codeVersion'] : null;
+        $fromConfig = $config['codeVersion'] ?? null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['code_version']) ? $config['code_version'] : null;
+            $fromConfig = $config['code_version'] ?? null;
         }
         $this->codeVersion = self::$defaults->codeVersion($fromConfig);
     }
 
     protected function setPlatform($config)
     {
-        $fromConfig = isset($config['platform']) ? $config['platform'] : null;
+        $fromConfig = $config['platform'] ?? null;
         $this->platform = self::$defaults->platform($fromConfig);
     }
 
     protected function setFramework($config)
     {
-        $this->framework = isset($config['framework']) ? $config['framework'] : null;
+        $this->framework = $config['framework'] ?? null;
     }
 
     protected function setContext($config)
     {
-        $this->context = isset($config['context']) ? $config['context'] : null;
+        $this->context = $config['context'] ?? null;
     }
 
     protected function setRequestParams($config)
     {
-        $this->requestParams = isset($config['requestParams']) ? $config['requestParams'] : null;
+        $this->requestParams = $config['requestParams'] ?? null;
     }
 
     /*
@@ -225,7 +225,7 @@ class DataBuilder implements DataBuilderInterface
     protected function setRequestBody($config)
     {
         
-        $this->requestBody = isset($config['requestBody']) ? $config['requestBody'] : null;
+        $this->requestBody = $config['requestBody'] ?? null;
         
         if (!$this->requestBody && $this->rawRequestBody) {
             $this->requestBody = file_get_contents("php://input");
@@ -234,46 +234,42 @@ class DataBuilder implements DataBuilderInterface
 
     protected function setRequestExtras($config)
     {
-        $this->requestExtras = isset($config["requestExtras"]) ? $config["requestExtras"] : null;
+        $this->requestExtras = $config["requestExtras"] ?? null;
     }
 
     protected function setPerson($config)
     {
-        $this->person = isset($config['person']) ? $config['person'] : null;
+        $this->person = $config['person'] ?? null;
     }
 
     protected function setPersonFunc($config)
     {
-        $this->personFunc = isset($config['person_fn']) ? $config['person_fn'] : null;
+        $this->personFunc = $config['person_fn'] ?? null;
     }
 
     protected function setServerRoot($config)
     {
-        $fromConfig = isset($config['serverRoot']) ? $config['serverRoot'] : null;
+        $fromConfig = $config['serverRoot'] ?? null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['root']) ? $config['root'] : null;
+            $fromConfig = $config['root'] ?? null;
         }
         $this->serverRoot = self::$defaults->serverRoot($fromConfig);
     }
 
     protected function setServerBranch($config)
     {
-        $fromConfig = isset($config['serverBranch']) ? $config['serverBranch'] : null;
+        $fromConfig = $config['serverBranch'] ?? null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['branch']) ? $config['branch'] : null;
+            $fromConfig = $config['branch'] ?? null;
         }
             
         $this->serverBranch = self::$defaults->branch($fromConfig);
         
         if ($this->serverBranch === null) {
-            $autodetectBranch = isset($config['autodetect_branch']) ?
-                $config['autodetect_branch'] :
-                self::$defaults->autodetectBranch();
+            $autodetectBranch = $config['autodetect_branch'] ?? self::$defaults->autodetectBranch();
             
             if ($autodetectBranch) {
-                $allowExec = isset($config['allow_exec']) ?
-                    $config['allow_exec'] :
-                    self::$defaults->allowExec();
+                $allowExec = $config['allow_exec'] ?? self::$defaults->allowExec();
                     
                 $this->serverBranch = $this->detectGitBranch($allowExec);
             }
@@ -282,64 +278,62 @@ class DataBuilder implements DataBuilderInterface
 
     protected function setServerCodeVersion($config)
     {
-        $this->serverCodeVersion = isset($config['serverCodeVersion']) ? $config['serverCodeVersion'] : null;
+        $this->serverCodeVersion = $config['serverCodeVersion'] ?? null;
     }
 
     protected function setServerExtras($config)
     {
-        $this->serverExtras = isset($config['serverExtras']) ? $config['serverExtras'] : null;
+        $this->serverExtras = $config['serverExtras'] ?? null;
     }
 
     public function setCustom($config)
     {
-        $this->custom = isset($config['custom']) ? $config['custom'] : \Rollbar\Defaults::get()->custom();
+        $this->custom = $config['custom'] ?? \Rollbar\Defaults::get()->custom();
     }
     
     public function setCustomDataMethod($config)
     {
-        $this->customDataMethod = isset($config['custom_data_method']) ?
-            $config['custom_data_method'] :
-            \Rollbar\Defaults::get()->customDataMethod();
+        $this->customDataMethod = $config['custom_data_method'] ?? \Rollbar\Defaults::get()->customDataMethod();
     }
 
     protected function setFingerprint($config)
     {
-        $this->fingerprint = isset($config['fingerprint']) ? $config['fingerprint'] : null;
+        $this->fingerprint = $config['fingerprint'] ?? null;
     }
 
     protected function setTitle($config)
     {
-        $this->title = isset($config['title']) ? $config['title'] : null;
+        $this->title = $config['title'] ?? null;
     }
 
     protected function setNotifier($config)
     {
-        $fromConfig = isset($config['notifier']) ? $config['notifier'] : null;
+        $fromConfig = $config['notifier'] ?? null;
         $this->notifier = self::$defaults->notifier($fromConfig);
     }
 
     protected function setBaseException($config)
     {
-        $fromConfig = isset($config['baseException']) ? $config['baseException'] : null;
+        $fromConfig = $config['baseException'] ?? null;
         $this->baseException = self::$defaults->baseException($fromConfig);
     }
 
     protected function setIncludeCodeContext($config)
     {
-        $fromConfig = isset($config['include_error_code_context']) ? $config['include_error_code_context'] : null;
+        $fromConfig = $config['include_error_code_context'] ?? null;
         $this->includeCodeContext = self::$defaults->includeCodeContext($fromConfig);
     }
 
     protected function setIncludeExcCodeContext($config)
     {
         $fromConfig =
-            isset($config['include_exception_code_context']) ? $config['include_exception_code_context'] : null;
+            $config['include_exception_code_context'] ?? null;
         $this->includeExcCodeContext = self::$defaults->includeExcCodeContext($fromConfig);
     }
     
     protected function setLevelFactory($config)
     {
-        $this->levelFactory = isset($config['levelFactory']) ? $config['levelFactory'] : null;
+        $this->levelFactory = $config['levelFactory'] ?? null;
         if (!$this->levelFactory) {
             throw new \InvalidArgumentException(
                 'Missing dependency: LevelFactory not provided to the DataBuilder.'
@@ -349,7 +343,7 @@ class DataBuilder implements DataBuilderInterface
     
     protected function setUtilities($config)
     {
-        $this->utilities = isset($config['utilities']) ? $config['utilities'] : null;
+        $this->utilities = $config['utilities'] ?? null;
         if (!$this->utilities) {
             throw new \InvalidArgumentException(
                 'Missing dependency: Utilities not provided to the DataBuilder.'
@@ -359,7 +353,7 @@ class DataBuilder implements DataBuilderInterface
 
     protected function setHost($config)
     {
-        $this->host = isset($config['host']) ? $config['host'] : self::$defaults->host();
+        $this->host = $config['host'] ?? self::$defaults->host();
     }
 
     /**
@@ -615,8 +609,8 @@ class DataBuilder implements DataBuilderInterface
             ->setUserIp($this->getUserIp());
       
         if (isset($_SERVER)) {
-            $request->setMethod(isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : null)
-                ->setQueryString(isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : null);
+            $request->setMethod($_SERVER['REQUEST_METHOD'] ?? null)
+                ->setQueryString($_SERVER['QUERY_STRING'] ?? null);
         }
       
         if (isset($_GET)) {
@@ -682,11 +676,11 @@ class DataBuilder implements DataBuilderInterface
                     
                     if (stripos($fpPart, 'for=') !== false) {
                         // Parse 'for' forwarded pair
-                        $result['for'] = isset($result['for']) ? $result['for'] : array();
+                        $result['for'] = $result['for'] ?? array();
                         $result['for'][] = substr($fpPart, strlen('for='));
                     } elseif (stripos($fpPart, 'by=') !== false) {
                         // Parse 'by' forwarded pair
-                        $result['by'] = isset($result['by']) ? $result['by'] : array();
+                        $result['by'] = $result['by'] ?? array();
                         $result['by'][] = substr($fpPart, strlen('by='));
                     }
                 }
@@ -784,7 +778,7 @@ class DataBuilder implements DataBuilderInterface
         }
 
         if (isset($_SERVER)) {
-            $path = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '/';
+            $path = $_SERVER['REQUEST_URI'] ?? '/';
             $url .= $path;
         }
 
@@ -940,10 +934,7 @@ class DataBuilder implements DataBuilderInterface
 
     protected function getHost()
     {
-        if (isset($this->host)) {
-            return $this->host;
-        }
-        return gethostname();
+        return $this->host ?? gethostname();
     }
 
     protected function getServerRoot()
@@ -1065,7 +1056,7 @@ class DataBuilder implements DataBuilderInterface
 
     protected function getFingerprint($context)
     {
-        return isset($context['fingerprint']) ? $context['fingerprint'] : $this->fingerprint;
+        return $context['fingerprint'] ?? $this->fingerprint;
     }
 
     protected function getTitle()
@@ -1193,7 +1184,7 @@ class DataBuilder implements DataBuilderInterface
 
         // in XDebug 3 and later, the function is defined but disabled unless
         // the xdebug mode parameter includes it
-        return false === strpos(ini_get('xdebug.mode'), 'develop') ? false : true;
+        return !str_contains(ini_get('xdebug.mode'), 'develop') ? false : true;
     }
     
     private function fetchErrorTrace()

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -57,7 +57,7 @@ class Defaults
             'csrf_token',
             'access_token'
         );
-        $this->serverRoot = isset($_ENV["HEROKU_APP_DIR"]) ? $_ENV["HEROKU_APP_DIR"] : null;
+        $this->serverRoot = $_ENV["HEROKU_APP_DIR"] ?? null;
         $this->platform = php_uname('a');
         $this->notifier = Notifier::defaultNotifier();
         $this->baseException = Throwable::class;
@@ -86,252 +86,252 @@ class Defaults
     
     public function psrLevels($value = null)
     {
-        return $value !== null ? $value : $this->psrLevels;
+        return $value ?? $this->psrLevels;
     }
 
     public function errorLevels($value = null)
     {
-        return $value !== null ? $value : $this->errorLevels;
+        return $value ?? $this->errorLevels;
     }
 
     public function autodetectBranch($value = null)
     {
-        return $value !== null ? $value : $this->autodetectBranch;
+        return $value ?? $this->autodetectBranch;
     }
 
     public function branch($value = null)
     {
-        return $value !== null ? $value : $this->branch;
+        return $value ?? $this->branch;
     }
 
     public function serverRoot($value = null)
     {
-        return $value !== null ? $value : $this->serverRoot;
+        return $value ?? $this->serverRoot;
     }
 
     public function platform($value = null)
     {
-        return $value !== null ? $value : $this->platform;
+        return $value ?? $this->platform;
     }
 
     public function notifier($value = null)
     {
-        return $value !== null ? $value : $this->notifier;
+        return $value ?? $this->notifier;
     }
 
     public function baseException($value = null)
     {
-        return $value !== null ? $value : $this->baseException;
+        return $value ?? $this->baseException;
     }
 
     public function codeVersion($value = null)
     {
-        return $value !== null ? $value : $this->codeVersion;
+        return $value ?? $this->codeVersion;
     }
 
     public function sendMessageTrace($value = null)
     {
-        return $value !== null ? $value : $this->sendMessageTrace;
+        return $value ?? $this->sendMessageTrace;
     }
 
     public function includeCodeContext($value = null)
     {
-        return $value !== null ? $value : $this->includeCodeContext;
+        return $value ?? $this->includeCodeContext;
     }
 
     public function includeExcCodeContext($value = null)
     {
-        return $value !== null ? $value : $this->includeExcCodeContext;
+        return $value ?? $this->includeExcCodeContext;
     }
 
     public function rawRequestBody($value = null)
     {
-        return $value !== null ? $value : $this->rawRequestBody;
+        return $value ?? $this->rawRequestBody;
     }
 
     public function localVarsDump($value = null)
     {
-        return $value !== null ? $value : $this->localVarsDump;
+        return $value ?? $this->localVarsDump;
     }
 
     public function errorSampleRates($value = null)
     {
-        return $value !== null ? $value : $this->errorSampleRates;
+        return $value ?? $this->errorSampleRates;
     }
 
     public function exceptionSampleRates($value = null)
     {
-        return $value !== null ? $value : $this->exceptionSampleRates;
+        return $value ?? $this->exceptionSampleRates;
     }
 
     public function includedErrno($value = null)
     {
-        return $value !== null ? $value : $this->includedErrno;
+        return $value ?? $this->includedErrno;
     }
 
     public function includeErrorCodeContext($value = null)
     {
-        return $value !== null ? $value : $this->includeErrorCodeContext;
+        return $value ?? $this->includeErrorCodeContext;
     }
 
     public function includeExceptionCodeContext($value = null)
     {
-        return $value !== null ? $value : $this->includeExceptionCodeContext;
+        return $value ?? $this->includeExceptionCodeContext;
     }
 
     public function agentLogLocation($value = null)
     {
-        return $value !== null ? $value : $this->agentLogLocation;
+        return $value ?? $this->agentLogLocation;
     }
 
     public function allowExec($value = null)
     {
-        return $value !== null ? $value : $this->allowExec;
+        return $value ?? $this->allowExec;
     }
 
     public function messageLevel($value = null)
     {
-        return $value !== null ? $value : $this->messageLevel;
+        return $value ?? $this->messageLevel;
     }
 
     public function exceptionLevel($value = null)
     {
-        return $value !== null ? $value : $this->exceptionLevel;
+        return $value ?? $this->exceptionLevel;
     }
 
     public function endpoint($value = null)
     {
-        return $value !== null ? $value : $this->endpoint;
+        return $value ?? $this->endpoint;
     }
 
     public function captureErrorStacktraces($value = null)
     {
-        return $value !== null ? $value : $this->captureErrorStacktraces;
+        return $value ?? $this->captureErrorStacktraces;
     }
 
     public function checkIgnore($value = null)
     {
-        return $value !== null ? $value : $this->checkIgnore;
+        return $value ?? $this->checkIgnore;
     }
 
     public function custom($value = null)
     {
-        return $value !== null ? $value : $this->custom;
+        return $value ?? $this->custom;
     }
 
     public function customDataMethod($value = null)
     {
-        return $value !== null ? $value : $this->customDataMethod;
+        return $value ?? $this->customDataMethod;
     }
 
     public function enabled($value = null)
     {
-        return $value !== null ? $value : $this->enabled;
+        return $value ?? $this->enabled;
     }
 
     public function transmit($value = null)
     {
-        return $value !== null ? $value : $this->transmit;
+        return $value ?? $this->transmit;
     }
 
     public function logPayload($value = null)
     {
-        return $value !== null ? $value : $this->logPayload;
+        return $value ?? $this->logPayload;
     }
 
     public function verbose($value = null)
     {
-        return $value !== null ? $value : $this->verbose;
+        return $value ?? $this->verbose;
     }
 
     public function environment($value = null)
     {
-        return $value !== null ? $value : $this->environment;
+        return $value ?? $this->environment;
     }
 
     public function fluentHost($value = null)
     {
-        return $value !== null ? $value : $this->fluentHost;
+        return $value ?? $this->fluentHost;
     }
 
     public function fluentPort($value = null)
     {
-        return $value !== null ? $value : $this->fluentPort;
+        return $value ?? $this->fluentPort;
     }
 
     public function fluentTag($value = null)
     {
-        return $value !== null ? $value : $this->fluentTag;
+        return $value ?? $this->fluentTag;
     }
 
     public function handler($value = null)
     {
-        return $value !== null ? $value : $this->handler;
+        return $value ?? $this->handler;
     }
 
     public function host($value = null)
     {
-        return $value !== null ? $value : $this->host;
+        return $value ?? $this->host;
     }
 
     public function timeout($value = null)
     {
-        return $value !== null ? $value : $this->timeout;
+        return $value ?? $this->timeout;
     }
 
     public function reportSuppressed($value = null)
     {
-        return $value !== null ? $value : $this->reportSuppressed;
+        return $value ?? $this->reportSuppressed;
     }
 
     public function useErrorReporting($value = null)
     {
-        return $value !== null ? $value : $this->useErrorReporting;
+        return $value ?? $this->useErrorReporting;
     }
 
     public function captureIP($value = null)
     {
-        return $value !== null ? $value : $this->captureIP;
+        return $value ?? $this->captureIP;
     }
 
     public function captureEmail($value = null)
     {
-        return $value !== null ? $value : $this->captureEmail;
+        return $value ?? $this->captureEmail;
     }
 
     public function captureUsername($value = null)
     {
-        return $value !== null ? $value : $this->captureUsername;
+        return $value ?? $this->captureUsername;
     }
 
     public function scrubFields($value = null)
     {
-        return $value !== null ? $value : $this->scrubFields;
+        return $value ?? $this->scrubFields;
     }
 
     public function customTruncation($value = null)
     {
-        return $value !== null ? $value : $this->customTruncation;
+        return $value ?? $this->customTruncation;
     }
 
     public function maxNestingDepth($value = null)
     {
-        return $value !== null ? $value : $this->maxNestingDepth;
+        return $value ?? $this->maxNestingDepth;
     }
     
     public function maxItems($value = null)
     {
-        return $value !== null ? $value : $this->maxItems;
+        return $value ?? $this->maxItems;
     }
 
     public function minimumLevel($value = null)
     {
-        return $value !== null ? $value : $this->minimumLevel;
+        return $value ?? $this->minimumLevel;
     }
     
     public function raiseOnError($value = null)
     {
-        return $value !== null ? $value : $this->raiseOnError;
+        return $value ?? $this->raiseOnError;
     }
 
     private $psrLevels;

--- a/src/ErrorWrapper.php
+++ b/src/ErrorWrapper.php
@@ -29,7 +29,7 @@ class ErrorWrapper extends \Exception
                 E_USER_DEPRECATED => "E_USER_DEPRECATED"
             );
         }
-        return isset(self::$constName[$const]) ? self::$constName[$const] : null;
+        return self::$constName[$const] ?? null;
     }
 
     public function __construct(

--- a/src/Handlers/FatalHandler.php
+++ b/src/Handlers/FatalHandler.php
@@ -58,6 +58,6 @@ class FatalHandler extends AbstractHandler
             in_array($lastError['type'], self::$fatalErrors, true) &&
             // don't log uncaught exceptions as they were handled by exceptionHandler()
             !(isset($lastError['message']) &&
-              strpos($lastError['message'], 'Uncaught') === 0);
+                str_starts_with($lastError['message'], 'Uncaught'));
     }
 }

--- a/src/LevelFactory.php
+++ b/src/LevelFactory.php
@@ -37,7 +37,7 @@ class LevelFactory
     {
         self::init();
         $name = strtolower($name);
-        return array_key_exists($name, self::$values) ? self::$values[$name] : null;
+        return self::$values[$name] ?? null;
     }
     
     /**

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -54,7 +54,7 @@ class Rollbar
             return;
         }
 
-        self::$logger = isset($logger) ? $logger : new RollbarLogger($configOrLogger);
+        self::$logger = $logger ?? new RollbarLogger($configOrLogger);
     }
     
     public static function enable()

--- a/src/RollbarJsHelper.php
+++ b/src/RollbarJsHelper.php
@@ -140,8 +140,8 @@ class RollbarJsHelper
     public function shouldAppendNonce($headers)
     {
         foreach ($headers as $header) {
-            if (strpos($header, 'Content-Security-Policy') !== false &&
-                strpos($header, "'unsafe-inline'") !== false) {
+            if (str_contains($header, 'Content-Security-Policy') &&
+                str_contains($header, "'unsafe-inline'")) {
                 return true;
             }
         }

--- a/src/Scrubber.php
+++ b/src/Scrubber.php
@@ -17,9 +17,9 @@ class Scrubber implements ScrubberInterface
 
     protected function setScrubFields($config)
     {
-        $fromConfig = isset($config['scrubFields']) ? $config['scrubFields'] : null;
+        $fromConfig = $config['scrubFields'] ?? null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['scrub_fields']) ? $config['scrub_fields'] : null;
+            $fromConfig = $config['scrub_fields'] ?? null;
         }
         $this->scrubFields = self::$defaults->scrubFields($fromConfig);
     }
@@ -31,11 +31,11 @@ class Scrubber implements ScrubberInterface
 
     protected function setSafelist($config)
     {
-        $fromConfig = isset($config['scrubSafelist']) ? $config['scrubSafelist'] : null;
+        $fromConfig = $config['scrubSafelist'] ?? null;
         if (!isset($fromConfig)) {
-            $fromConfig = isset($config['scrub_safelist']) ? $config['scrub_safelist'] : null;
+            $fromConfig = $config['scrub_safelist'] ?? null;
         }
-        $this->safelist = $fromConfig ? $fromConfig : array();
+        $this->safelist = $fromConfig ?: array();
     }
 
     public function getSafelist()

--- a/src/Truncation/AbstractStrategy.php
+++ b/src/Truncation/AbstractStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 class AbstractStrategy implements IStrategy
 {

--- a/src/Truncation/FramesStrategy.php
+++ b/src/Truncation/FramesStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 class FramesStrategy extends AbstractStrategy
 {

--- a/src/Truncation/IStrategy.php
+++ b/src/Truncation/IStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 interface IStrategy
 {

--- a/src/Truncation/MinBodyStrategy.php
+++ b/src/Truncation/MinBodyStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 class MinBodyStrategy extends AbstractStrategy
 {

--- a/src/Truncation/RawStrategy.php
+++ b/src/Truncation/RawStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 class RawStrategy extends AbstractStrategy
 {

--- a/src/Truncation/StringsStrategy.php
+++ b/src/Truncation/StringsStrategy.php
@@ -2,7 +2,7 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\EncodedPayload;
 
 class StringsStrategy extends AbstractStrategy
 {

--- a/src/Truncation/Truncation.php
+++ b/src/Truncation/Truncation.php
@@ -2,16 +2,19 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Payload\EncodedPayload;
-use \Rollbar\Config;
+use Rollbar\Payload\EncodedPayload;
+use Rollbar\Config;
+use Rollbar\Truncation\AbstractStrategy;
+use Rollbar\Truncation\StringsStrategy;
+use Rollbar\Truncation\FramesStrategy;
 
 class Truncation
 {
     const MAX_PAYLOAD_SIZE = 131072; // 128 * 1024
  
     protected static $truncationStrategies = array(
-        "Rollbar\Truncation\FramesStrategy",
-        "Rollbar\Truncation\StringsStrategy"
+        FramesStrategy::class,
+        StringsStrategy::class
     );
     
     public function __construct(private Config $config)
@@ -23,7 +26,7 @@ class Truncation
     
     public function registerStrategy($type)
     {
-        if (!class_exists($type) || !is_subclass_of($type, "Rollbar\Truncation\AbstractStrategy")) {
+        if (!class_exists($type) || !is_subclass_of($type, AbstractStrategy::class)) {
             throw new \Exception(
                 "Truncation strategy '$type' doesn't exist or is not a subclass " .
                 "of Rollbar\Truncation\AbstractStrategy"

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -63,7 +63,7 @@ final class Utilities
             return;
         }
 
-        if (!is_integer($input)) {
+        if (!is_int($input)) {
             throw new \InvalidArgumentException("\$$name must be an integer");
         }
         if (!is_null($minValue) && $input < $minValue) {

--- a/tests/AgentTest.php
+++ b/tests/AgentTest.php
@@ -4,14 +4,14 @@ namespace Rollbar\Senders; // in a different namespace, so we can monkey-patch m
 
 use Rollbar;
 
-function microtime()
+function microtime(): int
 {
     return 2;
 }
 
 class AgentTest extends Rollbar\BaseRollbarTest
 {
-    private $path = '/tmp/rollbar-php';
+    private string $path = '/tmp/rollbar-php';
 
     protected function setUp(): void
     {
@@ -20,7 +20,7 @@ class AgentTest extends Rollbar\BaseRollbarTest
         }
     }
 
-    public function testAgent()
+    public function testAgent(): void
     {
         Rollbar\Rollbar::init(array(
             'access_token' => $this->getTestAccessToken(),
@@ -30,7 +30,7 @@ class AgentTest extends Rollbar\BaseRollbarTest
         ), false, false, false);
         $logger = Rollbar\Rollbar::logger();
         $logger->info("this is a test");
-        $file = fopen($this->path . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar', 'r');
+        $file = fopen($this->path . '/rollbar-relay.' . getmypid() . '.' . microtime() . '.rollbar', 'r');
         $line = fgets($file);
         $this->assertStringContainsString('this is a test', $line);
     }
@@ -41,7 +41,7 @@ class AgentTest extends Rollbar\BaseRollbarTest
         $this->rrmdir($this->path);
     }
 
-    private function rrmdir($dir)
+    private function rrmdir($dir): void
     {
         if (!is_dir($dir)) {
             return;

--- a/tests/BaseRollbarTest.php
+++ b/tests/BaseRollbarTest.php
@@ -15,8 +15,6 @@ abstract class BaseRollbarTest extends TestCase
 
     public function getTestAccessToken()
     {
-        return isset($_ENV['ROLLBAR_TEST_TOKEN']) ?
-            $_ENV['ROLLBAR_TEST_TOKEN'] :
-            static::DEFAULT_ACCESS_TOKEN;
+        return $_ENV['ROLLBAR_TEST_TOKEN'] ?? static::DEFAULT_ACCESS_TOKEN;
     }
 }

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -1,23 +1,24 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Body;
+use Rollbar\Payload\ContentInterface;
 
 class BodyTest extends BaseRollbarTest
 {
-    public function testBodyValue()
+    public function testBodyValue(): void
     {
-        $value = m::mock("Rollbar\Payload\ContentInterface");
+        $value = m::mock(ContentInterface::class);
         $body = new Body($value);
         $this->assertEquals($value, $body->getValue());
 
-        $mock2 = m::mock("Rollbar\Payload\ContentInterface");
+        $mock2 = m::mock(ContentInterface::class);
         $this->assertEquals($mock2, $body->setValue($mock2)->getValue());
     }
 
-    public function testExtra()
+    public function testExtra(): void
     {
-        $value = m::mock("Rollbar\Payload\ContentInterface")
+        $value = m::mock(ContentInterface::class)
             ->shouldReceive("serialize")
             ->andReturn("{CONTENT}")
             ->shouldReceive("getKey")
@@ -30,9 +31,9 @@ class BodyTest extends BaseRollbarTest
         $this->assertEquals($body->getExtra(), $expected);
     }
 
-    public function testSerialize()
+    public function testSerialize(): void
     {
-        $value = m::mock("Rollbar\Payload\ContentInterface")
+        $value = m::mock(ContentInterface::class)
             ->shouldReceive("serialize")
             ->andReturn("{CONTENT}")
             ->shouldReceive("getKey")

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,11 +1,11 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Context;
 
 class ContextTest extends BaseRollbarTest
 {
-    public function testContextPre()
+    public function testContextPre(): void
     {
         $pre = array("hello", "world");
         $context = new Context($pre, array());
@@ -15,7 +15,7 @@ class ContextTest extends BaseRollbarTest
         $this->assertEquals($pre2, $context->setPre($pre2)->getPre());
     }
 
-    public function testContextPost()
+    public function testContextPost(): void
     {
         $post = array("four", "five");
         $context = new Context(array(), $post);
@@ -25,7 +25,7 @@ class ContextTest extends BaseRollbarTest
         $this->assertEquals($post2, $context->setPost($post2)->getPost());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $context = new Context(array(), array());
         $encoded = json_encode($context->serialize());

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -17,7 +17,8 @@ class CurlSenderTest extends BaseRollbarTest
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
 
         $this->assertContains(
-            $response->getInfo(), array(
+            $response->getInfo(),
+            array(
                 "Couldn't resolve host 'fake-endpointitem'", // hack for PHP 5.3
                 "Could not resolve host: fake-endpointitem",
                 "Could not resolve: fake-endpointitem (Domain name not found)",

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -7,7 +7,7 @@ use Rollbar\Payload\Level;
 class CurlSenderTest extends BaseRollbarTest
 {
     
-    public function testCurlError()
+    public function testCurlError(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -16,15 +16,12 @@ class CurlSenderTest extends BaseRollbarTest
         ));
         $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
 
-        $this->assertTrue(
-            in_array(
-                $response->getInfo(),
-                array(
-                    "Couldn't resolve host 'fake-endpointitem'", // hack for PHP 5.3
-                    "Could not resolve host: fake-endpointitem",
-                    "Could not resolve: fake-endpointitem (Domain name not found)",
-                    "Empty reply from server"
-                )
+        $this->assertContains(
+            $response->getInfo(), array(
+                "Couldn't resolve host 'fake-endpointitem'", // hack for PHP 5.3
+                "Could not resolve host: fake-endpointitem",
+                "Could not resolve: fake-endpointitem (Domain name not found)",
+                "Empty reply from server"
             )
         );
     }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -7,9 +7,6 @@ use Rollbar\TestHelpers\MockPhpStream;
 
 class DataBuilderTest extends BaseRollbarTest
 {
-    /**
-     * @var DataBuilder
-     */
     private DataBuilder $dataBuilder;
 
     public function setUp(): void
@@ -886,8 +883,7 @@ class DataBuilderTest extends BaseRollbarTest
     public function testCaptureErrorStacktracesException(
         $captureErrorStacktraces,
         $expected
-    ): void
-    {
+    ): void {
     
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -921,9 +917,9 @@ class DataBuilderTest extends BaseRollbarTest
             'tests/DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
-        // 919 is the line number where the comment "// A" is found
+        // 915 is the line number where the comment "// A" is found
         $this->assertEquals(
-            919,
+            915,
             $frames[count($frames)-1]->getLineno(),
             "Possible false negative: did this file change? Check the line number for line with '// A' comment"
         );
@@ -936,8 +932,7 @@ class DataBuilderTest extends BaseRollbarTest
     public function testCaptureErrorStacktracesError(
         $captureErrorStacktraces,
         $expected
-    ): void
-    {
+    ): void {
     
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -7,11 +7,10 @@ use Rollbar\TestHelpers\MockPhpStream;
 
 class DataBuilderTest extends BaseRollbarTest
 {
-
     /**
      * @var DataBuilder
      */
-    private $dataBuilder;
+    private DataBuilder $dataBuilder;
 
     public function setUp(): void
     {
@@ -33,13 +32,13 @@ class DataBuilderTest extends BaseRollbarTest
      * @testWith [ "bogus", null ]
      *           [ "error", "error" ]
      */
-    public function testMakeDataLevel($given, $resolved)
+    public function testMakeDataLevel($given, $resolved): void
     {
         $output = $this->dataBuilder->makeData($given, "testing", array());
         $this->assertEquals($resolved, $output->getLevel());
     }
 
-    public function testMakeData()
+    public function testMakeData(): void
     {
         $output = $this->dataBuilder->makeData(Level::ERROR, "testing", array());
         $this->assertEquals('tests', $output->getEnvironment());
@@ -48,7 +47,7 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider getUrlProvider
      */
-    public function testGetUrl($protoData, $hostData, $portData)
+    public function testGetUrl($protoData, $hostData, $portData): void
     {
         // Set up proto
         $pre_SERVER = $_SERVER;
@@ -82,7 +81,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($expected, $result);
     }
     
-    public function getUrlProvider()
+    public function getUrlProvider(): array
     {
         $protoData = $this->getUrlProtoProvider();
         $hostData = $this->getUrlHostProvider();
@@ -116,13 +115,13 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider parseForwardedStringProvider
      */
-    public function testParseForwardedString($forwaded, $expected)
+    public function testParseForwardedString($forwaded, $expected): void
     {
         $output = $this->dataBuilder->parseForwardedString($forwaded);
         $this->assertEquals($expected, $output);
     }
     
-    public function parseForwardedStringProvider()
+    public function parseForwardedStringProvider(): array
     {
         return array(
             array( // test 1
@@ -174,7 +173,7 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider getUrlProtoProvider
      */
-    public function testGetUrlProto($data, $expected)
+    public function testGetUrlProto($data, $expected): void
     {
         $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
@@ -186,7 +185,7 @@ class DataBuilderTest extends BaseRollbarTest
         $_SERVER = $pre_SERVER;
     }
     
-    public function getUrlProtoProvider()
+    public function getUrlProtoProvider(): array
     {
         return array(
             array( // test 1: HTTP_FORWARDED
@@ -229,7 +228,7 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider getUrlHostProvider
      */
-    public function testGetUrlHost($data, $expected)
+    public function testGetUrlHost($data, $expected): void
     {
         $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
@@ -241,7 +240,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($expected, $output);
     }
     
-    public function getUrlHostProvider()
+    public function getUrlHostProvider(): array
     {
         return array(
             array( // test 1: HTTP_FORWARDED
@@ -281,7 +280,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
     }
 
-    public function testGetHeaders()
+    public function testGetHeaders(): void
     {
         $pre_SERVER = $_SERVER;
         $_SERVER = array(
@@ -301,13 +300,13 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider getUrlPortProvider
      */
-    public function testGetUrlPort($data, $expected)
+    public function testGetUrlPort($data, $expected): void
     {
         $pre_SERVER = $_SERVER;
         $_SERVER = array_merge($_SERVER, $data);
         
         $output = $this->dataBuilder->getUrlPort(
-            isset($_SERVER['$proto']) ? $_SERVER['$proto'] : null
+            $_SERVER['$proto'] ?? null
         );
         
         $_SERVER = $pre_SERVER;
@@ -315,7 +314,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($expected, $output);
     }
     
-    public function getUrlPortProvider()
+    public function getUrlPortProvider(): array
     {
         return array(
             array( // test 1: HTTP_X_FORWARDED
@@ -343,7 +342,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
     }
 
-    public function testBranchKey()
+    public function testBranchKey(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -357,7 +356,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('test-branch', $output->getServer()->getBranch());
     }
 
-    public function testCodeVersion()
+    public function testCodeVersion(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -370,7 +369,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('3.4.1', $output->getCodeVersion());
     }
 
-    public function testHost()
+    public function testHost(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -383,7 +382,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('my host', $output->getServer()->getHost());
     }
     
-    public function testGetMessage()
+    public function testGetMessage(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -396,7 +395,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($result->getBody()->getValue()->getBacktrace());
     }
     
-    public function testGetMessageSendMessageTrace()
+    public function testGetMessageSendMessageTrace(): void
     {
         
         $dataBuilder = new DataBuilder(array(
@@ -411,7 +410,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNotEmpty($result->getBody()->getValue()->getBacktrace());
     }
     
-    public function testGetMessageTraceArguments()
+    public function testGetMessageTraceArguments(): void
     {
         // Negative test
         $c = new Config(array(
@@ -450,7 +449,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
     }
     
-    public function testStackFramesAreUnavailableWhenLocalVarsDumpConfigUnset()
+    public function testStackFramesAreUnavailableWhenLocalVarsDumpConfigUnset(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -470,7 +469,7 @@ class DataBuilderTest extends BaseRollbarTest
      * @testWith [0]
      *           [1]
      */
-    public function testStackFramesAreAvailableWhenLocalVarsDumpRequested($valueOfZendExceptionIgnoreArgs)
+    public function testStackFramesAreAvailableWhenLocalVarsDumpRequested($valueOfZendExceptionIgnoreArgs): void
     {
         ini_set('zend.exception_ignore_args', $valueOfZendExceptionIgnoreArgs);
 
@@ -501,12 +500,12 @@ class DataBuilderTest extends BaseRollbarTest
      *
      * @return \Exception
      */
-    private function exceptionTraceArgsHelper($message)
+    private function exceptionTraceArgsHelper(string $message): \Exception
     {
         return new \Exception($message);
     }
 
-    public function testExceptionFramesWithoutContext()
+    public function testExceptionFramesWithoutContext(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -520,7 +519,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output[1]->getContext());
     }
 
-    public function testExceptionFramesWithoutContextDefault()
+    public function testExceptionFramesWithoutContextDefault(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -532,7 +531,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output[1]->getContext());
     }
 
-    public function testExceptionFramesWithContext()
+    public function testExceptionFramesWithContext(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -545,7 +544,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNotEmpty($output[count($output)-1]->getContext());
     }
 
-    public function testFramesWithoutContext()
+    public function testFramesWithoutContext(): void
     {
         $utilities = new Utilities;
         
@@ -584,7 +583,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output[0]->getContext());
     }
 
-    public function testFramesWithContext()
+    public function testFramesWithContext(): void
     {
         $utilities = new Utilities;
 
@@ -616,10 +615,10 @@ class DataBuilderTest extends BaseRollbarTest
             $lineNumber++;
             $line = fgets($file);
 
-            if ($line == '    public function testFramesWithoutContext()
+            if ($line === '    public function testFramesWithoutContext(): void
 ') {
                 $backTrace[0]['line'] = $lineNumber;
-            } elseif ($line == '    public function testFramesWithContext()
+            } elseif ($line === '    public function testFramesWithContext()
 ') {
                 $backTrace[1]['line'] = $lineNumber;
             }
@@ -651,7 +650,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
     }
 
-    public function testFramesWithoutContextDefault()
+    public function testFramesWithoutContextDefault(): void
     {
         $testFilePath = __DIR__ . '/DataBuilderTest.php';
         
@@ -704,7 +703,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output[0]->getContext());
     }
 
-    public function testPerson()
+    public function testPerson(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -723,7 +722,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output->getPerson()->getEmail());
     }
     
-    public function testPersonCaptureEmailUsername()
+    public function testPersonCaptureEmailUsername(): void
     {
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
@@ -745,7 +744,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('test@test.com', $output->getPerson()->getEmail());
     }
 
-    public function testPersonFunc()
+    public function testPersonFunc(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -763,7 +762,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('123', $output->getPerson()->getId());
     }
 
-    public function testPersonIntID()
+    public function testPersonIntID(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -782,7 +781,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output->getPerson()->getEmail());
     }
     
-    public function testPersonFuncException()
+    public function testPersonFuncException(): void
     {
         \Rollbar\Rollbar::init(array(
             'access_token' => $this->getTestAccessToken(),
@@ -802,7 +801,7 @@ class DataBuilderTest extends BaseRollbarTest
         }
     }
 
-    public function testRoot()
+    public function testRoot(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -815,14 +814,14 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals('/var/www/app', $output->getServer()->getRoot());
     }
 
-    public function testSetRequestBody()
+    public function testSetRequestBody(): void
     {
         $_POST['arg1'] = "val1";
         $_POST['arg2'] = "val2";
         $streamInput = http_build_query($_POST);
         
         stream_wrapper_unregister("php");
-        stream_wrapper_register("php", "\Rollbar\TestHelpers\MockPhpStream");
+        stream_wrapper_register("php", MockPhpStream::class);
 
         file_put_contents('php://input', $streamInput);
         
@@ -841,7 +840,7 @@ class DataBuilderTest extends BaseRollbarTest
         stream_wrapper_restore("php");
     }
     
-    public function testPostDataPutRequest()
+    public function testPostDataPutRequest(): void
     {
         $_SERVER['REQUEST_METHOD'] = 'PUT';
         
@@ -851,7 +850,7 @@ class DataBuilderTest extends BaseRollbarTest
         ));
         
         stream_wrapper_unregister("php");
-        stream_wrapper_register("php", "\Rollbar\TestHelpers\MockPhpStream");
+        stream_wrapper_register("php", MockPhpStream::class);
 
         file_put_contents('php://input', $streamInput);
         
@@ -874,11 +873,11 @@ class DataBuilderTest extends BaseRollbarTest
         stream_wrapper_restore("php");
     }
     
-    public function testGenerateErrorWrapper()
+    public function testGenerateErrorWrapper(): void
     {
         $result = $this->dataBuilder->generateErrorWrapper(E_ERROR, 'bork', null, null);
         
-        $this->assertTrue($result instanceof ErrorWrapper);
+        $this->assertInstanceOf(ErrorWrapper::class, $result);
     }
 
     /**
@@ -887,7 +886,8 @@ class DataBuilderTest extends BaseRollbarTest
     public function testCaptureErrorStacktracesException(
         $captureErrorStacktraces,
         $expected
-    ) {
+    ): void
+    {
     
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -907,7 +907,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($expected, count($frames) === 0);
     }
     
-    public function testFramesOrder()
+    public function testFramesOrder(): void
     {
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -936,7 +936,8 @@ class DataBuilderTest extends BaseRollbarTest
     public function testCaptureErrorStacktracesError(
         $captureErrorStacktraces,
         $expected
-    ) {
+    ): void
+    {
     
         $dataBuilder = new DataBuilder(array(
             'accessToken' => $this->getTestAccessToken(),
@@ -952,7 +953,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($expected, count($frames) == 0);
     }
     
-    public function captureErrorStacktracesProvider()
+    public function captureErrorStacktracesProvider(): array
     {
         return array(
             array(false,true),
@@ -963,7 +964,7 @@ class DataBuilderTest extends BaseRollbarTest
     /**
      * @dataProvider getUserIpProvider
      */
-    public function testGetUserIp($ipAddress, $expected, $captureIP)
+    public function testGetUserIp($ipAddress, $expected, $captureIP): void
     {
         $_SERVER['REMOTE_ADDR'] = $ipAddress;
         
@@ -1002,7 +1003,7 @@ class DataBuilderTest extends BaseRollbarTest
         unset($_SERVER['HTTP_X_REAL_IP']);
     }
     
-    public function getUserIpProvider()
+    public function getUserIpProvider(): array
     {
         return array(
             array('127.0.0.1', '127.0.0.1', null),
@@ -1021,7 +1022,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
     }
 
-    public function testGitBranch()
+    public function testGitBranch(): void
     {
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
@@ -1034,7 +1035,7 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertEquals($val, $dataBuilder->detectGitBranch());
     }
 
-    public function testGitBranchNoExec()
+    public function testGitBranchNoExec(): void
     {
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -1,21 +1,26 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Data;
 use Rollbar\Payload\Level;
+use Rollbar\Payload\Notifier;
+use Rollbar\Payload\Server;
+use Rollbar\Payload\Person;
+use Rollbar\Payload\Request;
+use Rollbar\Payload\Body;
 
 class DataTest extends BaseRollbarTest
 {
-    private $body;
-    private $data;
+    private m\LegacyMockInterface|Body|m\MockInterface $body;
+    private Data $data;
 
     public function setUp(): void
     {
-        $this->body = m::mock("Rollbar\Payload\Body");
+        $this->body = m::mock(Body::class);
         $this->data = new Data("test", $this->body);
     }
 
-    public function testEnvironmentMustBeString()
+    public function testEnvironmentMustBeString(): void
     {
         $data = new Data("env", $this->body);
         $this->assertEquals("env", $data->getEnvironment());
@@ -23,16 +28,16 @@ class DataTest extends BaseRollbarTest
         $this->assertEquals("test", $data->setEnvironment("test")->getEnvironment());
     }
 
-    public function testBody()
+    public function testBody(): void
     {
         $data = new Data("env", $this->body);
         $this->assertEquals($this->body, $data->getBody());
 
-        $body2 = m::mock("Rollbar\Payload\Body");
+        $body2 = m::mock(Body::class);
         $this->assertEquals($body2, $data->setBody($body2)->getBody());
     }
 
-    public function testLevel()
+    public function testLevel(): void
     {
         $levelFactory = new LevelFactory;
         $level = Level::ERROR;
@@ -43,62 +48,61 @@ class DataTest extends BaseRollbarTest
         );
     }
 
-    public function testTimestamp()
+    public function testTimestamp(): void
     {
         $timestamp = time();
         $this->assertEquals($timestamp, $this->data->setTimestamp($timestamp)->getTimestamp());
     }
 
-    public function testCodeVersion()
+    public function testCodeVersion(): void
     {
         $codeVersion = "v0.18.1";
         $this->assertEquals($codeVersion, $this->data->setCodeVersion($codeVersion)->getCodeVersion());
     }
 
-    public function testPlatform()
+    public function testPlatform(): void
     {
         $platform = "Linux";
         $this->assertEquals($platform, $this->data->setPlatform($platform)->getPlatform());
     }
 
-    public function testLanguage()
+    public function testLanguage(): void
     {
         $language = "PHP";
         $this->assertEquals($language, $this->data->setLanguage($language)->getLanguage());
     }
 
-    public function testFramework()
+    public function testFramework(): void
     {
         $framework = "Laravel";
         $this->assertEquals($framework, $this->data->setFramework($framework)->getFramework());
     }
 
-    public function testContext()
+    public function testContext(): void
     {
         $context = "SuperController->getResource()";
         $this->assertEquals($context, $this->data->setContext($context)->getContext());
     }
 
-    public function testRequest()
+    public function testRequest(): void
     {
-        $request = m::mock("Rollbar\Payload\Request");
+        $request = m::mock(Request::class);
         $this->assertEquals($request, $this->data->setRequest($request)->getRequest());
     }
 
-    public function testPerson()
+    public function testPerson(): void
     {
-        $person = m::mock("Rollbar\Payload\Person");
-        ;
+        $person = m::mock(Person::class);
         $this->assertEquals($person, $this->data->setPerson($person)->getPerson());
     }
 
-    public function testServer()
+    public function testServer(): void
     {
-        $server = m::mock("Rollbar\Payload\Server");
+        $server = m::mock(Server::class);
         $this->assertEquals($server, $this->data->setServer($server)->getServer());
     }
 
-    public function testCustom()
+    public function testCustom(): void
     {
         $custom = array(
             "x" => 1,
@@ -108,39 +112,39 @@ class DataTest extends BaseRollbarTest
         $this->assertEquals($custom, $this->data->setCustom($custom)->getCustom());
     }
 
-    public function testFingerprint()
+    public function testFingerprint(): void
     {
         $fingerprint = "bad-error-with-database";
         $this->assertEquals($fingerprint, $this->data->setFingerprint($fingerprint)->getFingerprint());
     }
 
-    public function testTitle()
+    public function testTitle(): void
     {
         $title = "End of the World as we know it";
         $this->assertEquals($title, $this->data->setTitle($title)->getTitle());
     }
 
-    public function testUuid()
+    public function testUuid(): void
     {
         $uuid = "21EC2020-3AEA-4069-A2DD-08002B30309D";
         $this->assertEquals($uuid, $this->data->setUuid($uuid)->getUuid());
     }
 
-    public function testNotifier()
+    public function testNotifier(): void
     {
-        $notifier = m::mock("Rollbar\Payload\Notifier");
+        $notifier = m::mock(Notifier::class);
         $this->assertEquals($notifier, $this->data->setNotifier($notifier)->getNotifier());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $time = time();
-        $level = $this->mockSerialize("Rollbar\Payload\Level", "{LEVEL}");
+        $level = $this->mockSerialize(Level::class, "{LEVEL}");
         $body = $this->mockSerialize($this->body, "{BODY}");
-        $request = $this->mockSerialize("Rollbar\Payload\Request", "{REQUEST}");
-        $person = $this->mockSerialize("Rollbar\Payload\Person", "{PERSON}");
-        $server = $this->mockSerialize("Rollbar\Payload\Server", "{SERVER}");
-        $notifier = $this->mockSerialize("Rollbar\Payload\Notifier", "{NOTIFIER}");
+        $request = $this->mockSerialize(Request::class, "{REQUEST}");
+        $person = $this->mockSerialize(Person::class, "{PERSON}");
+        $server = $this->mockSerialize(Server::class, "{SERVER}");
+        $notifier = $this->mockSerialize(Notifier::class, "{NOTIFIER}");
 
         $data = $this->data
             ->setEnvironment("testing")

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -12,32 +12,32 @@ class DefaultsTest extends BaseRollbarTest
     /**
      * @var Defaults
      */
-    private $defaults;
+    private \Rollbar\Defaults $defaults;
 
     public function setUp(): void
     {
         $this->defaults = new Defaults;
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $defaults = Defaults::get();
-        $this->assertInstanceOf("Rollbar\Defaults", $defaults);
+        $this->assertInstanceOf(Defaults::class, $defaults);
     }
 
-    public function testMessageLevel()
+    public function testMessageLevel(): void
     {
         $this->assertEquals("warning", $this->defaults->messageLevel());
         $this->assertEquals("error", $this->defaults->messageLevel(Level::ERROR));
     }
 
-    public function testExceptionLevel()
+    public function testExceptionLevel(): void
     {
         $this->assertEquals("error", $this->defaults->exceptionLevel());
         $this->assertEquals("warning", $this->defaults->exceptionLevel(Level::WARNING));
     }
 
-    public function testErrorLevels()
+    public function testErrorLevels(): void
     {
         $expected = array(
             E_ERROR => "error",
@@ -59,7 +59,7 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals($expected, $this->defaults->errorLevels());
     }
 
-    public function testPsrLevels()
+    public function testPsrLevels(): void
     {
         $expected = $this->defaultPsrLevels = array(
             LogLevel::EMERGENCY => "critical",
@@ -74,37 +74,37 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals($expected, $this->defaults->psrLevels());
     }
 
-    public function testBranch()
+    public function testBranch(): void
     {
         $val = 'some-branch';
         $this->assertEquals($val, $this->defaults->branch($val));
     }
 
-    public function testServerRoot()
+    public function testServerRoot(): void
     {
         $_ENV["HEROKU_APP_DIR"] = "abc123";
         $defaults = new Defaults;
         $this->assertEquals("abc123", $defaults->serverRoot());
     }
 
-    public function testPlatform()
+    public function testPlatform(): void
     {
         $this->assertEquals(php_uname('a'), $this->defaults->platform());
     }
 
-    public function testNotifier()
+    public function testNotifier(): void
     {
         $this->assertEquals(Notifier::defaultNotifier(), $this->defaults->notifier());
     }
 
-    public function testBaseException()
+    public function testBaseException(): void
     {
         $expected = Throwable::class;
         $base = $this->defaults->baseException();
         $this->assertEquals($expected, $base);
     }
 
-    public function testScrubFields()
+    public function testScrubFields(): void
     {
         $expected = array(
             'passwd',
@@ -119,102 +119,102 @@ class DefaultsTest extends BaseRollbarTest
         $this->assertEquals($expected, $this->defaults->scrubFields());
     }
     
-    public function testSendMessageTrace()
+    public function testSendMessageTrace(): void
     {
         $this->assertFalse($this->defaults->sendMessageTrace());
     }
     
-    public function testAgentLogLocation()
+    public function testAgentLogLocation(): void
     {
         $this->assertEquals('/var/tmp', $this->defaults->agentLogLocation());
     }
     
-    public function testAllowExec()
+    public function testAllowExec(): void
     {
         $this->assertEquals(true, $this->defaults->allowExec());
     }
     
-    public function testEndpoint()
+    public function testEndpoint(): void
     {
         $this->assertEquals('https://api.rollbar.com/api/1/', $this->defaults->endpoint());
     }
     
-    public function testCaptureErrorStacktraces()
+    public function testCaptureErrorStacktraces(): void
     {
         $this->assertTrue($this->defaults->captureErrorStacktraces());
     }
     
-    public function testCheckIgnore()
+    public function testCheckIgnore(): void
     {
         $this->assertNull($this->defaults->checkIgnore());
     }
     
-    public function testCodeVersion()
+    public function testCodeVersion(): void
     {
         $this->assertEquals("", $this->defaults->codeVersion());
     }
     
-    public function testCustom()
+    public function testCustom(): void
     {
         $this->assertNull($this->defaults->custom());
     }
     
-    public function testEnabled()
+    public function testEnabled(): void
     {
         $this->assertTrue($this->defaults->enabled());
     }
 
-    public function testTransmit()
+    public function testTransmit(): void
     {
         $this->assertTrue($this->defaults->transmit());
     }
 
-    public function testLogPayload()
+    public function testLogPayload(): void
     {
         $this->assertFalse($this->defaults->logPayload());
     }
     
-    public function testEnvironment()
+    public function testEnvironment(): void
     {
         $this->assertEquals('production', $this->defaults->environment());
     }
     
-    public function testErrorSampleRates()
+    public function testErrorSampleRates(): void
     {
         $this->assertEmpty($this->defaults->errorSampleRates());
     }
     
-    public function testExceptionSampleRates()
+    public function testExceptionSampleRates(): void
     {
         $this->assertEmpty($this->defaults->exceptionSampleRates());
     }
     
-    public function testFluentHost()
+    public function testFluentHost(): void
     {
         $this->assertEquals('127.0.0.1', $this->defaults->fluentHost());
     }
     
-    public function testFluentPort()
+    public function testFluentPort(): void
     {
         $this->assertEquals(24224, $this->defaults->fluentPort());
     }
     
-    public function testFluentTag()
+    public function testFluentTag(): void
     {
         $this->assertEquals('rollbar', $this->defaults->fluentTag());
     }
     
-    public function testHandler()
+    public function testHandler(): void
     {
         $this->assertEquals('blocking', $this->defaults->handler());
     }
     
-    public function testHost()
+    public function testHost(): void
     {
         $this->assertNull($this->defaults->host());
     }
     
-    public function testIncludedErrnoDefault()
+    public function testIncludedErrnoDefault(): void
     {
         $expected = E_ERROR | E_WARNING | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR;
         $this->assertEquals(
@@ -232,7 +232,7 @@ class DefaultsTest extends BaseRollbarTest
      * @runInSeparateProcess
      * @preserveGlobalState disabled
      */
-    public function testIncludedErrnoDefineOverride()
+    public function testIncludedErrnoDefineOverride(): void
     {
         // unlike other tests that use `$this->defaults`, we must make our
         // own Defaults object now, _after_ defining the bitmask: in the
@@ -244,37 +244,37 @@ class DefaultsTest extends BaseRollbarTest
         );
     }
 
-    public function testTimeout()
+    public function testTimeout(): void
     {
         $this->assertEquals(3, $this->defaults->timeout());
     }
     
-    public function testReportSuppressed()
+    public function testReportSuppressed(): void
     {
         $this->assertFalse($this->defaults->reportSuppressed());
     }
     
-    public function testUseErrorReporting()
+    public function testUseErrorReporting(): void
     {
         $this->assertFalse($this->defaults->useErrorReporting());
     }
     
-    public function testCaptureEmail()
+    public function testCaptureEmail(): void
     {
         $this->assertFalse($this->defaults->captureEmail());
     }
     
-    public function testCaptureUsername()
+    public function testCaptureUsername(): void
     {
         $this->assertFalse($this->defaults->captureUsername());
     }
     
-    public function testMaxItems()
+    public function testMaxItems(): void
     {
         $this->assertEquals(10, $this->defaults->maxItems());
     }
     
-    public function testRaiseOnError()
+    public function testRaiseOnError(): void
     {
         $this->assertEquals(false, $this->defaults->raiseOnError());
     }
@@ -283,7 +283,7 @@ class DefaultsTest extends BaseRollbarTest
      * @testWith ["message_level", "warning"]
      *           ["MESSAGE_LEVEL", "warning"]
      */
-    public function testFromSnakeCaseGetsExpectedValueForValidOption($option, $value)
+    public function testFromSnakeCaseGetsExpectedValueForValidOption($option, $value): void
     {
         $this->assertEquals(
             $value,
@@ -291,7 +291,7 @@ class DefaultsTest extends BaseRollbarTest
         );
     }
 
-    public function testFromSnakeCaseThrowsOnInvalidOption()
+    public function testFromSnakeCaseThrowsOnInvalidOption(): void
     {
         $this->expectException(Exception::class);
         \Rollbar\Defaults::get()->fromSnakeCase('no_such_option');

--- a/tests/ErrorWrapperTest.php
+++ b/tests/ErrorWrapperTest.php
@@ -4,7 +4,7 @@ use Rollbar\ErrorWrapper;
 
 class ErrorWrapperTest extends BaseRollbarTest
 {
-    public function testBacktrace()
+    public function testBacktrace(): void
     {
         $errWrapper = new ErrorWrapper(
             E_ERROR,
@@ -17,7 +17,7 @@ class ErrorWrapperTest extends BaseRollbarTest
         $this->assertEquals("FAKE BACKTRACE", $errWrapper->getBacktrace());
     }
 
-    public function testGetClassName()
+    public function testGetClassName(): void
     {
         $errWrapper = new ErrorWrapper(
             E_ERROR,

--- a/tests/ExceptionInfoTest.php
+++ b/tests/ExceptionInfoTest.php
@@ -4,7 +4,7 @@ use Rollbar;
 
 class ExceptionInfoTest extends Rollbar\BaseRollbarTest
 {
-    public function testClass()
+    public function testClass(): void
     {
         $class = "HelloWorld";
         $exc = new ExceptionInfo($class, "message");
@@ -13,7 +13,7 @@ class ExceptionInfoTest extends Rollbar\BaseRollbarTest
         $this->assertEquals("TestClass", $exc->setClass("TestClass")->getClass());
     }
 
-    public function testMessage()
+    public function testMessage(): void
     {
         $message = "A message";
         $exc = new ExceptionInfo("C", $message);
@@ -22,7 +22,7 @@ class ExceptionInfoTest extends Rollbar\BaseRollbarTest
         $this->assertEquals("Another", $exc->setMessage("Another")->getMessage());
     }
 
-    public function testDescription()
+    public function testDescription(): void
     {
         $description = "long form";
         $exc = new ExceptionInfo("C", "s", $description);

--- a/tests/FakeDataBuilder.php
+++ b/tests/FakeDataBuilder.php
@@ -8,8 +8,8 @@ use Throwable;
 
 class FakeDataBuilder implements DataBuilderInterface
 {
-    public static $args = array();
-    public static $logged = array();
+    public static array $args = array();
+    public static array $logged = array();
 
     public function __construct($arr)
     {
@@ -23,7 +23,7 @@ class FakeDataBuilder implements DataBuilderInterface
         return new Data('test', new Body(new Message('test')));
     }
     
-    public function setCustom()
+    public function setCustom(): void
     {
     }
 }

--- a/tests/FakeLog.php
+++ b/tests/FakeLog.php
@@ -5,7 +5,7 @@ namespace Rollbar;
 class FakeLog
 {
     // log($level, $message)
-    public function log()
+    public function log(): void
     {
     }
 }

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -7,7 +7,7 @@ use Rollbar\Payload\Level;
 class FluentTest extends BaseRollbarTest
 {
 
-    public function testFluent()
+    public function testFluent(): void
     {
         if (!class_exists('Fluent\Logger\FluentLogger')) {
             $this->markTestSkipped(

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -1,20 +1,22 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Frame;
+use Rollbar\Payload\Context;
+use Rollbar\Payload\ExceptionInfo;
 
 class FrameTest extends BaseRollbarTest
 {
-    private $exception;
-    private $frame;
+    private m\LegacyMockInterface|m\MockInterface|ExceptionInfo $exception;
+    private Frame $frame;
 
     public function setUp(): void
     {
-        $this->exception = m::mock("Rollbar\Payload\ExceptionInfo");
-        $this->frame = new Frame("tests/FrameTest.php", $this->exception);
+        $this->exception = m::mock(ExceptionInfo::class);
+        $this->frame = new Frame("tests/FrameTest.php");
     }
 
-    public function testFilename()
+    public function testFilename(): void
     {
         $frame = new Frame("filename.php");
         $this->assertEquals("filename.php", $frame->getFilename());
@@ -22,38 +24,38 @@ class FrameTest extends BaseRollbarTest
         $this->assertEquals("other.php", $frame->getFilename());
     }
 
-    public function testLineno()
+    public function testLineno(): void
     {
         $this->frame->setLineno(5);
         $this->assertEquals(5, $this->frame->getLineno());
     }
 
-    public function testColno()
+    public function testColno(): void
     {
         $this->frame->setColno(5);
         $this->assertEquals(5, $this->frame->getColno());
     }
 
-    public function testMethod()
+    public function testMethod(): void
     {
         $this->frame->setMethod("method");
         $this->assertEquals("method", $this->frame->getMethod());
     }
 
-    public function testCode()
+    public function testCode(): void
     {
         $this->frame->setCode("code->whatever()");
         $this->assertEquals("code->whatever()", $this->frame->getCode());
     }
 
-    public function testContext()
+    public function testContext(): void
     {
-        $context = m::mock("Rollbar\Payload\Context");
+        $context = m::mock(Context::class);
         $this->frame->setContext($context);
         $this->assertEquals($context, $this->frame->getContext());
     }
 
-    public function testArgs()
+    public function testArgs(): void
     {
         $this->frame->setArgs(array());
         $this->assertEquals(array(), $this->frame->getArgs());
@@ -62,7 +64,7 @@ class FrameTest extends BaseRollbarTest
         $this->assertEquals(array(1, "hi"), $this->frame->getArgs());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $context = m::mock("Rollbar\Payload\Context, Rollbar\SerializerInterface")
             ->shouldReceive("serialize")

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -1,8 +1,9 @@
 <?php namespace Rollbar\Handlers;
 
-use \Rollbar\Rollbar;
-use \Rollbar\RollbarLogger;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Rollbar;
+use Rollbar\RollbarLogger;
+use Rollbar\BaseRollbarTest;
+use Rollbar\Handlers\ErrorHandler;
 
 /**
  * TODO: consider using $this->useErrorHandler to deal with stopping the
@@ -19,9 +20,9 @@ class ErrorHandlerTest extends BaseRollbarTest
         parent::__construct($name, $data, $dataName);
     }
 
-    private static $simpleConfig = array();
+    private static array $simpleConfig = array();
     
-    public function testPreviousErrorHandler()
+    public function testPreviousErrorHandler(): void
     {
         $testCase = $this;
         
@@ -37,9 +38,9 @@ class ErrorHandlerTest extends BaseRollbarTest
         @trigger_error(E_USER_ERROR);
     }
     
-    public function testRegister()
+    public function testRegister(): void
     {
-        $handler = $this->getMockBuilder('Rollbar\\Handlers\\ErrorHandler')
+        $handler = $this->getMockBuilder(ErrorHandler::class)
                         ->setConstructorArgs(array(new RollbarLogger(self::$simpleConfig)))
                         ->setMethods(array('handle'))
                         ->getMock();
@@ -52,9 +53,9 @@ class ErrorHandlerTest extends BaseRollbarTest
         trigger_error(E_USER_ERROR);
     }
     
-    public function testHandle()
+    public function testHandle(): void
     {
-        $logger = $this->getMockBuilder('Rollbar\\RollbarLogger')
+        $logger = $this->getMockBuilder(RollbarLogger::class)
                         ->setConstructorArgs(array(self::$simpleConfig))
                         ->setMethods(array('log'))
                         ->getMock();

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -1,9 +1,9 @@
 <?php namespace Rollbar\Handlers;
 
-use \Rollbar\Rollbar;
-use \Rollbar\RollbarLogger;
-use \Rollbar\BaseRollbarTest;
-use \Rollbar\Handlers\ExceptionHandler;
+use Rollbar\Rollbar;
+use Rollbar\RollbarLogger;
+use Rollbar\BaseRollbarTest;
+use Rollbar\Handlers\ExceptionHandler;
 
 class ExceptionHandlerTest extends BaseRollbarTest
 {
@@ -16,7 +16,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
         parent::__construct($name, $data, $dataName);
     }
 
-    private static $simpleConfig = array();
+    private static array $simpleConfig = array();
     
     /**
      * It's impossible to throw an uncaught exception with PHPUnit and thus
@@ -24,7 +24,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
      * this test invokes the handle() methd manually with an assertion in the
      * previously set exception handler.
      */
-    public function testPreviousExceptionHandler()
+    public function testPreviousExceptionHandler(): void
     {
         $testCase = $this;
         
@@ -45,9 +45,9 @@ class ExceptionHandlerTest extends BaseRollbarTest
      * this test fetches the exception handler set by the setup method with
      * set_exception_handler() and invokes it manually with a mock expectation.
      */
-    public function testSetup()
+    public function testSetup(): void
     {
-        $handler = $this->getMockBuilder('Rollbar\\Handlers\\ExceptionHandler')
+        $handler = $this->getMockBuilder(ExceptionHandler::class)
                         ->setConstructorArgs(array(new RollbarLogger(self::$simpleConfig)))
                         ->setMethods(array('handle'))
                         ->getMock();
@@ -66,12 +66,12 @@ class ExceptionHandlerTest extends BaseRollbarTest
         $handler->$method();
     }
     
-    public function testHandle()
+    public function testHandle(): void
     {
         set_exception_handler(function () {
         });
         
-        $logger = $this->getMockBuilder('Rollbar\\RollbarLogger')
+        $logger = $this->getMockBuilder(RollbarLogger::class)
                         ->setConstructorArgs(array(self::$simpleConfig))
                         ->setMethods(array('log'))
                         ->getMock();

--- a/tests/JsHelperTest.php
+++ b/tests/JsHelperTest.php
@@ -2,8 +2,8 @@
 
 class JsHelperTest extends BaseRollbarTest
 {
-    protected $jsHelper;
-    protected $testSnippetPath;
+    protected RollbarJsHelper $jsHelper;
+    protected string|false $testSnippetPath;
     
     public function setUp(): void
     {
@@ -11,7 +11,7 @@ class JsHelperTest extends BaseRollbarTest
         $this->testSnippetPath = realpath(__DIR__ . "/../data/rollbar.snippet.js");
     }
     
-    public function testSnippetPath()
+    public function testSnippetPath(): void
     {
         $this->assertEquals(
             $this->testSnippetPath,
@@ -22,9 +22,9 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider shouldAddJsProvider
      */
-    public function testShouldAddJs($setup, $expected)
+    public function testShouldAddJs($setup, $expected): void
     {
-        $mock = \Mockery::mock('Rollbar\RollbarJsHelper');
+        $mock = \Mockery::mock(\Rollbar\RollbarJsHelper::class);
              
         $status = $setup['status'];
         
@@ -40,7 +40,7 @@ class JsHelperTest extends BaseRollbarTest
         $this->assertEquals($expected, $mock->shouldAddJs($status, array()));
     }
     
-    public function shouldAddJsProvider()
+    public function shouldAddJsProvider(): array
     {
         return array(
             array(
@@ -81,7 +81,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider isHtmlProvider
      */
-    public function testIsHtml($headers, $expected)
+    public function testIsHtml($headers, $expected): void
     {
         $this->assertEquals(
             $expected,
@@ -89,7 +89,7 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function isHtmlProvider()
+    public function isHtmlProvider(): array
     {
         return array(
             array(
@@ -110,7 +110,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider hasAttachmentProvider
      */
-    public function testHasAttachment($headers, $expected)
+    public function testHasAttachment($headers, $expected): void
     {
         $this->assertEquals(
             $expected,
@@ -118,7 +118,7 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function hasAttachmentProvider()
+    public function hasAttachmentProvider(): array
     {
         return array(
             array(
@@ -135,7 +135,7 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function testJsSnippet()
+    public function testJsSnippet(): void
     {
         $expected = file_get_contents($this->testSnippetPath);
         
@@ -145,7 +145,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider shouldAppendNonceProvider
      */
-    public function testShouldAppendNonce($headers, $expected)
+    public function testShouldAppendNonce($headers, $expected): void
     {
         $this->assertEquals(
             $expected,
@@ -153,7 +153,7 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function shouldAppendNonceProvider()
+    public function shouldAppendNonceProvider(): array
     {
         return array(
             array(
@@ -180,7 +180,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider scriptTagProvider
      */
-    public function testScriptTag($content, $headers, $nonce, $expected)
+    public function testScriptTag($content, $headers, $nonce, $expected): void
     {
         if ($expected === 'Exception') {
             try {
@@ -198,7 +198,7 @@ class JsHelperTest extends BaseRollbarTest
         }
     }
     
-    public function scriptTagProvider()
+    public function scriptTagProvider(): array
     {
         return array(
             'nonce script' => array(
@@ -226,7 +226,7 @@ class JsHelperTest extends BaseRollbarTest
         );
     }
     
-    public function testConfigJsTag()
+    public function testConfigJsTag(): void
     {
         $config = array(
             'config1' => 'value 1'
@@ -244,7 +244,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider addJsProvider
      */
-    public function testBuildJs($config, $headers, $nonce, $expected)
+    public function testBuildJs($config, $headers, $nonce, $expected): void
     {
         $result = RollbarJsHelper::buildJs(
             $config,
@@ -259,7 +259,7 @@ class JsHelperTest extends BaseRollbarTest
     /**
      * @dataProvider addJsProvider
      */
-    public function testAddJs($config, $headers, $nonce, $expected)
+    public function testAddJs($config, $headers, $nonce, $expected): void
     {
         $helper = new RollbarJsHelper($config);
         
@@ -272,7 +272,7 @@ class JsHelperTest extends BaseRollbarTest
         $this->assertEquals($expected, $result);
     }
     
-    public function addJsProvider()
+    public function addJsProvider(): array
     {
         $this->setUp();
         $expectedJs = file_get_contents($this->testSnippetPath);

--- a/tests/LevelFactoryTest.php
+++ b/tests/LevelFactoryTest.php
@@ -4,7 +4,7 @@ use Rollbar\Payload\Level;
 
 class LevelFactoryTest extends BaseRollbarTest
 {
-    private $levelFactory;
+    private LevelFactory $levelFactory;
     
     public function setUp(): void
     {
@@ -14,7 +14,7 @@ class LevelFactoryTest extends BaseRollbarTest
     /**
      * @dataProvider isValidLevelProvider
      */
-    public function testIsValidLevelProvider($level, $expected)
+    public function testIsValidLevelProvider($level, $expected): void
     {
         $this->assertEquals(
             $expected,
@@ -22,7 +22,7 @@ class LevelFactoryTest extends BaseRollbarTest
         );
     }
     
-    public function isValidLevelProvider()
+    public function isValidLevelProvider(): array
     {
         $data = $this->fromNameProvider();
         foreach ($data as &$testParams) {
@@ -35,15 +35,15 @@ class LevelFactoryTest extends BaseRollbarTest
     /**
      * @dataProvider fromNameProvider
      */
-    public function testFromName($level)
+    public function testFromName($level): void
     {
         $this->assertInstanceOf(
-            'Rollbar\Payload\Level',
+            Level::class,
             $this->levelFactory->fromName($level)
         );
     }
     
-    public function fromNameProvider()
+    public function fromNameProvider(): array
     {
         return array(
             array(Level::EMERGENCY),

--- a/tests/LevelTest.php
+++ b/tests/LevelTest.php
@@ -1,17 +1,17 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Level;
 
 class LevelTest extends BaseRollbarTest
 {
-    public function testInvalidLevelThrowsAnException()
+    public function testInvalidLevelThrowsAnException(): void
     {
         $this->expectException(\Exception::class);
         $level = Level::TEST();
     }
 
-    public function testLevel()
+    public function testLevel(): void
     {
         $level = Level::CRITICAL();
         $this->assertNotNull($level);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -4,14 +4,14 @@ use Rollbar;
 
 class MessageTest extends Rollbar\BaseRollbarTest
 {
-    public function testBacktrace()
+    public function testBacktrace(): void
     {
         $expected = array('trace 1' => 'value 1');
         $msg = new Message("Test", $expected);
         $this->assertEquals($expected, $msg->getBacktrace());
     }
     
-    public function testBody()
+    public function testBody(): void
     {
         $msg = new Message("Test");
         $this->assertEquals("Test", $msg->getBody());
@@ -19,7 +19,7 @@ class MessageTest extends Rollbar\BaseRollbarTest
         $this->assertEquals("Test2", $msg->setBody("Test2")->getBody());
     }
 
-    public function testMessageKey()
+    public function testMessageKey(): void
     {
         $msg = new Message("Test");
         $this->assertEquals("message", $msg->getKey());

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -1,11 +1,11 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Notifier;
 
 class NotifierTest extends BaseRollbarTest
 {
-    public function testName()
+    public function testName(): void
     {
         $name = "rollbar-php";
         $notifier = new Notifier($name, "0.1");
@@ -15,7 +15,7 @@ class NotifierTest extends BaseRollbarTest
         $this->assertEquals($name2, $notifier->setName($name2)->getName());
     }
 
-    public function testVersion()
+    public function testVersion(): void
     {
         $version = Notifier::VERSION;
         $notifier = new Notifier("PHP-Rollbar", $version);
@@ -25,7 +25,7 @@ class NotifierTest extends BaseRollbarTest
         $this->assertEquals($version2, $notifier->setVersion($version2)->getVersion());
     }
 
-    public function testDefaultNotifierIsRepresentableAsJson()
+    public function testDefaultNotifierIsRepresentableAsJson(): void
     {
         $notifier = Notifier::defaultNotifier()->serialize();
         $encoding = json_encode($notifier, flags: JSON_THROW_ON_ERROR|JSON_FORCE_OBJECT);
@@ -34,7 +34,7 @@ class NotifierTest extends BaseRollbarTest
         $this->assertObjectHasAttribute('version', $decoding);
     }
 
-    public function testDefaultNotifierVersionIsSemVerCompliant()
+    public function testDefaultNotifierVersionIsSemVerCompliant(): void
     {
         // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         $semVerRegex = '/

--- a/tests/Payload/EncodedPayloadTest.php
+++ b/tests/Payload/EncodedPayloadTest.php
@@ -2,7 +2,7 @@
 
 class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
 {
-    public function testEncode()
+    public function testEncode(): void
     {
         $expected = '{"foo":"bar"}';
         
@@ -24,7 +24,7 @@ class EncodedPayloadTest extends \Rollbar\BaseRollbarTest
     /**
      * @requires PHP 5.5
      */
-    public function testEncodeMalformedData()
+    public function testEncodeMalformedData(): void
     {
         $encoded = new EncodedPayload(array(
             'data' => array(

--- a/tests/PayloadTest.php
+++ b/tests/PayloadTest.php
@@ -1,15 +1,18 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
+use Rollbar\DataBuilder;
+use Rollbar\Config;
+use Rollbar\Payload\Data;
 
 class PayloadTest extends BaseRollbarTest
 {
-    public function testPayloadData()
+    public function testPayloadData(): void
     {
-        $data = m::mock("Rollbar\Payload\Data");
-        $config = m::mock("Rollbar\Config")
+        $data = m::mock(Data::class);
+        $config = m::mock(Config::class)
                     ->shouldReceive('getAccessToken')
                     ->andReturn('012345678901234567890123456789ab')
                     ->mock();
@@ -18,15 +21,15 @@ class PayloadTest extends BaseRollbarTest
 
         $this->assertEquals($data, $payload->getData());
 
-        $data2 = m::mock("Rollbar\Payload\Data");
+        $data2 = m::mock(Data::class);
         $this->assertEquals($data2, $payload->setData($data2)->getData());
     }
 
-    public function testPayloadAccessToken()
+    public function testPayloadAccessToken(): void
     {
         $accessToken = "012345678901234567890123456789ab";
-        $data = m::mock("Rollbar\Payload\Data");
-        $config = m::mock("Rollbar\Config")
+        $data = m::mock(Data::class);
+        $config = m::mock(Config::class)
                     ->shouldReceive('getAccessToken')
                     ->andReturn($accessToken)
                     ->mock();
@@ -35,7 +38,7 @@ class PayloadTest extends BaseRollbarTest
         $this->assertEquals($accessToken, $payload->getAccessToken());
 
         $accessToken = "012345678901234567890123456789ab";
-        $config = m::mock("Rollbar\Config")
+        $config = m::mock(Config::class)
                     ->shouldReceive('getAccessToken')
                     ->andReturn($accessToken)
                     ->mock();
@@ -46,14 +49,14 @@ class PayloadTest extends BaseRollbarTest
         $this->assertEquals($at2, $payload->setAccessToken($at2)->getAccessToken());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $accessToken = $this->getTestAccessToken();
         $data = m::mock('Rollbar\Payload\Data, Rollbar\SerializerInterface')
             ->shouldReceive('serialize')
             ->andReturn(new \ArrayObject())
             ->mock();
-        m::mock('Rollbar\DataBuilder')
+        m::mock(DataBuilder::class)
             ->shouldReceive('getScrubFields')
             ->andReturn(array())
             ->shouldReceive('scrub')

--- a/tests/Performance/MassivePayload.php
+++ b/tests/Performance/MassivePayload.php
@@ -2,10 +2,10 @@
 
 namespace Rollbar\Performance;
 
-use \Rollbar\Truncation\StringsStrategyTest;
-use \Rollbar\Truncation\FramesStrategyTest;
+use Rollbar\Truncation\StringsStrategyTest;
+use Rollbar\Truncation\FramesStrategyTest;
 
-use \Rollbar\Truncation\StringsStrategy;
+use Rollbar\Truncation\StringsStrategy;
 
 class MassivePayload
 {

--- a/tests/Performance/TestHelpers/EncodedPayload.php
+++ b/tests/Performance/TestHelpers/EncodedPayload.php
@@ -2,7 +2,7 @@
 
 class EncodedPayload extends \Rollbar\Payload\EncodedPayload
 {
-    protected static $encodingCount = 0;
+    protected static int $encodingCount = 0;
     
     public function encode(?array $data = null): void
     {
@@ -10,12 +10,12 @@ class EncodedPayload extends \Rollbar\Payload\EncodedPayload
         self::$encodingCount++;
     }
     
-    public static function getEncodingCount()
+    public static function getEncodingCount(): int
     {
         return self::$encodingCount;
     }
     
-    public static function resetEncodingCount()
+    public static function resetEncodingCount(): void
     {
         self::$encodingCount = 0;
     }

--- a/tests/Performance/TestHelpers/Truncation.php
+++ b/tests/Performance/TestHelpers/Truncation.php
@@ -5,10 +5,10 @@ class Truncation extends \Rollbar\Truncation\Truncation
     protected $memoryUsage = 0;
     protected $timeUsage = 0;
     protected $payloadSize = 0;
-    protected $lastRunOutput = "";
-    protected $strategiesUsed = array();
+    protected string $lastRunOutput = "";
+    protected array $strategiesUsed = array();
     
-    public function truncate(\Rollbar\Payload\EncodedPayload $payload)
+    public function truncate(\Rollbar\Payload\EncodedPayload $payload): \Rollbar\Payload\EncodedPayload
     {
         $this->strategiesUsed = array();
         
@@ -33,7 +33,7 @@ class Truncation extends \Rollbar\Truncation\Truncation
         return $result;
     }
     
-    public function needsTruncating(\Rollbar\Payload\EncodedPayload $payload, $strategy)
+    public function needsTruncating(\Rollbar\Payload\EncodedPayload $payload, $strategy): bool
     {
         $result = parent::needsTruncating($payload, $strategy);
         
@@ -44,12 +44,12 @@ class Truncation extends \Rollbar\Truncation\Truncation
         return $result;
     }
     
-    public function getLastRun()
+    public function getLastRun(): string
     {
         return $this->lastRunOutput;
     }
     
-    public function composeLastRunOutput()
+    public function composeLastRunOutput(): string
     {
         $output = "\n";
         
@@ -58,7 +58,7 @@ class Truncation extends \Rollbar\Truncation\Truncation
                     round($this->payloadSize / 1024 / 1024, 2) . " MB \n";
                 
         $output .= "Strategies used: \n" .
-                    (count($this->strategiesUsed) ? join(", \n", $this->strategiesUsed) : "none") . "\n";
+                    (count($this->strategiesUsed) ? implode(", \n", $this->strategiesUsed) : "none") . "\n";
         
         $output .= "Encoding triggered: " .
                     \Rollbar\Performance\TestHelpers\EncodedPayload::getEncodingCount() . "\n";

--- a/tests/Performance/TruncationTest.php
+++ b/tests/Performance/TruncationTest.php
@@ -2,16 +2,16 @@
 
 namespace Rollbar\Performance;
 
-use \Rollbar\Performance\MassivePayload;
-use \Rollbar\Performance\TestHelpers\Truncation;
-use \Rollbar\Performance\TestHelpers\EncodedPayload;
+use Rollbar\Performance\MassivePayload;
+use Rollbar\Performance\TestHelpers\Truncation;
+use Rollbar\Performance\TestHelpers\EncodedPayload;
 
-use \Rollbar\Truncation\StringsStrategyTest;
-use \Rollbar\Truncation\FramesStrategyTest;
-use \Rollbar\Truncation\MinBodyStrategyTest;
+use Rollbar\Truncation\StringsStrategyTest;
+use Rollbar\Truncation\FramesStrategyTest;
+use Rollbar\Truncation\MinBodyStrategyTest;
 
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
 
 class TruncationTest extends BaseRollbarTest
 {
@@ -176,7 +176,7 @@ class TruncationTest extends BaseRollbarTest
     /**
      * @dataProvider truncateProvider
      */
-    public function testTruncate($dataName, $data, array $assertions = array())
+    public function testTruncate($dataName, $data, array $assertions = array()): void
     {
         $payload = new EncodedPayload($data);
         $payload->encode();
@@ -193,7 +193,7 @@ class TruncationTest extends BaseRollbarTest
         }
     }
     
-    public function truncateProvider()
+    public function truncateProvider(): array
     {
         $stringsTest = new StringsStrategyTest();
         $framesTest = new FramesStrategyTest();

--- a/tests/PersonTest.php
+++ b/tests/PersonTest.php
@@ -1,11 +1,11 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Person;
 
 class PersonTest extends BaseRollbarTest
 {
-    public function testId()
+    public function testId(): void
     {
         $id = "rollbar-php";
         $person = new Person($id);
@@ -15,7 +15,7 @@ class PersonTest extends BaseRollbarTest
         $this->assertEquals($id2, $person->setId($id2)->getId());
     }
 
-    public function testUsername()
+    public function testUsername(): void
     {
         $username = "user@rollbar.com";
         $person = new Person("15", $username);
@@ -25,7 +25,7 @@ class PersonTest extends BaseRollbarTest
         $this->assertEquals($username2, $person->setUsername($username2)->getUsername());
     }
 
-    public function testEmail()
+    public function testEmail(): void
     {
         $email = "1.0.0";
         $person = new Person("Rollbar_Master", null, $email);
@@ -35,14 +35,14 @@ class PersonTest extends BaseRollbarTest
         $this->assertEquals($email2, $person->setEmail($email2)->getEmail());
     }
 
-    public function testExtra()
+    public function testExtra(): void
     {
         $person = new Person("42");
         $person->test = "testing";
         $this->assertEquals("testing", $person->test);
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $person = new Person("1024");
         $person->setUsername("username")

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -13,7 +13,7 @@ function do_something()
 
 class ReadmeTest extends BaseRollbarTest
 {
-    public function testQuickStart()
+    public function testQuickStart(): void
     {
         // installs global error and exception handlers
         Rollbar::init(
@@ -53,7 +53,7 @@ class ReadmeTest extends BaseRollbarTest
         throw new \Exception('testing exception handler');
     }
 
-    public function testSetup1()
+    public function testSetup1(): void
     {
         $config = array(
             // required
@@ -68,7 +68,7 @@ class ReadmeTest extends BaseRollbarTest
         $this->assertTrue(true);
     }
 
-    public function testSetup2()
+    public function testSetup2(): void
     {
         $config = array(
             // required
@@ -86,7 +86,7 @@ class ReadmeTest extends BaseRollbarTest
         $this->assertTrue(true);
     }
 
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         Rollbar::init(
             array(
@@ -107,7 +107,7 @@ class ReadmeTest extends BaseRollbarTest
         $this->assertEquals(200, $result2->getStatus());
     }
 
-    public function testBasicUsage2()
+    public function testBasicUsage2(): void
     {
         Rollbar::init(
             array(

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,11 +1,11 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Request;
 
 class RequestTest extends BaseRollbarTest
 {
-    public function testUrl()
+    public function testUrl(): void
     {
         $url = "www.rollbar.com";
         $request = new Request();
@@ -16,7 +16,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($url2, $request->setUrl($url2)->getUrl());
     }
 
-    public function testMethod()
+    public function testMethod(): void
     {
         $method = "POST";
         $request = new Request();
@@ -27,7 +27,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($method2, $request->setMethod($method2)->getMethod());
     }
 
-    public function testHeaders()
+    public function testHeaders(): void
     {
         $headers = array("Auth-X" => "abc352", "Hello" => "World");
         $request = new Request();
@@ -38,7 +38,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($headers2, $request->setHeaders($headers2)->getHeaders());
     }
 
-    public function testParams()
+    public function testParams(): void
     {
         $params = array(
             "controller" => "project",
@@ -52,7 +52,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($params2, $request->setParams($params2)->getParams());
     }
 
-    public function testGet()
+    public function testGet(): void
     {
         $get = array("query" => "where's waldo?", "page" => 15);
         $request = new Request();
@@ -63,7 +63,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($get2, $request->setGet($get2)->getGet());
     }
 
-    public function testQueryString()
+    public function testQueryString(): void
     {
         $queryString = "?slug=Rollbar&update=true";
         $request = new Request();
@@ -75,7 +75,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($queryString2, $actual);
     }
 
-    public function testPost()
+    public function testPost(): void
     {
         $post = array("Big" => "Data");
         $request = new Request();
@@ -91,7 +91,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($post2, $request->setPost($post2)->getPost());
     }
 
-    public function testBody()
+    public function testBody(): void
     {
         $body = "a long string\nwith new lines and stuff";
         $request = new Request();
@@ -102,7 +102,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($body2, $request->setBody($body2)->getBody());
     }
 
-    public function testUserIp()
+    public function testUserIp(): void
     {
         $userIp = "192.0.1.12";
         $request = new Request();
@@ -113,7 +113,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals($userIp2, $request->setUserIp($userIp2)->getUserIp());
     }
 
-    public function testExtra()
+    public function testExtra(): void
     {
         $request = new Request();
         $request->setExtras(array("test" => "testing"));
@@ -121,7 +121,7 @@ class RequestTest extends BaseRollbarTest
         $this->assertEquals("testing", $extras["test"]);
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $request = new Request();
         $request->setUrl("www.rollbar.com/account/project")

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -4,25 +4,25 @@ use Rollbar\Response;
 
 class ResponseTest extends BaseRollbarTest
 {
-    public function testStatus()
+    public function testStatus(): void
     {
         $r = new Response(200, array("whatever"=>5));
         $this->assertEquals(200, $r->getStatus());
     }
 
-    public function testInfo()
+    public function testInfo(): void
     {
         $r = new Response(200, "FAKE INFO");
         $this->assertEquals("FAKE INFO", $r->getInfo());
     }
 
-    public function testUuid()
+    public function testUuid(): void
     {
         $r = new Response(200, "FAKE INFO", "abc123");
         $this->assertEquals("abc123", $r->getUuid());
     }
 
-    public function testWasSuccessful()
+    public function testWasSuccessful(): void
     {
         $response = new Response(200, null);
         $this->assertTrue($response->wasSuccessful());
@@ -36,7 +36,7 @@ class ResponseTest extends BaseRollbarTest
      * @testWith ["abc123", "https://rollbar.com/occurrence/uuid/?uuid=abc123"]
      *           ["a bar", "https://rollbar.com/occurrence/uuid/?uuid=a+bar"]
      */
-    public function testUrl(string $uuid, string $expectedOccurrenceUrl)
+    public function testUrl(string $uuid, string $expectedOccurrenceUrl): void
     {
         $response = new Response(200, "fake", $uuid);
         $this->assertEquals($expectedOccurrenceUrl, $response->getOccurrenceUrl());

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -447,8 +447,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         string $scrubField = 'sensitive',
         bool   $recursive = true,
         string $replacement = '*'
-    ): void
-    {
+    ): void {
     
         $this->assertEquals(
             str_repeat($replacement, 8),

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -7,6 +7,11 @@ use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
 use StdClass;
+use Rollbar\Payload\EncodedPayload;
+use Rollbar\Senders\SenderInterface;
+use Rollbar\TestHelpers\MalformedPayloadDataTransformer;
+use Monolog\Handler\ErrorLogHandler;
+use Psr\Log\LoggerInterface;
 
 class RollbarLoggerTest extends BaseRollbarTest
 {
@@ -23,7 +28,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         parent::tearDown();
     }
     
-    public function testAddCustom()
+    public function testAddCustom(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -65,7 +70,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("bar", $customData["foo"]);
     }
     
-    public function testRemoveCustom()
+    public function testRemoveCustom(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -91,7 +96,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("xyz", $customData["bar"]);
     }
     
-    public function testGetCustom()
+    public function testGetCustom(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -108,7 +113,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("xyz", $custom["bar"]);
     }
 
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -119,7 +124,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(15, $extended['extraData']);
     }
 
-    public function testLog()
+    public function testLog(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -129,9 +134,9 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
 
-    public function testNotLoggingPayload()
+    public function testNotLoggingPayload(): void
     {
-        $logPayloadLoggerMock = $this->getMockBuilder('\Psr\Log\LoggerInterface')->getMock();
+        $logPayloadLoggerMock = $this->getMockBuilder(LoggerInterface::class)->getMock();
         $logPayloadLoggerMock->expects($this->never())->method('debug');
 
         $logger = new RollbarLogger(array(
@@ -145,12 +150,12 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
 
-    public function testDefaultVerbose()
+    public function testDefaultVerbose(): void
     {
-        return $this->testNotVerbose();
+        $this->testNotVerbose();
     }
 
-    public function testNotVerbose()
+    public function testNotVerbose(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -162,7 +167,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $originalHandler = $verboseLogger->getHandlers();
         $originalHandler = $originalHandler[0];
 
-        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
+        $handlerMock = $this->getMockBuilder(ErrorLogHandler::class)
             ->setMethods(array('handle'))
             ->getMock();
 
@@ -175,7 +180,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $logger->info('Internal message');
     }
 
-    public function testVerbose()
+    public function testVerbose(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -187,7 +192,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $originalHandler = $verboseLogger->getHandlers();
         $originalHandler = $originalHandler[0];
 
-        $handlerMock = $this->getMockBuilder('\Monolog\Handler\ErrorLogHandler')
+        $handlerMock = $this->getMockBuilder(ErrorLogHandler::class)
             ->setMethods(array('handle'))
             ->getMock();
         $handlerMock->setLevel($originalHandler->getLevel());
@@ -199,7 +204,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $logger->info('Internal message');
     }
     
-    public function testEnabled()
+    public function testEnabled(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -219,7 +224,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("Disabled", $response->getInfo());
     }
 
-    public function testTransmit()
+    public function testTransmit(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -238,9 +243,9 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("Not transmitting (transmitting disabled in configuration)", $response->getInfo());
     }
 
-    public function testTransmitBatched()
+    public function testTransmitBatched(): void
     {
-        $senderMock = $this->getMockBuilder('Rollbar\Senders\SenderInterface')->getMock();
+        $senderMock = $this->getMockBuilder(SenderInterface::class)->getMock();
         $senderMock->expects($this->once())->method('sendBatch');
 
         // transmit on (default)
@@ -256,7 +261,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $logger->flush();
 
         // transmit off
-        $senderMock = $this->getMockBuilder('Rollbar\Senders\SenderInterface')->getMock();
+        $senderMock = $this->getMockBuilder(SenderInterface::class)->getMock();
         $senderMock->expects($this->never())->method('sendBatch');
 
         $logger->configure(array(
@@ -272,12 +277,12 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals("Not transmitting (transmitting disabled in configuration)", $response->getInfo());
     }
     
-    public function testLogMalformedPayloadData()
+    public function testLogMalformedPayloadData(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
-            "transformer" => '\Rollbar\TestHelpers\MalformedPayloadDataTransformer'
+            "transformer" => MalformedPayloadDataTransformer::class
         ));
         
         $response = $logger->log(
@@ -289,11 +294,11 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(400, $response->getStatus());
     }
 
-    public function testFlush()
+    public function testFlush(): void
     {
-        $senderMock = $this->getMockBuilder('Rollbar\Senders\SenderInterface')->getMock();
+        $senderMock = $this->getMockBuilder(SenderInterface::class)->getMock();
         $senderMock->expects($this->once())->method('sendBatch')->with(
-            $this->containsOnlyInstancesOf('Rollbar\Payload\EncodedPayload'),
+            $this->containsOnlyInstancesOf(EncodedPayload::class),
             $this->anything()
         );
 
@@ -315,7 +320,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $response = $logger->flush();
     }
     
-    public function testContext()
+    public function testContext(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -331,7 +336,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
     
-    public function testLogStaticLevel()
+    public function testLogStaticLevel(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -341,7 +346,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
 
-    public function testErrorSampleRates()
+    public function testErrorSampleRates(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -365,13 +370,13 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(0, $response->getStatus());
     }
 
-    public function testExceptionSampleRates()
+    public function testExceptionSampleRates(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => "ad865e76e7fb496fab096ac07b1dbabb",
             "environment" => "testing-php",
             "exception_sample_rates" => array(
-                'Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate' => 0.0
+                SilentExceptionSampleRate::class => 0.0
             )
         ));
         $response = $l->log(Level::ERROR, new SilentExceptionSampleRate);
@@ -383,7 +388,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
 
-    public function testIncludedErrNo()
+    public function testIncludedErrNo(): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -437,12 +442,13 @@ class RollbarLoggerTest extends BaseRollbarTest
      * @param string $replacement Character used for scrubbing
      */
     private function scrubTestAssert(
-        $dataName,
-        $result,
-        $scrubField = 'sensitive',
-        $recursive = true,
-        $replacement = '*'
-    ) {
+        string $dataName,
+        array  $result,
+        string $scrubField = 'sensitive',
+        bool   $recursive = true,
+        string $replacement = '*'
+    ): void
+    {
     
         $this->assertEquals(
             str_repeat($replacement, 8),
@@ -459,7 +465,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         }
     }
     
-    public function scrubDataProvider()
+    public function scrubDataProvider(): array
     {
         return array(
             array( // test 1
@@ -478,7 +484,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testScrubGET($testData)
+    public function testScrubGET($testData): void
     {
         $_GET = $testData;
         $result = $this->scrubTestHelper();
@@ -489,7 +495,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testGetRequestScrubPOST($testData)
+    public function testGetRequestScrubPOST($testData): void
     {
         $_POST = $testData;
         $result = $this->scrubTestHelper();
@@ -499,14 +505,14 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testGetRequestScrubSession($testData)
+    public function testGetRequestScrubSession($testData): void
     {
         $_SESSION = $testData;
         $result = $this->scrubTestHelper();
         $this->scrubTestAssert('$_SESSION', $result['data']['request']['session']);
     }
     
-    public function testGetScrubbedHeaders()
+    public function testGetScrubbedHeaders(): void
     {
         $_SERVER['HTTP_CONTENT_TYPE'] = 'text/html; charset=utf-8';
         $_SERVER['HTTP_SENSITIVE'] = 'Scrub this';
@@ -525,7 +531,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testGetRequestScrubExtras($testData)
+    public function testGetRequestScrubExtras($testData): void
     {
         $extras = array(
             'extraField1' => $testData
@@ -542,7 +548,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testMakeDataScrubServerExtras($testData)
+    public function testMakeDataScrubServerExtras($testData): void
     {
         $extras = array(
             'extraField1' => $testData
@@ -559,7 +565,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testMakeDataScrubCustom($testData)
+    public function testMakeDataScrubCustom($testData): void
     {
         $custom = $testData;
         $result = $this->scrubTestHelper(array('custom' => $custom));
@@ -573,7 +579,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testMakeDataScrubPerson($testData)
+    public function testMakeDataScrubPerson($testData): void
     {
         $testData['id'] = '123';
         $result = $this->scrubTestHelper(
@@ -601,7 +607,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testGetRequestScrubBodyContext($testData)
+    public function testGetRequestScrubBodyContext($testData): void
     {
         $bodyContext = array(
             'context1' => $testData
@@ -618,7 +624,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         );
     }
     
-    public function scrubQueryStringDataProvider()
+    public function scrubQueryStringDataProvider(): array
     {
         $data = $this->scrubDataProvider();
         
@@ -632,7 +638,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
-    public function testGetUrlScrub($testData)
+    public function testGetUrlScrub($testData): void
     {
         $_SERVER['SERVER_NAME'] = 'localhost';
         $_SERVER['REQUEST_URI'] = "/index.php?$testData";
@@ -653,7 +659,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider scrubQueryStringDataProvider
      */
-    public function testGetRequestScrubQueryString($testData)
+    public function testGetRequestScrubQueryString($testData): void
     {
         $_SERVER['QUERY_STRING'] = "?$testData";
         
@@ -680,7 +686,7 @@ class RollbarLoggerTest extends BaseRollbarTest
      *           ["info"]
      *           ["debug"]
      */
-    public function testPsr3MethodCallsDoNotCrash($method)
+    public function testPsr3MethodCallsDoNotCrash($method): void
     {
         $l = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -695,7 +701,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider maxItemsProvider
      */
-    public function testMaxItems($maxItemsConfig)
+    public function testMaxItems($maxItemsConfig): void
     {
         $config = array('access_token' => $this->getTestAccessToken());
         if ($maxItemsConfig !== null) {
@@ -705,7 +711,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         Rollbar::init($config);
         $logger = Rollbar::logger();
         
-        $maxItems = $maxItemsConfig === null ? Defaults::get()->maxItems() : $maxItemsConfig;
+        $maxItems = $maxItemsConfig ?? Defaults::get()->maxItems();
         
         for ($i = 0; $i < $maxItems; $i++) {
             $response = $logger->log(Level::INFO, 'testing info level');
@@ -723,7 +729,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         );
     }
     
-    public function maxItemsProvider()
+    public function maxItemsProvider(): array
     {
         return array(
             'use default max_items' => array(null),
@@ -731,7 +737,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         );
     }
     
-    public function testRaiseOnError()
+    public function testRaiseOnError(): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -750,7 +756,7 @@ class RollbarLoggerTest extends BaseRollbarTest
     /**
      * @dataProvider providesToLogEntityForUncaughtCheck
      */
-    public function testIsUncaughtLogData(mixed $toLog, bool $expected, string $message)
+    public function testIsUncaughtLogData(mixed $toLog, bool $expected, string $message): void
     {
         $logger = new RollbarLogger(array(
             "access_token" => $this->getTestAccessToken(),
@@ -761,7 +767,7 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertSame($logger->isUncaughtLogData($toLog), $expected, $message);
     }
 
-    public static function providesToLogEntityForUncaughtCheck()
+    public static function providesToLogEntityForUncaughtCheck(): array
     {
         $uncaught = new Exception;
         $uncaught->isUncaught = true;

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -3,6 +3,7 @@
 use Rollbar\Rollbar;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
+use Rollbar\RollbarLogger;
 
 /**
  * Usage of static method Rollbar::logger() is intended here.
@@ -18,53 +19,53 @@ class RollbarTest extends BaseRollbarTest
         self::$simpleConfig['environment'] = 'test';
     }
 
-    private static $simpleConfig = array();
+    private static string|array $simpleConfig = array();
     
     public static function setUpBeforeClass(): void
     {
         Rollbar::destroy();
     }
     
-    public function testInitWithConfig()
+    public function testInitWithConfig(): void
     {
         Rollbar::init(self::$simpleConfig);
         
-        $this->assertInstanceOf('Rollbar\RollbarLogger', Rollbar::logger());
+        $this->assertInstanceOf(RollbarLogger::class, Rollbar::logger());
         $this->assertEquals(new Config(self::$simpleConfig), Rollbar::logger()->getConfig());
     }
     
-    public function testInitWithLogger()
+    public function testInitWithLogger(): void
     {
-        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
 
         Rollbar::init($logger);
         
         $this->assertSame($logger, Rollbar::logger());
     }
     
-    public function testInitConfigureLogger()
+    public function testInitConfigureLogger(): void
     {
-        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
         $logger->expects($this->once())->method('configure')->with(self::$simpleConfig);
 
         Rollbar::init($logger);
         Rollbar::init(self::$simpleConfig);
     }
     
-    public function testInitReplaceLogger()
+    public function testInitReplaceLogger(): void
     {
         Rollbar::init(self::$simpleConfig);
 
-        $this->assertInstanceOf('Rollbar\RollbarLogger', Rollbar::logger());
+        $this->assertInstanceOf(RollbarLogger::class, Rollbar::logger());
 
-        $logger = $this->getMockBuilder('Rollbar\RollbarLogger')->disableOriginalConstructor()->getMock();
+        $logger = $this->getMockBuilder(RollbarLogger::class)->disableOriginalConstructor()->getMock();
 
         Rollbar::init($logger);
 
         $this->assertSame($logger, Rollbar::logger());
     }
 
-    public function testLogException()
+    public function testLogException(): void
     {
         Rollbar::init(self::$simpleConfig);
 
@@ -77,7 +78,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertTrue(true);
     }
     
-    public function testLogMessage()
+    public function testLogMessage(): void
     {
         Rollbar::init(self::$simpleConfig);
       
@@ -86,7 +87,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertTrue(true);
     }
     
-    public function testLogExtraData()
+    public function testLogExtraData(): void
     {
         Rollbar::init(self::$simpleConfig);
         
@@ -113,47 +114,47 @@ class RollbarTest extends BaseRollbarTest
         );
     }
     
-    public function testDebug()
+    public function testDebug(): void
     {
         $this->shortcutMethodTestHelper(Level::DEBUG);
     }
     
-    public function testInfo()
+    public function testInfo(): void
     {
         $this->shortcutMethodTestHelper(Level::INFO);
     }
     
-    public function testNotice()
+    public function testNotice(): void
     {
         $this->shortcutMethodTestHelper(Level::NOTICE);
     }
     
-    public function testWarning()
+    public function testWarning(): void
     {
         $this->shortcutMethodTestHelper(Level::WARNING);
     }
     
-    public function testError()
+    public function testError(): void
     {
         $this->shortcutMethodTestHelper(Level::ERROR);
     }
     
-    public function testCritical()
+    public function testCritical(): void
     {
         $this->shortcutMethodTestHelper(Level::CRITICAL);
     }
     
-    public function testAlert()
+    public function testAlert(): void
     {
         $this->shortcutMethodTestHelper(Level::ALERT);
     }
     
-    public function testEmergency()
+    public function testEmergency(): void
     {
         $this->shortcutMethodTestHelper(Level::EMERGENCY);
     }
     
-    protected function shortcutMethodTestHelper($level)
+    protected function shortcutMethodTestHelper($level): void
     {
         $message = "shortcutMethodTestHelper: $level";
         
@@ -166,7 +167,7 @@ class RollbarTest extends BaseRollbarTest
     /**
      * Below are backwards compatibility tests with v0.18.2
      */
-    public function testBackwardsSimpleMessageVer()
+    public function testBackwardsSimpleMessageVer(): void
     {
         Rollbar::init(self::$simpleConfig);
 
@@ -174,7 +175,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
     }
     
-    public function testBackwardsSimpleError()
+    public function testBackwardsSimpleError(): void
     {
         set_error_handler(function () {
         }); // disable PHPUnit's error handler
@@ -186,7 +187,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertFalse($result);
     }
     
-    public function testBackwardsSimpleException()
+    public function testBackwardsSimpleException(): void
     {
         Rollbar::init(self::$simpleConfig);
         
@@ -200,7 +201,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertStringMatchesFormat('%x-%x-%x-%x-%x', $uuid);
     }
 
-    public function testBackwardsFlush()
+    public function testBackwardsFlush(): void
     {
         Rollbar::init(self::$simpleConfig);
 
@@ -208,7 +209,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertTrue(true);
     }
     
-    public function testConfigure()
+    public function testConfigure(): void
     {
         $expected = 'expectedEnv';
         
@@ -228,7 +229,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertEquals($expected, $payload->getData()->getEnvironment());
     }
     
-    public function testEnable()
+    public function testEnable(): void
     {
         Rollbar::init(self::$simpleConfig);
         $this->assertTrue(Rollbar::enabled());
@@ -252,7 +253,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertTrue(Rollbar::disabled());
     }
 
-    public function testLogUncaughtUnsetLogger()
+    public function testLogUncaughtUnsetLogger(): void
     {
         $sut = new Rollbar;
         $result = $sut->logUncaught('level', new \Exception);
@@ -260,7 +261,7 @@ class RollbarTest extends BaseRollbarTest
         $this->assertEquals($expected, $result);
     }
 
-    public function testLogUncaught()
+    public function testLogUncaught(): void
     {
         $sut = new Rollbar;
         Rollbar::init(self::$simpleConfig);

--- a/tests/ScrubberTest.php
+++ b/tests/ScrubberTest.php
@@ -7,7 +7,7 @@ use Rollbar\TestHelpers\MockPhpStream;
 
 class ScrubberTest extends BaseRollbarTest
 {
-    public function scrubUrlDataProvider()
+    public function scrubUrlDataProvider(): array
     {
         return array(
             'nothing to scrub' => array(
@@ -26,7 +26,7 @@ class ScrubberTest extends BaseRollbarTest
     /**
      * @dataProvider scrubSafelistProvider
      */
-    public function testScrubSafelist($testData, $scrubFields, $safelist, $expected)
+    public function testScrubSafelist($testData, $scrubFields, $safelist, $expected): void
     {
         $scrubber = new Scrubber(array(
             'scrubFields' => $scrubFields,
@@ -40,7 +40,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
     
-    public function scrubSafelistProvider()
+    public function scrubSafelistProvider(): array
     {
         return array(
             array(
@@ -87,7 +87,7 @@ class ScrubberTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testScrub($testData, $scrubFields, $expected)
+    public function testScrub($testData, $scrubFields, $expected): void
     {
         $scrubber = new Scrubber(array(
             'scrubFields' => $scrubFields
@@ -96,7 +96,7 @@ class ScrubberTest extends BaseRollbarTest
         $this->assertEquals($expected, $result, "Looks like some fields did not get scrubbed correctly.");
     }
     
-    public function scrubDataProvider()
+    public function scrubDataProvider(): array
     {
         return array_merge(array(
             'flat data array' =>
@@ -112,7 +112,7 @@ class ScrubberTest extends BaseRollbarTest
         ), $this->scrubUrlDataProvider(), $this->scrubJSONNumbersProvider());
     }
 
-    private function scrubJSONNumbersProvider()
+    private function scrubJSONNumbersProvider(): array
     {
         return array(
             'plain array' => array(
@@ -132,7 +132,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
 
-    private function scrubFlatDataProvider()
+    private function scrubFlatDataProvider(): array
     {
         return array(
             array( // $testData
@@ -149,7 +149,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
     
-    private function scrubRecursiveDataProvider()
+    private function scrubRecursiveDataProvider(): array
     {
         return array(
             array( // $testData
@@ -196,7 +196,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
     
-    private function scrubFlatStringDataProvider()
+    private function scrubFlatStringDataProvider(): array
     {
         return array(
             // $testData
@@ -221,7 +221,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
     
-    private function scrubRecursiveStringDataProvider()
+    private function scrubRecursiveStringDataProvider(): array
     {
         return array(
             // $testData
@@ -252,7 +252,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
     
-    private function scrubRecursiveStringRecursiveDataProvider()
+    private function scrubRecursiveStringRecursiveDataProvider(): array
     {
         return array(
             array( // $testData
@@ -315,7 +315,7 @@ class ScrubberTest extends BaseRollbarTest
     /**
      * @dataProvider scrubArrayDataProvider
      */
-    public function testScrubArray($testData, $scrubFields, $expected)
+    public function testScrubArray($testData, $scrubFields, $expected): void
     {
         $scrubber = new Scrubber(array(
             'scrubFields' => $scrubFields
@@ -324,7 +324,7 @@ class ScrubberTest extends BaseRollbarTest
         $this->assertEquals($expected, $result, "Looks like some fields did not get scrubbed correctly.");
     }
 
-    public function scrubArrayDataProvider()
+    public function scrubArrayDataProvider(): array
     {
         return array(
             'flat data array' => array(
@@ -381,7 +381,7 @@ class ScrubberTest extends BaseRollbarTest
         );
     }
 
-    public function testScrubReplacement()
+    public function testScrubReplacement(): void
     {
         $testData = array('scrubit' => '123');
         

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -4,7 +4,7 @@ use Rollbar\Payload\Server;
 
 class ServerTest extends BaseRollbarTest
 {
-    public function testHost()
+    public function testHost(): void
     {
         $val = "TEST";
         $server = new Server();
@@ -15,7 +15,7 @@ class ServerTest extends BaseRollbarTest
         $this->assertEquals($val2, $server->setHost($val2)->getHost());
     }
 
-    public function testRoot()
+    public function testRoot(): void
     {
         $val = "TEST";
         $server = new Server();
@@ -26,7 +26,7 @@ class ServerTest extends BaseRollbarTest
         $this->assertEquals($val2, $server->setRoot($val2)->getRoot());
     }
 
-    public function testBranch()
+    public function testBranch(): void
     {
         $val = "TEST";
         $server = new Server();
@@ -37,7 +37,7 @@ class ServerTest extends BaseRollbarTest
         $this->assertEquals($val2, $server->setBranch($val2)->getBranch());
     }
 
-    public function testCodeVersion()
+    public function testCodeVersion(): void
     {
         $val = "TEST";
         $server = new Server();
@@ -48,7 +48,7 @@ class ServerTest extends BaseRollbarTest
         $this->assertEquals($val2, $server->setCodeVersion($val2)->getCodeVersion());
     }
 
-    public function testExtra()
+    public function testExtra(): void
     {
         $server = new Server();
         $server->setExtras(array("test" => "testing"));
@@ -56,7 +56,7 @@ class ServerTest extends BaseRollbarTest
         $this->assertEquals("testing", $extras["test"]);
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $server = new Server();
         $server->setHost("server2-ec-us")

--- a/tests/TestHelpers/CustomSerializable.php
+++ b/tests/TestHelpers/CustomSerializable.php
@@ -2,19 +2,19 @@
 
 class CustomSerializable implements \Serializable
 {
-    public $data;
+    public array $data;
 
     public function __construct($data)
     {
         $this->data = $data;
     }
 
-    public function serialize()
+    public function serialize(): array
     {
         return $this->data;
     }
 
-    public function unserialize(string $data)
+    public function unserialize(string $data): void
     {
         throw new \Exception("Not implemented");
     }

--- a/tests/TestHelpers/CustomTruncation.php
+++ b/tests/TestHelpers/CustomTruncation.php
@@ -2,12 +2,12 @@
 
 namespace Rollbar\TestHelpers;
 
-use \Rollbar\Truncation\AbstractStrategy;
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Truncation\AbstractStrategy;
+use Rollbar\Payload\EncodedPayload;
 
 class CustomTruncation extends AbstractStrategy
 {
-    public function execute(EncodedPayload $payload)
+    public function execute(EncodedPayload $payload): EncodedPayload
     {
         $payload->encode(array(
             "data" => array(

--- a/tests/TestHelpers/CycleCheck/ChildCycleCheckSerializable.php
+++ b/tests/TestHelpers/CycleCheck/ChildCycleCheckSerializable.php
@@ -11,7 +11,7 @@ class ChildCycleCheckSerializable implements SerializerInterface
         $this->parent = $parent;
     }
     
-    public function serialize()
+    public function serialize(): array
     {
         return array(
             "parent" => \Rollbar\Utilities::serializeForRollbarInternal($this->parent)

--- a/tests/TestHelpers/CycleCheck/ParentCycleCheck.php
+++ b/tests/TestHelpers/CycleCheck/ParentCycleCheck.php
@@ -2,7 +2,7 @@
 
 class ParentCycleCheck
 {
-    public $child;
+    public ChildCycleCheck $child;
     
     public function __construct()
     {

--- a/tests/TestHelpers/CycleCheck/ParentCycleCheckSerializable.php
+++ b/tests/TestHelpers/CycleCheck/ParentCycleCheckSerializable.php
@@ -4,14 +4,14 @@ use Rollbar\SerializerInterface;
 
 class ParentCycleCheckSerializable implements SerializerInterface
 {
-    public $child;
+    public ChildCycleCheck $child;
     
     public function __construct()
     {
         $this->child = new ChildCycleCheck($this);
     }
     
-    public function serialize()
+    public function serialize(): array
     {
         return array(
             "child" => \Rollbar\Utilities::serializeForRollbarInternal($this->child)

--- a/tests/TestHelpers/MalformedPayloadDataTransformer.php
+++ b/tests/TestHelpers/MalformedPayloadDataTransformer.php
@@ -1,7 +1,8 @@
 <?php namespace Rollbar\TestHelpers;
 
-use \Rollbar\Payload\Level;
-use \Rollbar\Payload\Payload;
+use Rollbar\Payload\Level;
+use Rollbar\Payload\Payload;
+use Rollbar\Payload\Data;
 
 class MalformedPayloadDataTransformer implements \Rollbar\TransformerInterface
 {
@@ -11,7 +12,7 @@ class MalformedPayloadDataTransformer implements \Rollbar\TransformerInterface
         mixed $toLog,
         array $context = array()
     ): ?Payload {
-        $mock = \Mockery::mock('\Rollbar\Payload\Data')->makePartial();
+        $mock = \Mockery::mock(Data::class)->makePartial();
         $mock->shouldReceive("serialize")->andReturn(false);
         $levelFactory = new \Rollbar\LevelFactory();
         $mock->setLevel($levelFactory->fromName($level));

--- a/tests/TestHelpers/MockPhpStream.php
+++ b/tests/TestHelpers/MockPhpStream.php
@@ -5,7 +5,7 @@ namespace Rollbar\TestHelpers;
 class MockPhpStream
 {
     
-    protected static $index = 0;
+    protected static int $index = 0;
     protected static $length = null;
 
     /**
@@ -13,21 +13,21 @@ class MockPhpStream
      * there are multiple instances of MockPhpStream being used in PHP
      * to deal with the stream wrapper.
      */
-    protected static $data = '';
+    protected static string|Data $data = '';
     
     // @codingStandardsIgnoreStart
     
-    public function stream_open()
+    public function stream_open(): bool
     {
         return true;
     }
     
-    public function stream_stat()
+    public function stream_stat(): array
     {
         return array();
     }
     
-    public function stream_read($count)
+    public function stream_read($count): string
     {
         if (is_null(self::$length) === true) {
             $this->length = strlen(self::$data);
@@ -38,12 +38,12 @@ class MockPhpStream
         return $data;
     }
     
-    public function stream_eof()
+    public function stream_eof(): bool
     {
         return (self::$index >= self::$length ? true : false);
     }
     
-    public function stream_write($data)
+    public function stream_write($data): ?int
     {
         self::$data = $data;
         self::$length = strlen(self::$data);

--- a/tests/TraceChainTest.php
+++ b/tests/TraceChainTest.php
@@ -1,22 +1,23 @@
 <?php namespace Rollbar\Payload\TraceChain;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\TraceChain;
 
 use Rollbar;
+use Rollbar\Payload\Trace;
 
 class TraceChainTest extends Rollbar\BaseRollbarTest
 {
-    private $trace1;
-    private $trace2;
+    private m\LegacyMockInterface|Trace|m\MockInterface $trace1;
+    private m\LegacyMockInterface|Trace|m\MockInterface $trace2;
 
     public function setUp(): void
     {
-        $this->trace1 = m::mock("Rollbar\Payload\Trace");
-        $this->trace2 = m::mock("Rollbar\Payload\Trace");
+        $this->trace1 = m::mock(Trace::class);
+        $this->trace2 = m::mock(Trace::class);
     }
 
-    public function testTraces()
+    public function testTraces(): void
     {
         $chain = array($this->trace1);
         $traceChain = new TraceChain($chain);
@@ -28,19 +29,19 @@ class TraceChainTest extends Rollbar\BaseRollbarTest
         $this->assertEquals($chain, $traceChain->getTraces());
     }
 
-    public function testKey()
+    public function testKey(): void
     {
         $chain = new TraceChain(array($this->trace1));
         $this->assertEquals("trace_chain", $chain->getKey());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
-        $trace1 = m::mock("Rollbar\Payload\Trace")
+        $trace1 = m::mock(Trace::class)
             ->shouldReceive("serialize")
             ->andReturn("TRACE1")
             ->mock();
-        $trace2 = m::mock("Rollbar\Payload\Trace")
+        $trace2 = m::mock(Trace::class)
             ->shouldReceive("serialize")
             ->andReturn("TRACE2")
             ->mock();

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -1,15 +1,16 @@
 <?php namespace Rollbar;
 
-use \Mockery as m;
+use Mockery as m;
 use Rollbar\Payload\Trace;
 use Rollbar\Payload\Frame;
+use Rollbar\Payload\ExceptionInfo;
 
 class TraceTest extends BaseRollbarTest
 {
-    public function testTraceConstructor()
+    public function testTraceConstructor(): void
     {
-        $exc = m::mock("Rollbar\Payload\ExceptionInfo");
-        $frames = array(m::mock("Rollbar\Payload\Frame"));
+        $exc = m::mock(ExceptionInfo::class);
+        $frames = array(m::mock(Frame::class));
         $badFrames = array(1);
 
         $trace = new Trace(array(), $exc);
@@ -21,28 +22,28 @@ class TraceTest extends BaseRollbarTest
         $this->assertEquals($exc, $trace->getException());
     }
 
-    public function testFrames()
+    public function testFrames(): void
     {
         $frames = array(
             new Frame("one.php"),
             new Frame("two.php")
         );
-        $exc = m::mock("Rollbar\Payload\ExceptionInfo");
+        $exc = m::mock(ExceptionInfo::class);
         $trace = new Trace(array(), $exc);
         $this->assertEquals($frames, $trace->setFrames($frames)->getFrames());
     }
 
-    public function testException()
+    public function testException(): void
     {
-        $exc = m::mock("Rollbar\Payload\ExceptionInfo");
+        $exc = m::mock(ExceptionInfo::class);
         $trace = new Trace(array(), $exc);
         $this->assertEquals($exc, $trace->getException());
 
-        $exc2 = m::mock("Rollbar\Payload\ExceptionInfo");
+        $exc2 = m::mock(ExceptionInfo::class);
         $this->assertEquals($exc2, $trace->setException($exc2)->getException());
     }
 
-    public function testEncode()
+    public function testEncode(): void
     {
         $value = m::mock("Rollbar\Payload\ExceptionInfo, Rollbar\SerializerInterface")
             ->shouldReceive("serialize")
@@ -53,9 +54,9 @@ class TraceTest extends BaseRollbarTest
         $this->assertEquals("{\"frames\":[],\"exception\":\"{EXCEPTION}\"}", $encoded);
     }
 
-    public function testTraceKey()
+    public function testTraceKey(): void
     {
-        $trace = new Trace(array(), m::mock("Rollbar\Payload\ExceptionInfo"));
+        $trace = new Trace(array(), m::mock(ExceptionInfo::class));
         $this->assertEquals("trace", $trace->getKey());
     }
 }

--- a/tests/Truncation/FramesStrategyTest.php
+++ b/tests/Truncation/FramesStrategyTest.php
@@ -3,15 +3,15 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\Payload\EncodedPayload;
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
 
 class FramesStrategyTest extends BaseRollbarTest
 {
     /**
      * @dataProvider executeProvider
      */
-    public function testExecute($data, $expected)
+    public function testExecute($data, $expected): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));
         $truncation = new Truncation($config);
@@ -26,7 +26,7 @@ class FramesStrategyTest extends BaseRollbarTest
         $this->assertEquals($expected, $result->data());
     }
     
-    public function executeProvider()
+    public function executeProvider(): array
     {
         $data = array(
             'nothing to truncate using trace key' => array(

--- a/tests/Truncation/MinBodyStrategyTest.php
+++ b/tests/Truncation/MinBodyStrategyTest.php
@@ -3,8 +3,8 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\Payload\EncodedPayload;
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
 
 class MinBodyStrategyTest extends BaseRollbarTest
 {
@@ -12,7 +12,7 @@ class MinBodyStrategyTest extends BaseRollbarTest
     /**
      * @dataProvider executeProvider
      */
-    public function testExecute($data, $expected)
+    public function testExecute($data, $expected): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));
         $truncation = new Truncation($config);
@@ -27,7 +27,7 @@ class MinBodyStrategyTest extends BaseRollbarTest
         $this->assertEquals($expected, $result->data());
     }
     
-    public function executeProvider()
+    public function executeProvider(): array
     {
         $data = array();
         
@@ -63,7 +63,7 @@ class MinBodyStrategyTest extends BaseRollbarTest
         return $data;
     }
     
-    protected function payloadStructureProvider($body)
+    protected function payloadStructureProvider($body): array
     {
         return array(
             "data" => array(

--- a/tests/Truncation/RawStrategyTest.php
+++ b/tests/Truncation/RawStrategyTest.php
@@ -3,12 +3,12 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\Payload\EncodedPayload;
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
 
 class RawStrategyTest extends BaseRollbarTest
 {
-    public function testExecute()
+    public function testExecute(): void
     {
         $payload = array('test' => 'test data');
 

--- a/tests/Truncation/StringsStrategyTest.php
+++ b/tests/Truncation/StringsStrategyTest.php
@@ -3,13 +3,13 @@
 namespace Rollbar\Truncation;
 
 use Rollbar\Payload\EncodedPayload;
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
 
 class StringsStrategyTest extends BaseRollbarTest
 {
     
-    protected function execute($data)
+    protected function execute($data): array
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));
         $truncation = new Truncation($config);
@@ -25,13 +25,13 @@ class StringsStrategyTest extends BaseRollbarTest
     /**
      * @dataProvider executeTruncateNothingProvider
      */
-    public function testExecuteTruncateNothing($data, $expected)
+    public function testExecuteTruncateNothing($data, $expected): void
     {
         $result = $this->execute($data);
         $this->assertEquals($expected, $result);
     }
     
-    public function executeTruncateNothingProvider()
+    public function executeTruncateNothingProvider(): array
     {
         $data = array();
         
@@ -46,7 +46,7 @@ class StringsStrategyTest extends BaseRollbarTest
     /**
      * @dataProvider executeArrayProvider
      */
-    public function testExecuteArray($data, $expectedThreshold)
+    public function testExecuteArray($data, $expectedThreshold): void
     {
         $result = $this->execute($data);
         
@@ -61,7 +61,7 @@ class StringsStrategyTest extends BaseRollbarTest
         }
     }
     
-    public function executeArrayProvider()
+    public function executeArrayProvider(): array
     {
         $data = array();
         
@@ -73,7 +73,7 @@ class StringsStrategyTest extends BaseRollbarTest
         return $data;
     }
     
-    public function thresholdTestProvider($threshold)
+    public function thresholdTestProvider($threshold): array
     {
         $stringLengthToTrim = $threshold*2;
         
@@ -90,7 +90,7 @@ class StringsStrategyTest extends BaseRollbarTest
         return array($payload, $threshold);
     }
 
-    public function executeProvider()
+    public function executeProvider(): array
     {
         $data = array();
 
@@ -107,7 +107,7 @@ class StringsStrategyTest extends BaseRollbarTest
         return $data;
     }
     
-    public function payloadStructureProvider($message)
+    public function payloadStructureProvider($message): array
     {
         return array(
             "data" => array(

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -2,9 +2,10 @@
 
 namespace Rollbar\Truncation;
 
-use \Rollbar\Config;
-use \Rollbar\BaseRollbarTest;
-use \Rollbar\Payload\EncodedPayload;
+use Rollbar\Config;
+use Rollbar\BaseRollbarTest;
+use Rollbar\Payload\EncodedPayload;
+use Rollbar\TestHelpers\CustomTruncation;
 
 class TruncationTest extends BaseRollbarTest
 {
@@ -15,11 +16,11 @@ class TruncationTest extends BaseRollbarTest
         $this->truncate = new \Rollbar\Truncation\Truncation($config);
     }
     
-    public function testCustomTruncation()
+    public function testCustomTruncation(): void
     {
         $config = new Config(array(
             'access_token' => $this->getTestAccessToken(),
-            'custom_truncation' => 'Rollbar\TestHelpers\CustomTruncation'
+            'custom_truncation' => CustomTruncation::class
         ));
         $this->truncate = new \Rollbar\Truncation\Truncation($config);
         
@@ -38,13 +39,13 @@ class TruncationTest extends BaseRollbarTest
         
         $result = $this->truncate->truncate($data);
         
-        $this->assertFalse(strpos($data, 'Custom truncation test string') === false);
+        $this->assertNotFalse(str_contains($data, 'Custom truncation test string'));
     }
 
     /**
      * @dataProvider truncateProvider
      */
-    public function testTruncateNoPerformance($data)
+    public function testTruncateNoPerformance($data): void
     {
         
         $data = new \Rollbar\Payload\EncodedPayload($data);
@@ -60,7 +61,7 @@ class TruncationTest extends BaseRollbarTest
         );
     }
     
-    public function truncateProvider()
+    public function truncateProvider(): array
     {
         
         $stringsTest = new StringsStrategyTest();

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -7,7 +7,7 @@ use Rollbar\TestHelpers\CycleCheck\ChildCycleCheckSerializable;
 
 class UtilitiesTest extends BaseRollbarTest
 {
-    public function testValidateString()
+    public function testValidateString(): void
     {
         Utilities::validateString("");
         Utilities::validateString("true");
@@ -18,25 +18,25 @@ class UtilitiesTest extends BaseRollbarTest
             Utilities::validateString(null, "null", null, false);
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$null must not be null");
+            $this->assertEquals("\$null must not be null", $e->getMessage());
         }
 
         try {
             Utilities::validateString(1, "number");
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$number must be a string");
+            $this->assertEquals("\$number must be a string", $e->getMessage());
         }
 
         try {
             Utilities::validateString("1", "str", 2);
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$str must be 2 characters long, was '1'");
+            $this->assertEquals("\$str must be 2 characters long, was '1'", $e->getMessage());
         }
     }
 
-    public function testValidateInteger()
+    public function testValidateInteger(): void
     {
         Utilities::validateInteger(null);
         Utilities::validateInteger(0);
@@ -46,37 +46,37 @@ class UtilitiesTest extends BaseRollbarTest
             Utilities::validateInteger(null, "null", null, null, false);
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$null must not be null");
+            $this->assertEquals("\$null must not be null", $e->getMessage());
         }
 
         try {
             Utilities::validateInteger(0, "zero", 1);
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$zero must be >= 1");
+            $this->assertEquals("\$zero must be >= 1", $e->getMessage());
         }
 
         try {
             Utilities::validateInteger(0, "zero", null, -1);
             $this->fail("Above should throw");
         } catch (\InvalidArgumentException $e) {
-            $this->assertEquals($e->getMessage(), "\$zero must be <= -1");
+            $this->assertEquals("\$zero must be <= -1", $e->getMessage());
         }
     }
 
-    public function testValidateBooleanThrowsExceptionOnNullWhenNullAreNotAllowed()
+    public function testValidateBooleanThrowsExceptionOnNullWhenNullAreNotAllowed(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Utilities::validateBoolean(null, "foo", false);
     }
 
-    public function testValidateBooleanWithInvalidBoolean()
+    public function testValidateBooleanWithInvalidBoolean(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         Utilities::validateBoolean("not a boolean");
     }
 
-    public function testValidateBoolean()
+    public function testValidateBoolean(): void
     {
         Utilities::validateBoolean(true, "foo", false);
         Utilities::validateBoolean(true);
@@ -84,7 +84,7 @@ class UtilitiesTest extends BaseRollbarTest
         $this->expectNotToPerformAssertions();
     }
 
-    public function testSerializeForRollbar()
+    public function testSerializeForRollbar(): void
     {
         $obj = array(
             "one_two" => array(1, 2),
@@ -111,7 +111,7 @@ class UtilitiesTest extends BaseRollbarTest
         $this->assertArrayNotHasKey("my_null_value", $result);
     }
     
-    public function testSerializationCycleChecking()
+    public function testSerializationCycleChecking(): void
     {
         $config = new Config(array("access_token"=>$this->getTestAccessToken()));
         $data = $config->getRollbarData(\Rollbar\Payload\Level::WARNING, "String", array(new ParentCycleCheck()));
@@ -142,7 +142,7 @@ class UtilitiesTest extends BaseRollbarTest
         );
     }
 
-    public function testSerializeForRollbarNestingLevels()
+    public function testSerializeForRollbarNestingLevels(): void
     {
         $obj = array(
             "one" => array(

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -1079,8 +1079,7 @@ class VerbosityTest extends BaseRollbarTest
         callable             $verboseExpectations,
         callable             $pre = null,
         callable             $post = null
-    ): void
-    {
+    ): void {
         $unitTest = $this;
         // Quiet scenario
         $this->prepareForLogMocking(
@@ -1122,8 +1121,7 @@ class VerbosityTest extends BaseRollbarTest
         callable $expectations,
         callable $pre = null,
         callable $post = null
-    ): void
-    {
+    ): void {
         if ($pre !== null) {
             $pre();
         }
@@ -1158,8 +1156,7 @@ class VerbosityTest extends BaseRollbarTest
         string   $messageLevel = Level::WARNING,
         callable $pre = null,
         callable $post = null
-    ): void
-    {
+    ): void {
         $rollbarLogger = $this->verboseRollbarLogger($config);
 
         $this->configurableObjectVerbosityTest(

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -5,6 +5,10 @@ namespace Rollbar;
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 use Rollbar\Response;
+use Monolog\Handler\AbstractHandler;
+use Rollbar\ResponseHandlerInterface;
+use Rollbar\FilterInterface;
+use Rollbar\Payload\Data;
 
 /**
  * \Rollbar\VerboseTest tests the verbosity of the SDK.
@@ -53,7 +57,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerEnabled()
+    public function testRollbarLoggerEnabled(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -83,7 +87,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerDisabled()
+    public function testRollbarLoggerDisabled(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -105,7 +109,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerInvalidLogLevel()
+    public function testRollbarLoggerInvalidLogLevel(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -136,7 +140,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerInternalCheckIgnored()
+    public function testRollbarLoggerInternalCheckIgnored(): void
     {
         $unitTest = $this;
         $errorReporting = \error_reporting();
@@ -167,7 +171,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerCheckIgnored()
+    public function testRollbarLoggerCheckIgnored(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -192,7 +196,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerSendMaxItems()
+    public function testRollbarLoggerSendMaxItems(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -219,7 +223,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerSendBatched()
+    public function testRollbarLoggerSendBatched(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -245,7 +249,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerFlush()
+    public function testRollbarLoggerFlush(): void
     {
         $unitTest = $this;
         $rollbarLogger = $this->verboseRollbarLogger(array(
@@ -276,7 +280,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerResponseStatusZero()
+    public function testRollbarLoggerResponseStatusZero(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -305,7 +309,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerResponseStatusError()
+    public function testRollbarLoggerResponseStatusError(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -332,7 +336,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarLoggerResponseStatusSuccess()
+    public function testRollbarLoggerResponseStatusSuccess(): void
     {
         $unitTest = $this;
         $this->rollbarLogTest(
@@ -358,7 +362,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigInternalCheckIgnoredShouldSuppress()
+    public function testRollbarConfigInternalCheckIgnoredShouldSuppress(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -400,7 +404,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigInternalCheckIgnoredLevelTooLow()
+    public function testRollbarConfigInternalCheckIgnoredLevelTooLow(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -433,7 +437,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigShouldIgnoreErrorErrorReporting()
+    public function testRollbarConfigShouldIgnoreErrorErrorReporting(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -474,7 +478,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigShouldIgnoreErrorIncludedErrno()
+    public function testRollbarConfigShouldIgnoreErrorIncludedErrno(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -515,7 +519,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigShouldIgnoreErrorErrorSampleRates()
+    public function testRollbarConfigShouldIgnoreErrorErrorSampleRates(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -549,7 +553,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigShouldIgnoreException()
+    public function testRollbarConfigShouldIgnoreException(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -583,7 +587,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigCheckIgnored()
+    public function testRollbarConfigCheckIgnored(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -598,11 +602,11 @@ class VerbosityTest extends BaseRollbarTest
             $config,
             function () use ($config, $unitTest) {
             // logic under test
-                $dataMock = $unitTest->getMockBuilder('\Rollbar\Payload\Data')
+                $dataMock = $unitTest->getMockBuilder(Data::class)
                     ->disableOriginalConstructor()
                     ->getMock();
                 $dataMock->method('getLevel')->willReturn(\Rollbar\Payload\Level::INFO());
-                $payloadMock = $unitTest->getMockBuilder('\Rollbar\Payload\Payload')
+                $payloadMock = $unitTest->getMockBuilder(Payload::class)
                     ->disableOriginalConstructor()
                     ->getMock();
                 $payloadMock->method('getData')->willReturn($dataMock);
@@ -630,7 +634,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigCheckIgnoredException()
+    public function testRollbarConfigCheckIgnoredException(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -666,7 +670,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigCheckIgnoredPayloadLevelTooLow()
+    public function testRollbarConfigCheckIgnoredPayloadLevelTooLow(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -700,10 +704,10 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigCheckIgnoredFilter()
+    public function testRollbarConfigCheckIgnoredFilter(): void
     {
         $unitTest = $this;
-        $filterMock = $this->getMockBuilder('\Rollbar\FilterInterface')->getMock();
+        $filterMock = $this->getMockBuilder(FilterInterface::class)->getMock();
         $filterMock->method('shouldSend')->willReturn(true);
 
         $config = $this->verboseRollbarConfig(array( // config
@@ -737,7 +741,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigSendTransmit()
+    public function testRollbarConfigSendTransmit(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -770,7 +774,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigSendBatchTransmit()
+    public function testRollbarConfigSendBatchTransmit(): void
     {
         $unitTest = $this;
         $config = $this->verboseRollbarConfig(array( // config
@@ -804,10 +808,10 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarConfigHandleResponse()
+    public function testRollbarConfigHandleResponse(): void
     {
         $unitTest = $this;
-        $responseHandlerMock = $this->getMockBuilder('\Rollbar\ResponseHandlerInterface')->getMock();
+        $responseHandlerMock = $this->getMockBuilder(ResponseHandlerInterface::class)->getMock();
         $config = $this->verboseRollbarConfig(array( // config
             "access_token" => $this->getTestAccessToken(),
             "environment" => "testing-php",
@@ -843,7 +847,7 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @return void
      */
-    public function testRollbarTruncation()
+    public function testRollbarTruncation(): void
     {
         $unitTest = $this;
         $rollbarLogger = $this->verboseRollbarLogger(array(
@@ -886,10 +890,10 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @param array $config Config array used to configure
      * the $object.
-     * @param \Rollbar\RollbarLogger|\Rollbar\Config $object
+     * @param \Rollbar\Config|\Rollbar\RollbarLogger $object
      * Object to be set up for the test.
      */
-    private function prepareForLogMocking($config, $object)
+    private function prepareForLogMocking(array $config, Config|RollbarLogger $object): Config|RollbarLogger
     {
         $verboseLogger = new \Monolog\Logger('rollbar.verbose.test');
 
@@ -897,9 +901,7 @@ class VerbosityTest extends BaseRollbarTest
             'verbose_logger' => $verboseLogger
         )));
 
-        $verbose = isset($config['verbose']) ?
-            $config['verbose'] :
-            \Rollbar\Config::VERBOSE_NONE;
+        $verbose = $config['verbose'] ?? \Rollbar\Config::VERBOSE_NONE;
 
         if ($verbose == \Rollbar\Config::VERBOSE_NONE) {
             $verbose = \Rollbar\Config::VERBOSE_NONE_INT;
@@ -907,7 +909,7 @@ class VerbosityTest extends BaseRollbarTest
             $verbose = \Monolog\Logger::toMonologLevel($verbose);
         }
 
-        $handlerMock = $this->getMockBuilder('\Monolog\Handler\AbstractHandler')
+        $handlerMock = $this->getMockBuilder(AbstractHandler::class)
             ->setMethods(array('handle'))
             ->getMock();
         $handlerMock->setLevel($verbose);
@@ -928,7 +930,7 @@ class VerbosityTest extends BaseRollbarTest
      * @param array $config Configuration options for Rollbar
      * @return \Rollbar\Config
      */
-    private function verboseRollbarConfig($config)
+    private function verboseRollbarConfig(array $config): Config|RollbarLogger
     {
         return $this->prepareForLogMocking(
             $config,
@@ -945,7 +947,7 @@ class VerbosityTest extends BaseRollbarTest
      * @param array $config Configuration options for Rollbar
      * @return \Rollbar\RollbarLogger
      */
-    private function verboseRollbarLogger($config)
+    private function verboseRollbarLogger(array $config): Config|RollbarLogger
     {
         return $this->prepareForLogMocking(
             $config,
@@ -962,7 +964,7 @@ class VerbosityTest extends BaseRollbarTest
      * @param string $level The level of the log recorded which will
      * be asserted.
      */
-    private function withLogParams($messageRegEx, $level)
+    private function withLogParams(string $messageRegEx, string $level): \PHPUnit\Framework\Constraint\Callback
     {
         return $this->callback(function ($record) use ($messageRegEx, $level) {
             return
@@ -974,7 +976,7 @@ class VerbosityTest extends BaseRollbarTest
     /**
      * Convenience method for asserting a log record is in a valid format.
      */
-    private function withLog()
+    private function withLog(): \PHPUnit\Framework\Constraint\Callback
     {
         return $this->callback(function ($record) {
             return is_array($record);
@@ -1035,7 +1037,7 @@ class VerbosityTest extends BaseRollbarTest
      * @param mock|null $handlerMock (optional) The handler mock on which to set the
      * expectations.
      */
-    public function expectLog($at, $messageRegEx, $level, $handlerMock = null)
+    public function expectLog(int $at, string $messageRegEx, string $level, mock $handlerMock = null): void
     {
         $this->expectConsecutiveLog([ $at, $messageRegEx, $level ]);
     }
@@ -1046,7 +1048,7 @@ class VerbosityTest extends BaseRollbarTest
      * @param mock|null $handlerMock (optional) The handler mock on which to set the
      * expectations.
      */
-    public function expectQuiet($handlerMock = null)
+    public function expectQuiet(mock $handlerMock = null): void
     {
         if ($handlerMock === null) {
             $handlerMock = $this->verboseHandlerMock;
@@ -1063,21 +1065,22 @@ class VerbosityTest extends BaseRollbarTest
      * to the initial config is not needed as the method takes
      * care of performing assertions in both quiet and verbose scenarios.
      *
-     * @param \Rollbar\RollbarLogger|\Rollbar\Config $object Object under test.
+     * @param \Rollbar\Config|\Rollbar\RollbarLogger $object Object under test.
      * @param callback $test Logic under test
      * @param callback $verboseExpectations A callback with
      * expectations to be set on the verbose logger handler mock
      * in the verbose scenario.
-     * @param callback $pre (optional) Logic to be executed before test.
-     * @param callback $post (optional) Logic to be executed after the test
+     * @param callback|null $pre (optional) Logic to be executed before test.
+     * @param callback|null $post (optional) Logic to be executed after the test
      */
     private function configurableObjectVerbosityTest(
-        $object,
-        $test,
-        $verboseExpectations,
-        $pre = null,
-        $post = null
-    ) {
+        Config|RollbarLogger $object,
+        callable             $test,
+        callable             $verboseExpectations,
+        callable             $pre = null,
+        callable             $post = null
+    ): void
+    {
         $unitTest = $this;
         // Quiet scenario
         $this->prepareForLogMocking(
@@ -1111,15 +1114,16 @@ class VerbosityTest extends BaseRollbarTest
      *
      * @param callback $test Logic under test.
      * @param callback $expectations Logic with expectations.
-     * @param callback $pre (optional) Test set up.
-     * @param callback $post (optional) Test tear down.
+     * @param callback|null $pre (optional) Test set up.
+     * @param callback|null $post (optional) Test tear down.
      */
     private function withTestLambdas(
-        $test,
-        $expectations,
-        $pre = null,
-        $post = null
-    ) {
+        callable $test,
+        callable $expectations,
+        callable $pre = null,
+        callable $post = null
+    ): void
+    {
         if ($pre !== null) {
             $pre();
         }
@@ -1145,16 +1149,17 @@ class VerbosityTest extends BaseRollbarTest
      * set on the verbose logger handler mock.
      * @param string $messageLevel (optional) The level of the Rollbar log
      * message invoked.
-     * @param callback $pre (optional) Logic to be executed before test.
-     * @param callback $post (optional) Logic to be executed after the test
+     * @param callback|null $pre (optional) Logic to be executed before test.
+     * @param callback|null $post (optional) Logic to be executed after the test
      */
     private function rollbarLogTest(
-        $config,
-        $expectations,
-        $messageLevel = Level::WARNING,
-        $pre = null,
-        $post = null
-    ) {
+        array    $config,
+        callable $expectations,
+        string   $messageLevel = Level::WARNING,
+        callable $pre = null,
+        callable $post = null
+    ): void
+    {
         $rollbarLogger = $this->verboseRollbarLogger($config);
 
         $this->configurableObjectVerbosityTest(


### PR DESCRIPTION
## Description of the change

- language level mitigations for php 8. Changes are mostly suggestions from PhpStorm IDE.
- add typehints for /tests/
- small fix in order of arguments in tests (assertEquals)


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
