### PR TITLE
Added typing / comments to the `FilterInterface` and removed the token argument

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -856,7 +856,7 @@ class Config
         }
 
         if (!is_null($this->filter)) {
-            $filter = $this->filter->shouldSend($payload);
+            $filter = $this->filter->shouldSend($payload, $isUncaught);
             $this->verboseLogger()->debug("Custom filter result: " . var_export($filter, true));
             return $filter;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -833,7 +833,7 @@ class Config
         return $this->sendMessageTrace;
     }
 
-    public function checkIgnored($payload, string $accessToken, $toLog, bool $isUncaught)
+    public function checkIgnored($payload, $toLog, bool $isUncaught)
     {
         if (isset($this->checkIgnore)) {
             try {
@@ -856,7 +856,7 @@ class Config
         }
 
         if (!is_null($this->filter)) {
-            $filter = $this->filter->shouldSend($payload, $accessToken);
+            $filter = $this->filter->shouldSend($payload);
             $this->verboseLogger()->debug("Custom filter result: " . var_export($filter, true));
             return $filter;
         }

--- a/src/FilterInterface.php
+++ b/src/FilterInterface.php
@@ -4,7 +4,19 @@ namespace Rollbar;
 
 use Rollbar\Payload\Payload;
 
+/**
+ * The FilterInterface allows a custom payload filter to be used. It should be passed to the configs with the 'filter'
+ * key. A custom filter should implement this interface.
+ */
 interface FilterInterface
 {
-    public function shouldSend(Payload $payload, string $accessToken);
+    /**
+     * Method called to determine if a payload should be sent to the Rollbar service. If true is returned the payload
+     * will not be sent.
+     *
+     * @param Payload $payload The payload instance that may be sent.
+     *
+     * @return bool
+     */
+    public function shouldSend(Payload $payload): bool;
 }

--- a/src/FilterInterface.php
+++ b/src/FilterInterface.php
@@ -14,9 +14,11 @@ interface FilterInterface
      * Method called to determine if a payload should be sent to the Rollbar service. If true is returned the payload
      * will not be sent.
      *
-     * @param Payload $payload The payload instance that may be sent.
+     * @param Payload $payload    The payload instance that may be sent.
+     * @param bool    $isUncaught True if the payload represents an error that was caught by one of the Rollbar
+     *                            exception or error handlers.
      *
      * @return bool
      */
-    public function shouldSend(Payload $payload): bool;
+    public function shouldSend(Payload $payload, bool $isUncaught): bool;
 }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -242,7 +242,7 @@ class RollbarLogger extends AbstractLogger
         $payload     = $this->getPayload($accessToken, $level, $message, $context);
 
         $isUncaught = $this->isUncaughtLogData($message);
-        if ($this->config->checkIgnored($payload, $accessToken, $message, $isUncaught)) {
+        if ($this->config->checkIgnored($payload, $message, $isUncaught)) {
             $this->verboseLogger()->info('Occurrence ignored');
             $response = new Response(0, "Ignored");
         } else {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -341,12 +341,12 @@ class ConfigTest extends BaseRollbarTest
     
     public function assertPayloadIgnored($config, $payload): void
     {
-        $this->assertTrue($config->checkIgnored($payload, 'access-token', $this->error, false));
+        $this->assertTrue($config->checkIgnored($payload, $this->error, false));
     }
     
     public function assertPayloadNotIgnored($config, $payload): void
     {
-        $this->assertFalse($config->checkIgnored($payload, 'access-token', $this->error, false));
+        $this->assertFalse($config->checkIgnored($payload, $this->error, false));
     }
     
     private function prepareMockPayload($level): Payload
@@ -421,8 +421,8 @@ class ConfigTest extends BaseRollbarTest
             "environment" => $this->env,
             "filter" => $filter
         ));
-        $this->assertTrue($c->checkIgnored($p, "fake_access_token", $this->error, false));
-        $this->assertFalse($c->checkIgnored($p, "fake_access_token", $this->error, false));
+        $this->assertTrue($c->checkIgnored($p, $this->error, false));
+        $this->assertFalse($c->checkIgnored($p, $this->error, false));
     }
 
     public function testSender(): void
@@ -608,7 +608,6 @@ class ConfigTest extends BaseRollbarTest
                 $data,
                 $config->getAccessToken()
             ),
-            $this->getTestAccessToken(),
             $this->error,
             false
         );
@@ -647,7 +646,6 @@ class ConfigTest extends BaseRollbarTest
                 $data,
                 $config->getAccessToken()
             ),
-            $this->getTestAccessToken(),
             $this->error,
             true
         );

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -612,7 +612,6 @@ class VerbosityTest extends BaseRollbarTest
                 $payloadMock->method('getData')->willReturn($dataMock);
                 $config->checkIgnored(
                     $payloadMock,
-                    $unitTest->getTestAccessToken(),
                     $payloadMock,
                     false
                 );
@@ -651,7 +650,7 @@ class VerbosityTest extends BaseRollbarTest
             // logic under test
                 $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
                 $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, $unitTest->getTestAccessToken(), 'some message', false);
+                $config->checkIgnored($payload, 'some message', false);
             },
             function () use ($unitTest) {
             // verbosity expectations
@@ -685,7 +684,7 @@ class VerbosityTest extends BaseRollbarTest
             // logic under test
                 $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
                 $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, $unitTest->getTestAccessToken(), 'some message', false);
+                $config->checkIgnored($payload, 'some message', false);
             },
             function () use ($unitTest) {
             // verbosity expectations
@@ -722,7 +721,7 @@ class VerbosityTest extends BaseRollbarTest
             // logic under test
                 $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
                 $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, $unitTest->getTestAccessToken(), 'some message', false);
+                $config->checkIgnored($payload, 'some message', false);
             },
             function () use ($unitTest) {
             // verbosity expectations


### PR DESCRIPTION
There are six interfaces for custom classes that may be passed into the configs to change how the Rollbar package works. They are:

1. `DataBuilderInterface` handled in #586
2. `FilterInterface` handled in this PR
3. `ResponseHandlerInterface`
4. `ScrubberInterface`
5. `SenderInterface`
6. `TransformerInterface`

The others will be addressed in future PRs (coming soon).

## Description of the change

Implementing the `FilterInterface` is the lesser used filtering alternative to the `check_ignore` function.

I removed the `$accessToken` argument from the `FilterInterface::shouldSend()` method. This does not seem necessary, or helpful. And passing any sort of secret around where not needed seems like a poor idea. Additionally, if the implementation desperately needs it, calling `$payload->getAccessToken()` will provide it from the `Payload` instance.

## Design Question

The `check_ignore` function accepts a boolean `$isUncaught` argument that is used to designate the log item as an uncaught error or exception. `FilterInterface::shouldSend()` method could likely possibly benefit from this additional argument. Should I add it? Any input would be helpful.

If we did not add the `$isUncaught` argument to `FilterInterface::shouldSend()`, there is a simple workaround that would likely work...

```php
class MyCustomFilter implements FilterInterface {
    private static bool $isUncaught;
    public static function checkIgnore(bool $isUncaught, string|Stringable $toLog, Payload $payload) {
        self::$isUncaught = $isUncaught;
        // Other logic
    }
    public function shouldSend(Payload $payload): bool {
        $isUncaught = self::$isUncaught
        // More logic
    }
}
Rollbar::init([
    'check_ignore' => MyCustomFilter::checkIgnore,
    'filter' => MyCustomFilter::class,
]);
```

I appreciate any input on this question.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
