### PR TITLE
Added types and method docs to `Rollbar` and `RollbarLogger` classes

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -193,6 +193,10 @@ class Config
     private $mtRandmax;
 
     private $includedErrno;
+
+    /**
+     * @var bool Sets whether to respect current {@see error_reporting()} level or not.
+     */
     private bool $useErrorReporting = false;
 
     /**
@@ -884,10 +888,10 @@ class Config
     }
 
     /**
-     * Check if the error should be ignored due to `included_errno` config,
-     * `use_error_reporting` config or `error_sample_rates` config.
+     * Check if the error should be ignored due to `includedErrno` config, `useErrorReporting` config or
+     * `errorSampleRates` config.
      *
-     * @param errno
+     * @param int $errno The PHP error level bitmask.
      *
      * @return bool
      */
@@ -1058,7 +1062,8 @@ class Config
     public function sendBatch(array $batch, string $accessToken): ?Response
     {
         if ($this->transmitting()) {
-            return $this->sender->sendBatch($batch, $accessToken);
+            $this->sender->sendBatch($batch, $accessToken);
+            return null;
         } else {
             $response = new Response(0, "Not transmitting (transmitting disabled in configuration)");
             $this->verboseLogger()->warning($response->getInfo());

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar;
 
+use Exception;
 use Psr\Log\InvalidArgumentException;
 use Rollbar\Payload\Level;
 use Rollbar\Handlers\FatalHandler;
@@ -13,19 +14,68 @@ use Throwable;
 class Rollbar
 {
     /**
-     * @var RollbarLogger
+     * The instance of the logger. This is null if Rollbar has not been initialized or {@see Rollbar::destroy()} has
+     * been called.
+     *
+     * @var RollbarLogger|null
      */
-    private static $logger = null;
-    private static $fatalHandler = null;
-    private static $errorHandler = null;
-    private static $exceptionHandler = null;
+    private static ?RollbarLogger $logger = null;
 
+    /**
+     * The fatal error handler instance or null if it was disabled or Rollbar has not been initialized.
+     *
+     * @var FatalHandler|null
+     */
+    private static ?FatalHandler $fatalHandler = null;
+
+    /**
+     * The error handler instance or null if it was disabled or Rollbar has not been initialized.
+     *
+     * @var ErrorHandler|null
+     */
+    private static ?ErrorHandler $errorHandler = null;
+
+    /**
+     * The exception handler instance or null if it was disabled or Rollbar has not been initialized.
+     *
+     * @var ExceptionHandler|null
+     */
+    private static ?ExceptionHandler $exceptionHandler = null;
+
+    /**
+     * Sets up Rollbar monitoring and logging.
+     *
+     * This method may be called more than once to update or extend the configs. To do this pass an array as the
+     * $configOrLogger argument. Any config values in the array will update or replace existing configs.
+     *
+     * Note: this and the following two parameters are only used the first time the logger is created. This prevents
+     * multiple error monitors from reporting the same error more than once. To change these values you must call
+     * {@see Rollbar::destroy()} first.
+     *
+     * Example:
+     *
+     *     // Turn off the fatal error handler
+     *     $configs = Rollbar::logger()->getConfig();
+     *     Rollbar::destroy();
+     *     Rollbar::init($configs, handleFatal: false);
+     *
+     * @param RollbarLogger|array $configOrLogger  This can be either an array of config options or an already
+     *                                             configured {@see RollbarLogger} instance.
+     * @param bool                $handleException If set to false Rollbar will not monitor exceptions.
+     * @param bool                $handleError     If set to false Rollbar will not monitor errors.
+     * @param bool                $handleFatal     If set to false Rollbar will not monitor fatal errors.
+     *
+     * @return void
+     * @throws Exception If the $configOrLogger argument is an array that has invalid configs.
+     *
+     * @link https://docs.rollbar.com/docs/basic-php-installation-setup
+     */
     public static function init(
-        $configOrLogger,
-        $handleException = true,
-        $handleError = true,
-        $handleFatal = true
-    ) {
+        RollbarLogger|array $configOrLogger,
+        bool $handleException = true,
+        bool $handleError = true,
+        bool $handleFatal = true
+    ): void {
         $setupHandlers = is_null(self::$logger);
 
         self::setLogger($configOrLogger);
@@ -44,47 +94,92 @@ class Rollbar
         }
     }
 
-    private static function setLogger($configOrLogger)
+    /**
+     * Creates or configures the RollbarLogger instance.
+     *
+     * @param RollbarLogger|array $configOrLogger The configs array or a new {@see RollbarLogger} to use or replace the
+     *                                            current one with, if one already exists. If a logger already exists
+     *                                            and this is an array the current logger's configs will be extended
+     *                                            configs from the array.
+     *
+     * @return void
+     * @throws Exception If the $configOrLogger argument is an array that has invalid configs.
+     */
+    private static function setLogger(RollbarLogger|array $configOrLogger): void
     {
         if ($configOrLogger instanceof RollbarLogger) {
-            $logger = $configOrLogger;
+            self::$logger = $configOrLogger;
+            return;
         }
 
         // Replacing the logger rather than configuring the existing logger breaks BC
-        if (self::$logger && !isset($logger)) {
+        if (self::$logger !== null) {
             self::$logger->configure($configOrLogger);
             return;
         }
 
-        self::$logger = $logger ?? new RollbarLogger($configOrLogger);
+        self::$logger = new RollbarLogger($configOrLogger);
     }
-    
-    public static function enable()
+
+    /**
+     * Enables logging of errors to Rollbar.
+     *
+     * @return void
+     */
+    public static function enable(): void
     {
-        return self::logger()->enable();
+        self::logger()->enable();
     }
-    
-    public static function disable()
+
+    /**
+     * Disables logging of errors to Rollbar.
+     *
+     * @return void
+     */
+    public static function disable(): void
     {
-        return self::logger()->disable();
+        self::logger()->disable();
     }
-    
-    public static function enabled()
+
+    /**
+     * Returns true if the Rollbar logger is enabled.
+     *
+     * @return bool
+     */
+    public static function enabled(): bool
     {
         return self::logger()->enabled();
     }
-    
-    public static function disabled()
+
+    /**
+     * Returns true if the Rollbar logger is disabled.
+     *
+     * @return bool
+     */
+    public static function disabled(): bool
     {
         return self::logger()->disabled();
     }
 
-    public static function logger()
+    /**
+     * Returns the current logger instance, or null if it has not been initialized or has been destroyed.
+     *
+     * @return RollbarLogger|null
+     */
+    public static function logger(): ?RollbarLogger
     {
         return self::$logger;
     }
 
-    public static function scope($config)
+    /**
+     * Creates and returns a new {@see RollbarLogger} instance.
+     *
+     * @param array $config The configs extend the configs of the current logger instance, if it exists.
+     *
+     * @return RollbarLogger
+     * @throws Exception If the $config argument is an array that has invalid configs.
+     */
+    public static function scope(array $config): RollbarLogger
     {
         if (is_null(self::$logger)) {
             return new RollbarLogger($config);
@@ -138,91 +233,202 @@ class Rollbar
     }
 
     /**
+     * Attempts to log a {@see Throwable} as an uncaught exception.
+     *
+     * @param string|Level $level   The log level severity to use.
+     * @param Throwable    $toLog   The exception to log.
+     * @param array        $context The array of additional data to pass with the stack trace.
+     *
+     * @return Response
+     * @throws Throwable The rethrown $toLog.
+     *
      * @since 3.0.0
      */
-    public static function logUncaught($level, Throwable $toLog, $extra = array())
+    public static function logUncaught(string|Level $level, Throwable $toLog, array $context = array()): Response
     {
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
         $toLog->isUncaught = true;
         try {
-            $result = self::$logger->report($level, $toLog, (array)$extra);
+            $result = self::$logger->report($level, $toLog, $context);
         } finally {
             unset($toLog->isUncaught);
         }
         return $result;
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::DEBUG} log level.
+     *
+     * @param string|Stringable $message The debug message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function debug(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::DEBUG, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::INFO} log level.
+     *
+     * @param string|Stringable $message The info message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function info(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::INFO, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::NOTICE} log level.
+     *
+     * @param string|Stringable $message The notice message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function notice(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::NOTICE, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::WARNING} log level.
+     *
+     * @param string|Stringable $message The warning message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function warning(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::WARNING, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::ERROR} log level.
+     *
+     * @param string|Stringable $message The error message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function error(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::ERROR, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::CRITICAL} log level.
+     *
+     * @param string|Stringable $message The critical message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function critical(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::CRITICAL, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::ALERT} log level.
+     *
+     * @param string|Stringable $message The alert message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function alert(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::ALERT, $message, $context);
     }
-    
+
+    /**
+     * Logs a message with the {@see Level::EMERGENCY} log level.
+     *
+     * @param string|Stringable $message The emergency message to log.
+     * @param array             $context The additional data to send with the message.
+     *
+     * @return void
+     * @throws Throwable
+     */
     public static function emergency(string|Stringable $message, array $context = array()): void
     {
         self::log(Level::EMERGENCY, $message, $context);
     }
 
-    public static function setupExceptionHandling()
+    /**
+     * Creates a listener that monitors for exceptions.
+     *
+     * @return void
+     */
+    public static function setupExceptionHandling(): void
     {
         self::$exceptionHandler = new ExceptionHandler(self::$logger);
         self::$exceptionHandler->register();
     }
-    
-    public static function setupErrorHandling()
+
+    /**
+     * Creates a listener that monitors for errors.
+     *
+     * @return void
+     */
+    public static function setupErrorHandling(): void
     {
         self::$errorHandler = new ErrorHandler(self::$logger);
         self::$errorHandler->register();
     }
 
-    public static function setupFatalHandling()
+    /**
+     * Creates a listener that monitors for fatal errors that cause the program to shut down.
+     *
+     * @return void
+     */
+    public static function setupFatalHandling(): void
     {
         self::$fatalHandler = new FatalHandler(self::$logger);
         self::$fatalHandler->register();
     }
 
+    /**
+     * Creates and returns a {@see Response} to use if Rollbar is attempted to be used prior to being initialized.
+     *
+     * @return Response
+     */
     private static function getNotInitializedResponse(): Response
     {
         return new Response(0, "Rollbar Not Initialized");
     }
-    
-    public static function setupBatchHandling()
+
+    /**
+     * This method makes sure the queue of logs stored in memory are sent to Rollbar prior to shut down.
+     *
+     * @return void
+     */
+    public static function setupBatchHandling(): void
     {
         register_shutdown_function('Rollbar\Rollbar::flushAndWait');
     }
 
-    public static function flush()
+    /**
+     * Sends all the queued logs to Rollbar.
+     *
+     * @return void
+     */
+    public static function flush(): void
     {
         if (is_null(self::$logger)) {
             return;
@@ -230,39 +436,75 @@ class Rollbar
         self::$logger->flush();
     }
 
-    public static function flushAndWait()
+    /**
+     * Sends all the queued logs to Rollbar and waits for the response.
+     *
+     * @return void
+     */
+    public static function flushAndWait(): void
     {
         if (is_null(self::$logger)) {
             return;
         }
         self::$logger->flushAndWait();
     }
-    
-    public static function addCustom($key, $value)
+
+    /**
+     * Adds a new key / value pair that will be sent with the payload to Rollbar. If the key already exists in the
+     * custom data array the existing value will be overwritten.
+     *
+     * @param string $key  The key to store this value in the custom array.
+     * @param mixed  $data The value that is going to be stored. Must be a primitive or JSON serializable.
+     *
+     * @return void
+     */
+    public static function addCustom(string $key, mixed $data): void
     {
-        self::$logger->addCustom($key, $value);
+        self::$logger->addCustom($key, $data);
     }
-    
-    public static function removeCustom($key)
+
+    /**
+     * Removes a key from the custom data array that is sent with the payload to Rollbar.
+     *
+     * @param string $key The key to remove.
+     *
+     * @return void
+     */
+    public static function removeCustom(string $key): void
     {
         self::$logger->removeCustom($key);
     }
-    
-    public static function getCustom()
+
+    /**
+     * Returns the array of key / value pairs that will be sent with the payload to Rollbar.
+     *
+     * @return array|null
+     */
+    public static function getCustom(): ?array
     {
-        self::$logger->getCustom();
+        return self::$logger->getCustom();
     }
-    
-    public static function configure($config)
+
+    /**
+     * Configures the existing {@see RollbarLogger} instance.
+     *
+     * @param array $config The array of configs. This does not need to be complete as it extends the existing
+     *                      configuration. Any existing values present in the new configs will be overwritten.
+     *
+     * @return void
+     */
+    public static function configure(array $config): void
     {
         self::$logger->configure($config);
     }
-    
+
     /**
-     * Destroys the currently stored $logger allowing for a fresh configuration.
-     * This is especially used in testing scenarios.
+     * Destroys the currently stored $logger allowing for a fresh configuration. This is especially used in testing
+     * scenarios.
+     *
+     * @return void
      */
-    public static function destroy()
+    public static function destroy(): void
     {
         self::$logger = null;
     }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar;
 
+use Exception;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Stringable;
@@ -10,77 +11,168 @@ use Psr\Log\AbstractLogger;
 use Rollbar\Payload\Payload;
 use Rollbar\Payload\Level;
 use Rollbar\Truncation\Truncation;
-use Monolog\Logger as MonologLogger;
 use Rollbar\Payload\EncodedPayload;
 
 class RollbarLogger extends AbstractLogger
 {
-    private $config;
-    private $truncation;
-    private $queue;
-    private $reportCount = 0;
+    /**
+     * @var Config $config The logger configuration instance.
+     */
+    private Config $config;
 
+    /**
+     * @var Truncation The payload truncation manager for the logger.
+     */
+    private Truncation $truncation;
+
+    /**
+     * @var array $queue The queue for sending payloads in batched mode.
+     */
+    private array $queue;
+
+    /**
+     * @var int $reportCount The number of reports already sent or queued.
+     */
+    private int $reportCount = 0;
+
+    /**
+     * Creates a new instance of the RollbarLogger.
+     *
+     * @param array $config The array of configs to use for the logger.
+     *
+     * @throws Exception If a custom truncation strategy class does not implement {@see StrategyInterface}.
+     */
     public function __construct(array $config)
     {
-        $this->config = new Config($config);
+        $this->config     = new Config($config);
         $this->truncation = new Truncation($this->config);
-        $this->queue = array();
+        $this->queue      = array();
     }
 
     /**
+     * Returns the configs object.
+     *
+     * @return Config
+     *
      * @since 3.0
      */
-    public function getConfig()
+    public function getConfig(): Config
     {
         return $this->config;
     }
-    
-    public function enable()
+
+    /**
+     * Enables logging of errors to Rollbar.
+     *
+     * @return void
+     */
+    public function enable(): void
     {
-        return $this->config->enable();
+        $this->config->enable();
     }
-    
-    public function disable()
+
+    /**
+     * Disables logging of errors to Rollbar.
+     *
+     * @return void
+     */
+    public function disable(): void
     {
-        return $this->config->disable();
+        $this->config->disable();
     }
-    
-    public function enabled()
+
+    /**
+     * Returns true if the Rollbar logger is enabled.
+     *
+     * @return bool
+     */
+    public function enabled(): bool
     {
         return $this->config->enabled();
     }
-    
-    public function disabled()
+
+    /**
+     * Returns true if the Rollbar logger is disabled.
+     *
+     * @return bool
+     */
+    public function disabled(): bool
     {
         return $this->config->disabled();
     }
 
-    public function configure(array $config)
+    /**
+     * Updates the existing configurations. All existing configurations will be kept unless explicitly updated in the
+     * $config array.
+     *
+     * @param array $config The new configurations to add or overwrite the existing configurations.
+     *
+     * @return void
+     */
+    public function configure(array $config): void
     {
         $this->config->configure($config);
     }
 
-    public function scope(array $config)
+    /**
+     * Returns a new {@see RollbarLogger} instance with a combination of the configs from the current logger updated
+     * with the extra $configs array.
+     *
+     * @param array $config Additional configurations to update or overwrite the existing configurations.
+     *
+     * @return RollbarLogger
+     * @throws Exception
+     */
+    public function scope(array $config): RollbarLogger
     {
         return new RollbarLogger($this->extend($config));
     }
 
-    public function extend(array $config)
+    /**
+     * Deeply combines the provided $config array and the existing configurations and returns the combined array of
+     * configs.
+     *
+     * @param array $config The new configs to update or overwrite the existing configurations.
+     *
+     * @return array
+     */
+    public function extend(array $config): array
     {
         return $this->config->extend($config);
     }
-    
-    public function addCustom($key, $data)
+
+    /**
+     * Adds a new key / value pair that will be sent with the payload to Rollbar. If the key already exists in the
+     * custom data array the existing value will be overwritten.
+     *
+     * @param string $key  The key to store this value in the custom array.
+     * @param mixed  $data The value that is going to be stored. Must be a primitive or JSON serializable.
+     *
+     * @return void
+     */
+    public function addCustom(string $key, mixed $data): void
     {
         $this->config->addCustom($key, $data);
     }
-    
-    public function removeCustom($key)
+
+    /**
+     * Removes a key from the custom data array that is sent with the payload to Rollbar.
+     *
+     * @param string $key The key to remove.
+     *
+     * @return void
+     */
+    public function removeCustom(string $key): void
     {
         $this->config->removeCustom($key);
     }
-    
-    public function getCustom()
+
+    /**
+     * Returns the array of key / value pairs that will be sent with the payload to Rollbar.
+     *
+     * @return array|null
+     */
+    public function getCustom(): mixed
     {
         return $this->config->getCustom();
     }
@@ -185,10 +277,15 @@ class RollbarLogger extends AbstractLogger
         return $response;
     }
 
+    /**
+     * Sends and flushes the batch payload queue.
+     *
+     * @return Response|null
+     */
     public function flush(): ?Response
     {
         if ($this->getQueueSize() > 0) {
-            $batch = $this->queue;
+            $batch       = $this->queue;
             $this->queue = array();
             return $this->config->sendBatch($batch, $this->getAccessToken());
         }
@@ -196,22 +293,47 @@ class RollbarLogger extends AbstractLogger
         return new Response(0, "Queue empty");
     }
 
+    /**
+     * Sends and flushes the batch payload queue, and waits for the requests to be sent.
+     *
+     * @return void
+     */
     public function flushAndWait(): void
     {
         $this->flush();
         $this->config->wait($this->getAccessToken());
     }
 
-    public function shouldIgnoreError($errno)
+    /**
+     * Returns true if the error level should be ignored because of error level or sampling rates.
+     *
+     * @param int $errno The PHP error level bitmask.
+     *
+     * @return bool
+     */
+    public function shouldIgnoreError(int $errno): bool
     {
         return $this->config->shouldIgnoreError($errno);
     }
 
+    /**
+     * Returns the number of report payloads currently in batch queue.
+     *
+     * @return int
+     */
     public function getQueueSize(): int
     {
         return count($this->queue);
     }
 
+    /**
+     * Sends a report to the Rollbar service.
+     *
+     * @param EncodedPayload $payload     The prepared payload to send.
+     * @param string         $accessToken The API access token.
+     *
+     * @return Response
+     */
     protected function send(EncodedPayload $payload, string $accessToken): Response
     {
         if ($this->reportCount >= $this->config->getMaxItems()) {
@@ -236,23 +358,47 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->debug("Added payload to the queue (running in `batched` mode).");
             return $response;
         }
-        
+
         return $this->config->send($payload, $accessToken);
     }
 
-    protected function getPayload(string $accessToken, $level, $toLog, $context)
-    {
-        $data = $this->config->getRollbarData($level, $toLog, $context);
+    /**
+     * Creates a payload from a log level and message or error.
+     *
+     * @param string            $accessToken The API access token.
+     * @param string            $level       The log level. Should be one of the {@see Level} constants.
+     * @param string|Stringable $toLog       The message or error to be sent to Rollbar.
+     * @param array             $context     Additional data to send with the message.
+     *
+     * @return Payload|null
+     */
+    protected function getPayload(
+        string $accessToken,
+        string $level,
+        string|Stringable $toLog,
+        array $context,
+    ): ?Payload {
+        $data    = $this->config->getRollbarData($level, $toLog, $context);
         $payload = new Payload($data, $accessToken);
         return $this->config->transform($payload, $level, $toLog, $context);
     }
 
+    /**
+     * Returns the access token for the logger instance.
+     *
+     * @return string
+     */
     protected function getAccessToken(): string
     {
         return $this->config->getAccessToken();
     }
-    
-    public function getDataBuilder()
+
+    /**
+     * Returns the configured DataBuilder instance.
+     *
+     * @return DataBuilder
+     */
+    public function getDataBuilder(): DataBuilder
     {
         return $this->config->getDataBuilder();
     }
@@ -267,18 +413,34 @@ class RollbarLogger extends AbstractLogger
         return $this->config->logPayloadLogger();
     }
 
-    public function verboseLogger()
+    /**
+     * Returns the verbose logger instance.
+     *
+     * @return LoggerInterface
+     */
+    public function verboseLogger(): LoggerInterface
     {
         return $this->config->verboseLogger();
     }
 
+    /**
+     * Calls the custom 'responseHandler', config if it exists.
+     *
+     * @param Payload $payload  The payload that was sent.
+     * @param mixed   $response The response from the Rollbar service.
+     *
+     * @return void
+     */
     protected function handleResponse(Payload $payload, mixed $response): void
     {
         $this->config->handleResponse($payload, $response);
     }
-    
+
     /**
-     * @param array $serializedPayload
+     * Tries to remove sensitive data from the payload before it is sent.
+     *
+     * @param array $serializedPayload The multidimensional array of data to be sent.
+     *
      * @return array
      */
     protected function scrub(array &$serializedPayload): array
@@ -286,21 +448,28 @@ class RollbarLogger extends AbstractLogger
         $serializedPayload['data'] = $this->config->getScrubber()->scrub($serializedPayload['data']);
         return $serializedPayload;
     }
-    
+
     /**
-     * @param \Rollbar\Payload\EncodedPayload $payload
-     * @return \Rollbar\Payload\EncodedPayload
+     * Reduces the size of the data, so it does not exceed size limits.
+     *
+     * @param EncodedPayload $payload The payload to possibly truncate.
+     *
+     * @return EncodedPayload
      */
-    protected function truncate(\Rollbar\Payload\EncodedPayload &$payload)
+    protected function truncate(EncodedPayload $payload): EncodedPayload
     {
         return $this->truncation->truncate($payload);
     }
-    
+
     /**
-     * @param array &$payload
-     * @return \Rollbar\Payload\EncodedPayload
+     * JSON serializes the payload.
+     *
+     * @param array $payload The data payload to serialize.
+     *
+     * @return EncodedPayload
+     * @throws Exception If JSON serialization fails.
      */
-    protected function encode(array &$payload)
+    protected function encode(array $payload): EncodedPayload
     {
         $encoded = new EncodedPayload($payload);
         $encoded->encode();


### PR DESCRIPTION
## Description of the change

This PR adds typing and comments to the `Rollbar` and `RollbarLogger` classes. These two classes are the ones a developer is most likely to interact with the most. Because of that these are the two that need the changes typing and comments the most.

The PR also adds a few updates to the `Config` class, and fixes an incorrect return type.

The only code change that is not simply handling return types, argument types, or comments is in `Rollbar::setLogger()`. I had to read the method a few times to make sure I understood exactly what it was doing. I decided to simplify the logic, so it is easier to read and understand.

Lastly

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
