### PR TITLE
Fixed #571 added null check on $filename

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -499,7 +499,7 @@ class DataBuilder implements DataBuilderInterface
 
     private function addCodeContextToFrame(Frame $frame, $filename, $line)
     {
-        if (!file_exists($filename)) {
+        if (null === $filename || !file_exists($filename)) {
             return;
         }
 


### PR DESCRIPTION
## Description of the change

This PR fixes #571 by ensuring `$filename` is not `null`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix #571 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
