### PR TITLE
Fixed call of method name changed in 8fac418

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -721,7 +721,12 @@ class Config
         }
     }
 
-    public function logPayloadLogger()
+    /**
+     * Returns the logger responsible for logging request payload and response dumps, if enabled.
+     *
+     * @return LoggerInterface
+     */
+    public function logPayloadLogger(): LoggerInterface
     {
         return $this->logPayloadLogger;
     }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -3,6 +3,7 @@
 namespace Rollbar;
 
 use Psr\Log\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use Stringable;
 use Throwable;
 use Psr\Log\AbstractLogger;
@@ -256,9 +257,14 @@ class RollbarLogger extends AbstractLogger
         return $this->config->getDataBuilder();
     }
 
-    public function outputLogger()
+    /**
+     * Returns the logger responsible for logging request payload and response dumps, if enabled.
+     *
+     * @return LoggerInterface
+     */
+    public function logPayloadLogger(): LoggerInterface
     {
-        return $this->config->outputLogger();
+        return $this->config->logPayloadLogger();
     }
 
     public function verboseLogger()


### PR DESCRIPTION
## Description of the change

In 8fac418 we renamed the `Config` properties `'output'` and `'output_logger'` and to `'log_payload'` and `'log_payload_logger'` respectively. We also renamed all the exposed methods that operated on these properties. Unfortunately, we missed one call to the old `Config::outputLogger()` method when doing the refactor. This commit fixes that and adds type annotations and method comments.

Note: at some point after 8fac418 we changed the property syntax from snake case to camel case.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
