### PR TITLE
Fixed #461 Added support for psr/log context exception

### DIFF
--- a/src/DataBuilderInterface.php
+++ b/src/DataBuilderInterface.php
@@ -3,9 +3,10 @@
 namespace Rollbar;
 
 use Rollbar\Payload\Data;
+use Stringable;
 use Throwable;
 
 interface DataBuilderInterface
 {
-    public function makeData(string $level, Throwable|string $toLog, array $context): Data;
+    public function makeData(string $level, Throwable|string|Stringable $toLog, array $context): Data;
 }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -922,7 +922,7 @@ class DataBuilderTest extends BaseRollbarTest
             'tests/DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
-        // The line number where the comment "// A" is found should be the expeced value.
+        // The line number where the comment "// A" is found should be the expected value.
         $this->assertEquals(
             920,
             $frames[count($frames)-1]->getLineno(),

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar;
 
+use Exception;
 use Rollbar\Payload\Level;
 use Rollbar\TestHelpers\MockPhpStream;
 
@@ -686,6 +687,32 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertNull($output[0]->getContext());
     }
 
+    public function testExceptionInContext(): void
+    {
+        $dataBuilder = new DataBuilder(array(
+            'accessToken' => $this->getTestAccessToken(),
+            'environment' => 'tests',
+            'utilities'   => new Utilities(),
+        ));
+
+        $output = $dataBuilder->makeData(
+            Level::ERROR,
+            "testing",
+            array(
+                'exception' => new Exception('testing exception'),
+            ),
+        )->serialize();
+
+        $this->assertSame(
+            array(
+                'class'       => 'Exception',
+                'message'     => 'testing exception',
+                'description' => 'testing',
+            ),
+            $output['body']['trace']['exception'],
+        );
+    }
+
     public function testPerson(): void
     {
         $dataBuilder = new DataBuilder(array(
@@ -897,7 +924,7 @@ class DataBuilderTest extends BaseRollbarTest
         );
         // 893 is the line number where the comment "// A" is found
         $this->assertEquals(
-            893,
+            920,
             $frames[count($frames)-1]->getLineno(),
             "Possible false negative: did this file change? Check the line number for line with '// A' comment"
         );

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -922,7 +922,7 @@ class DataBuilderTest extends BaseRollbarTest
             'tests/DataBuilderTest.php',
             $frames[count($frames)-1]->getFilename()
         );
-        // 893 is the line number where the comment "// A" is found
+        // The line number where the comment "// A" is found should be the expeced value.
         $this->assertEquals(
             920,
             $frames[count($frames)-1]->getLineno(),

--- a/tests/FakeDataBuilder.php
+++ b/tests/FakeDataBuilder.php
@@ -1,9 +1,9 @@
 <?php namespace Rollbar;
 
-use Rollbar\DataBuilderInterface;
 use Rollbar\Payload\Body;
 use Rollbar\Payload\Data;
 use Rollbar\Payload\Message;
+use Stringable;
 use Throwable;
 
 class FakeDataBuilder implements DataBuilderInterface
@@ -16,7 +16,7 @@ class FakeDataBuilder implements DataBuilderInterface
         self::$args[] = $arr;
     }
 
-    public function makeData(string $level, Throwable|string $toLog, array $context): Data
+    public function makeData(string $level, Throwable|string|Stringable $toLog, array $context): Data
     {
         self::$logged[] = array($level, $toLog, $context);
 


### PR DESCRIPTION
## Description of the change

This change brings us up to compliance with the [PSR-3 logging standard](https://www.php-fig.org/psr/psr-3/#13-context). PSR-3 requires an `Exception` in the `context` array must be in the `exception` key.

For example, the following is a pretty standard non-exception log...

```php
RollbarLogger::log(
    level: Level::INFO, 
    message: "something interesting happened", 
    context: []
);
```

However, the PSR-3 standard expects us to be able to accept the following log...

```php
RollbarLogger::log(
    level: Level::ERROR, 
    message: "something bad happened", 
    context: ['exception' => new Exception('it broke')]
);
```

Until now we have treated the `exception` key the same as any other key. Meaning we would not have created a stack trace of the `Exception`. We only did that if the `Exception` was the `message`.

This change adds a check to determine if the `context` array contains an `exception` key and it is a `Throwable`. If it is we use that as our `Exception` when generating the trace. To retain as much backwards compatibility as possible `Exceptions` can still be passed in as the `message`. In fact, this is the default behavior for our exception handler that automatically catches and logs uncaught exceptions. 

This does create a change in how we handle exceptions in the `$message`. If there is an exception in `$context['exception']` we will ignore any exception in `$message`. Instead, we take the string value of `$message` and use it as the `description` of the exception. Until now the `description` was always omitted.

The last additional change was to update some of our internal type annotations.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #461

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
