### PR TITLE
Added typing / comments to the `ScrubberInterface` and `Scrubber` class

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -833,7 +833,7 @@ class Config
         return $this->sendMessageTrace;
     }
 
-    public function checkIgnored($payload, string $accessToken, $toLog, bool $isUncaught)
+    public function checkIgnored(Payload $payload, string $accessToken, $toLog, bool $isUncaught)
     {
         if (isset($this->checkIgnore)) {
             try {

--- a/src/Payload/Payload.php
+++ b/src/Payload/Payload.php
@@ -40,7 +40,7 @@ class Payload implements SerializerInterface
         return $this;
     }
 
-    public function serialize($maxDepth = -1)
+    public function serialize($maxDepth = -1): array
     {
         $objectHashes = array();
         $result = array(

--- a/src/ScrubberInterface.php
+++ b/src/ScrubberInterface.php
@@ -2,7 +2,20 @@
 
 namespace Rollbar;
 
+/**
+ * The scrubber interface allows a custom scrubber to be created that removes sensitive data and PII from the payload
+ * before it is sent to the Rollbar service. Optionally, the class implementing the interface may include a constructor
+ * that accepts a single argument for the configs array.
+ */
 interface ScrubberInterface
 {
-    public function scrub(&$data, $replacement);
+    /**
+     * The scrub method is called to clean PII from the exception or the log message payload.
+     *
+     * @param array  $data        The array serialized data to be scrubbed.
+     * @param string $replacement The replacement value to use for anything that is deemed sensitive.
+     *
+     * @return array
+     */
+    public function scrub(array &$data, string $replacement): array;
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -318,7 +318,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             array()
         );
         
-        $this->assertEquals(400, $response->getStatus());
+        $this->assertEquals(422, $response->getStatus());
     }
 
     public function testFlush(): void

--- a/tests/ScrubberTest.php
+++ b/tests/ScrubberTest.php
@@ -11,14 +11,14 @@ class ScrubberTest extends BaseRollbarTest
     {
         return array(
             'nothing to scrub' => array(
-                'https://rollbar.com', // $testData
+                array('https://rollbar.com'), // $testData
                 array(), // $scrubfields
-                'https://rollbar.com' // $expected
+                array('https://rollbar.com'), // $expected
             ),
             'mix of scrub and no scrub' => array(
-                'https://rollbar.com?arg1=val1&arg2=val2&arg3=val3', // $testData
+                array('https://rollbar.com?arg1=val1&arg2=val2&arg3=val3'), // $testData
                 array('arg2'), // $scrubFields
-                'https://rollbar.com?arg1=val1&arg2=xxxxxxxx&arg3=val3' // $expected
+                array('https://rollbar.com?arg1=val1&arg2=xxxxxxxx&arg3=val3'), // $expected
             ),
         );
     }
@@ -87,12 +87,12 @@ class ScrubberTest extends BaseRollbarTest
     /**
      * @dataProvider scrubDataProvider
      */
-    public function testScrub($testData, $scrubFields, $expected): void
+    public function testScrub(array $testData, array $scrubFields, array $expected): void
     {
         $scrubber = new Scrubber(array(
-            'scrubFields' => $scrubFields
+            'scrubFields' => $scrubFields,
         ));
-        $result = $scrubber->scrub($testData);
+        $result   = $scrubber->scrub($testData);
         $this->assertEquals($expected, $result, "Looks like some fields did not get scrubbed correctly.");
     }
     
@@ -116,18 +116,18 @@ class ScrubberTest extends BaseRollbarTest
     {
         return array(
             'plain array' => array(
-                  '[1023,1924]',
+                  array('[1023,1924]'),
                   array(
                       'sensitive'
                   ),
-                  '[1023,1924]'
+                  array('[1023,1924]')
             ),
             'param equals array' => array(
-                'b=[1023,1924]',
+                array('b=[1023,1924]'),
                 array(
                     'sensitive'
                 ),
-                'b=[1023,1924]'
+                array('b=[1023,1924]')
             )
         );
     }
@@ -200,23 +200,27 @@ class ScrubberTest extends BaseRollbarTest
     {
         return array(
             // $testData
-            '?' . http_build_query(
-                array(
-                    'arg1' => 'val 1',
-                    'sensitive' => 'scrubit',
-                    'arg2' => 'val 3'
-                )
+            array(
+                '?' . http_build_query(
+                    array(
+                        'arg1'      => 'val 1',
+                        'sensitive' => 'scrubit',
+                        'arg2'      => 'val 3',
+                    )
+                ),
             ),
             array( // $scrubFields
                 'sensitive'
             ),
             // $expected
-            '?' . http_build_query(
-                array(
-                    'arg1' => 'val 1',
-                    'sensitive' => 'xxxxxxxx',
-                    'arg2' => 'val 3'
-                )
+            array(
+                '?' . http_build_query(
+                    array(
+                        'arg1'      => 'val 1',
+                        'sensitive' => 'xxxxxxxx',
+                        'arg2'      => 'val 3',
+                    )
+                ),
             ),
         );
     }
@@ -225,29 +229,33 @@ class ScrubberTest extends BaseRollbarTest
     {
         return array(
             // $testData
-            '?' . http_build_query(
-                array(
-                    'arg1' => 'val 1',
-                    'sensitive' => 'scrubit',
-                    'arg2' => array(
-                        'arg3' => 'val 3',
-                        'sensitive' => 'scrubit'
+            array(
+                '?' . http_build_query(
+                    array(
+                        'arg1'      => 'val 1',
+                        'sensitive' => 'scrubit',
+                        'arg2'      => array(
+                            'arg3'      => 'val 3',
+                            'sensitive' => 'scrubit',
+                        ),
                     )
-                )
+                ),
             ),
             array( // $scrubFields
-                'sensitive'
+                'sensitive',
             ),
             // $expected
-            '?' . http_build_query(
-                array(
-                    'arg1' => 'val 1',
-                    'sensitive' => 'xxxxxxxx',
-                    'arg2' => array(
-                        'arg3' => 'val 3',
-                        'sensitive' => 'xxxxxxxx'
+            array(
+                '?' . http_build_query(
+                    array(
+                        'arg1'      => 'val 1',
+                        'sensitive' => 'xxxxxxxx',
+                        'arg2'      => array(
+                            'arg3'      => 'val 3',
+                            'sensitive' => 'xxxxxxxx',
+                        ),
                     )
-                )
+                ),
             ),
         );
     }

--- a/tests/TestHelpers/MalformedPayloadDataTransformer.php
+++ b/tests/TestHelpers/MalformedPayloadDataTransformer.php
@@ -13,7 +13,7 @@ class MalformedPayloadDataTransformer implements \Rollbar\TransformerInterface
         array $context = array()
     ): ?Payload {
         $mock = \Mockery::mock(Data::class)->makePartial();
-        $mock->shouldReceive("serialize")->andReturn(false);
+        $mock->shouldReceive("serialize")->andReturn(array());
         $mock->setLevel(\Rollbar\LevelFactory::fromName($level));
         $payload->setData($mock);
         return $payload;


### PR DESCRIPTION
## Description of the change

This PR adds better typing and comments to the `ScrubberInterface` to make implementation less error prone. In the process it seemed best to add these same updates to the `Scrubber` class as well. 

The update of the `Scrubber` class required some additional updates around the serialization of the `Payload` class. Since the `Scubber::scrub()` method is only ever given the output of `Payload::serialize()`, I updated the `scrub()` method to only accept an `array` as the `$data` argument. This is stricter than it was previously, however, the only usage that deviates from `array` is in the tests. Additionally, if scrubbing of other types is needed, the `Scrubber::internalScrub()` method is unlike its name would lead you to believe `public`.

**Other changes**

1. The `MalformedPayloadDataTransformer` serialized payload was changed from `false` to an empty array.
2. The previous change caused the response HTTP status code to change from 400 to 422.
3. I cleaned up the logic and local variable usage of the anonymous function used for `array_walk()` in `Scrubber::scrubArray()`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
