### PR TITLE
Updated the typing and comments for the `ResponseHandlerInterface`

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1077,7 +1077,7 @@ class Config
         $this->sender->wait($accessToken, $max);
     }
 
-    public function handleResponse(Payload $payload, mixed $response): void
+    public function handleResponse(Payload $payload, Response $response): void
     {
         if (!is_null($this->responseHandler)) {
             $this->verboseLogger()->debug(

--- a/src/ResponseHandlerInterface.php
+++ b/src/ResponseHandlerInterface.php
@@ -4,7 +4,22 @@ namespace Rollbar;
 
 use Rollbar\Payload\Payload;
 
+/**
+ * The response handler interface allows the processing of responses from the Rollbar service after a log message or
+ * error report has been sent to Rollbar. A custom response handler FQCN may be passed in the config array with the key
+ * "responseHandler". The custom handler class constructor may be a single argument by including it in the config array
+ * with the "responseHandlerOptions" key. If the "responseHandlerOptions" key does not exist an empty array will be
+ * passed to the constructor.
+ */
 interface ResponseHandlerInterface
 {
-    public function handleResponse(Payload $payload, mixed $response): void;
+    /**
+     * The handleResponse method is called with the response from the Rollbar service after an error or log message has
+     * been sent.
+     *
+     * @param Payload  $payload  The payload object that was sent to Rollbar.
+     * @param Response $response The response that was returned. If the response status code is 0, it likely represents
+     *                           an ignored error that was never sent.
+     */
+    public function handleResponse(Payload $payload, Response $response): void;
 }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -426,12 +426,12 @@ class RollbarLogger extends AbstractLogger
     /**
      * Calls the custom 'responseHandler', config if it exists.
      *
-     * @param Payload $payload  The payload that was sent.
-     * @param mixed   $response The response from the Rollbar service.
+     * @param Payload  $payload  The payload that was sent.
+     * @param Response $response The response from the Rollbar service.
      *
      * @return void
      */
-    protected function handleResponse(Payload $payload, mixed $response): void
+    protected function handleResponse(Payload $payload, Response $response): void
     {
         $this->config->handleResponse($payload, $response);
     }


### PR DESCRIPTION
## Description of the change

This PR...

1. Adds comments to `ResponseHandlerInterface`.
2. Updates the `$response` argument type in the entire chain of functions to `ResponseHandlerInterface::handleResponse()` from `mixed` to `Response`. The function call only originates from the `RollbarLogger::report()` method where a `Response` object is passed to the `$response` argument.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
