### PR TITLE
Added support for psr/log v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   "require": {
     "php": ">=8.0.0 <9.0",
     "ext-curl": "*",
-    "psr/log": "^1 || ^2",
+    "psr/log": "^1 || ^2 || ^3",
     "monolog/monolog": "^2"
   },
 

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -146,8 +146,11 @@ class Rollbar
             return self::getNotInitializedResponse();
         }
         $toLog->isUncaught = true;
-        $result = self::$logger->report($level, $toLog, (array)$extra);
-        unset($toLog->isUncaught);
+        try {
+            $result = self::$logger->report($level, $toLog, (array)$extra);
+        } finally {
+            unset($toLog->isUncaught);
+        }
         return $result;
     }
     

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -2,10 +2,12 @@
 
 namespace Rollbar;
 
+use Psr\Log\InvalidArgumentException;
 use Rollbar\Payload\Level;
 use Rollbar\Handlers\FatalHandler;
 use Rollbar\Handlers\ErrorHandler;
 use Rollbar\Handlers\ExceptionHandler;
+use Stringable;
 use Throwable;
 
 class Rollbar
@@ -90,12 +92,49 @@ class Rollbar
         return self::$logger->scope($config);
     }
 
-    public static function log($level, $toLog, $extra = array())
+    /**
+     * Logs a message to the Rollbar service with the specified level.
+     *
+     * @param Level|string      $level   The severity level of the message.
+     *                                   Must be one of the levels as defined in
+     *                                   the {@see Level} constants.
+     * @param string|Stringable $message The log message.
+     * @param array             $context Arbitrary data.
+     *
+     * @return void
+     *
+     * @throws InvalidArgumentException If $level is not a valid level.
+     * @throws Throwable Rethrown $message if it is {@see Throwable} and {@see Config::raiseOnError} is true.
+     */
+    public static function log($level, string|Stringable $message, array $context = array()): void
+    {
+        if (is_null(self::$logger)) {
+            return;
+        }
+        self::$logger->log($level, $message, $context);
+    }
+
+    /**
+     * Creates the {@see Response} object and reports the message to the Rollbar
+     * service.
+     *
+     * @param string|Level      $level   The severity level to send to Rollbar.
+     * @param string|Stringable $message The log message.
+     * @param array             $context Any additional context data.
+     *
+     * @return Response
+     *
+     * @throws InvalidArgumentException If $level is not a valid level.
+     * @throws Throwable Rethrown $message if it is {@see Throwable} and {@see Config::raiseOnError} is true.
+     *
+     * @since 4.0.0
+     */
+    public static function report($level, string|Stringable $message, array $context = array()): Response
     {
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
-        return self::$logger->log($level, $toLog, (array)$extra);
+        return self::$logger->report($level, $message, $context);
     }
 
     /**
@@ -107,49 +146,49 @@ class Rollbar
             return self::getNotInitializedResponse();
         }
         $toLog->isUncaught = true;
-        $result = self::$logger->log($level, $toLog, (array)$extra);
+        $result = self::$logger->report($level, $toLog, (array)$extra);
         unset($toLog->isUncaught);
         return $result;
     }
     
-    public static function debug($toLog, $extra = array())
+    public static function debug(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::DEBUG, $toLog, $extra);
+        self::log(Level::DEBUG, $message, $context);
     }
     
-    public static function info($toLog, $extra = array())
+    public static function info(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::INFO, $toLog, $extra);
+        self::log(Level::INFO, $message, $context);
     }
     
-    public static function notice($toLog, $extra = array())
+    public static function notice(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::NOTICE, $toLog, $extra);
+        self::log(Level::NOTICE, $message, $context);
     }
     
-    public static function warning($toLog, $extra = array())
+    public static function warning(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::WARNING, $toLog, $extra);
+        self::log(Level::WARNING, $message, $context);
     }
     
-    public static function error($toLog, $extra = array())
+    public static function error(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::ERROR, $toLog, $extra);
+        self::log(Level::ERROR, $message, $context);
     }
     
-    public static function critical($toLog, $extra = array())
+    public static function critical(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::CRITICAL, $toLog, $extra);
+        self::log(Level::CRITICAL, $message, $context);
     }
     
-    public static function alert($toLog, $extra = array())
+    public static function alert(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::ALERT, $toLog, $extra);
+        self::log(Level::ALERT, $message, $context);
     }
     
-    public static function emergency($toLog, $extra = array())
+    public static function emergency(string|Stringable $message, array $context = array()): void
     {
-        return self::log(Level::EMERGENCY, $toLog, $extra);
+        self::log(Level::EMERGENCY, $message, $context);
     }
 
     public static function setupExceptionHandling()
@@ -170,7 +209,7 @@ class Rollbar
         self::$fatalHandler->register();
     }
 
-    private static function getNotInitializedResponse()
+    private static function getNotInitializedResponse(): Response
     {
         return new Response(0, "Rollbar Not Initialized");
     }
@@ -247,7 +286,7 @@ class Rollbar
     public static function report_exception($exc, $extra_data = null, $payload_data = null)
     {
         $extra_data = array_merge($extra_data ?? [], $payload_data ?? []);
-        return self::log(Level::ERROR, $exc, $extra_data)->getUuid();
+        return self::report(Level::ERROR, $exc, $extra_data)->getUuid();
     }
 
     /**
@@ -266,7 +305,7 @@ class Rollbar
     {
         $level = $level ?? Level::ERROR;
         $extra_data = array_merge($extra_data ?? [], $payload_data ?? []);
-        return self::log($level, $message, $extra_data)->getUuid();
+        return self::report($level, $message, $extra_data)->getUuid();
     }
 
 

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -14,7 +14,7 @@ class CurlSenderTest extends BaseRollbarTest
             "environment" => "testing-php",
             "endpoint" => "fake-endpoint"
         ));
-        $response = $logger->log(Level::WARNING, "Testing PHP Notifier", array());
+        $response = $logger->report(Level::WARNING, "Testing PHP Notifier", array());
 
         $this->assertContains(
             $response->getInfo(),

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -40,7 +40,7 @@ class ReadmeTest extends BaseRollbarTest
         );
 
         // If you want to check if logging with Rollbar was successful
-        $response = Rollbar::log(Level::INFO, 'testing wasSuccessful()');
+        $response = Rollbar::report((new LevelFactory)->fromName(Level::INFO), 'testing wasSuccessful()');
         if (!$response->wasSuccessful()) {
             throw new \Exception('logging with Rollbar failed');
         }
@@ -98,9 +98,9 @@ class ReadmeTest extends BaseRollbarTest
         try {
             do_something();
         } catch (\Exception $e) {
-            $result1 = Rollbar::log(Level::ERROR, $e);
+            $result1 = Rollbar::report(Level::ERROR, $e);
             // or
-            $result2 = Rollbar::log(Level::ERROR, $e, array("my" => "extra", "data" => 42));
+            $result2 = Rollbar::report(Level::ERROR, $e, array("my" => "extra", "data" => 42));
         }
         
         $this->assertEquals(200, $result1->getStatus());
@@ -116,8 +116,8 @@ class ReadmeTest extends BaseRollbarTest
             )
         );
         
-        $result1 = Rollbar::log(Level::WARNING, 'could not connect to mysql server');
-        $result2 = Rollbar::log(
+        $result1 = Rollbar::report(Level::WARNING, 'could not connect to mysql server');
+        $result2 = Rollbar::report(
             Level::INFO,
             'Here is a message with some additional data',
             array('x' => 10, 'code' => 'blue')

--- a/tests/TestHelpers/ArrayLogger.php
+++ b/tests/TestHelpers/ArrayLogger.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Rollbar\TestHelpers;
+
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+
+/**
+ * Simple logger that saves logs to an array.
+ *
+ * @since 4.0.0
+ */
+class ArrayLogger extends AbstractLogger
+{
+    public array $logs = [];
+
+    /**
+     * Serialize a level and message into a single string.
+     *
+     * @param                   $level
+     * @param Stringable|string $message
+     *
+     * @return string
+     */
+    private static function stringify($level, Stringable|string $message): string
+    {
+        return '[' . $level . ']' . $message;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $this->logs[] = self::stringify($level, $message);
+    }
+
+    /**
+     * Returns the number of instances of a log in the logs.
+     *
+     * @param                   $level
+     * @param Stringable|string $message
+     *
+     * @return int
+     */
+    public function count($level, Stringable|string $message): int
+    {
+        $count = 0;
+        $str   = self::stringify($level, $message);
+        foreach ($this->logs as $log) {
+            if ($str === $log) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+}

--- a/tests/TestHelpers/StdOutLogger.php
+++ b/tests/TestHelpers/StdOutLogger.php
@@ -2,13 +2,14 @@
 
 namespace Rollbar\TestHelpers;
 
+use Stringable;
 use Rollbar\RollbarLogger;
 use Psr\Log\LoggerTrait;
 
 class StdOutLogger extends RollbarLogger
 {
-    public function log($level, $toLog, array $context = array())
+    public function log($level, string|Stringable $message, array $context = array()): void
     {
-        echo '[' . get_class($this) . ': '. $level . '] ' . $message;
+        echo '[' . get_class($this) . ': ' . $level . '] ' . $message;
     }
 }


### PR DESCRIPTION
## Description of the change

This PR adds support for `psr/log` version 3. This has been a long-standing issue but could not be fixed without causing breaking changes. See #536 for a discussion.

I renamed the `log()` method in both `Rollbar` and `RollbarLogger` classes to `report()`. New `log()` methods were then created that were compliant with `Psr\Log\LoggerInterface`. Since the `report()` methods are not defined in the `psr/log` interface we can return the `Response` object. This is very important for testing purposes.

Almost all unit tests that used `Rollbar::log()` or `RollbarLogger::log()` were updated to use `Rollbar::report()` or `RollbarLogger::report()`. There are a few exceptions where the `log()` method was still tested. To validate that `log()` was working correctly a test helper class `ArrayLogger` was created that collects all verbose logs into an array in memory. Those logs can then be checked as a side effect of calling `log()` since it no longer returns anything.

It is worth noting that there is still one outstanding behavior defined by `psr/log` that has not been implemented. #461 explains this. I will resolve that issue in a separate PR.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #570

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
