### PR TITLE
Added typing / comments to the `SenderInterface`

### DIFF
--- a/src/Senders/AgentSender.php
+++ b/src/Senders/AgentSender.php
@@ -55,7 +55,7 @@ class AgentSender implements SenderInterface
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function wait(string $accessToken, int $max)
+    public function wait(string $accessToken, int $max): void
     {
         return;
     }
@@ -64,10 +64,5 @@ class AgentSender implements SenderInterface
     {
         $filename = $this->agentLogLocation . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar';
         $this->agentLog = fopen($filename, 'a');
-    }
-    
-    public function toString()
-    {
-        return "agent log: " . $this->agentLogLocation;
     }
 }

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -96,7 +96,7 @@ class CurlSender implements SenderInterface
         $this->checkForCompletedRequests($accessToken);
     }
 
-    public function wait(string $accessToken, int $max = 0)
+    public function wait(string $accessToken, int $max = 0): void
     {
         if (count($this->inflightRequests) <= $max) {
             return;
@@ -186,10 +186,5 @@ class CurlSender implements SenderInterface
             curl_close($handle);
         }
         $this->maybeSendMoreBatchRequests($accessToken);
-    }
-    
-    public function toString()
-    {
-        return "Rollbar API endpoint: " . $this->getEndpoint();
     }
 }

--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -96,7 +96,7 @@ class FluentSender implements SenderInterface
     /**
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
-    public function wait(string $accessToken, int $max)
+    public function wait(string $accessToken, int $max): void
     {
         return;
     }
@@ -107,11 +107,5 @@ class FluentSender implements SenderInterface
     protected function loadFluentLogger()
     {
         $this->fluentLogger = new FluentLogger($this->fluentHost, $this->fluentPort);
-    }
-    
-    public function toString()
-    {
-        return "fluentd " . $this->fluentHost . ":" . $this->fluentPort .
-                " tag: " . $this->fluentTag;
     }
 }

--- a/src/Senders/SenderInterface.php
+++ b/src/Senders/SenderInterface.php
@@ -2,13 +2,46 @@
 
 namespace Rollbar\Senders;
 
-use Rollbar\Payload\Payload;
 use Rollbar\Payload\EncodedPayload;
+use Rollbar\Payload\Payload;
+use Rollbar\Response;
 
+/**
+ * The sender interface is used to define how an error report sender should transport payloads to Rollbar Service.
+ *
+ * An optional constructor can be included in the implementing class. If the constructor is present a single argument
+ * with the value of the `senderOptions` config option will be passed to the constructor.
+ */
 interface SenderInterface
 {
-    public function send(EncodedPayload $payload, string $accessToken);
+    /**
+     * Sends the payload to the Rollbar service and returns the response.
+     *
+     * @param EncodedPayload $payload     The payload to deliver to the Rollbar service.
+     * @param string         $accessToken The project access token.
+     *
+     * @return Response
+     */
+    public function send(EncodedPayload $payload, string $accessToken): Response;
+
+    /**
+     * Sends an array of payloads to the Rollbar service.
+     *
+     * @param Payload[] $batch       The array of {@see Payload} instances.
+     * @param string    $accessToken The project access token.
+     *
+     * @return void
+     */
     public function sendBatch(array $batch, string $accessToken): void;
-    public function wait(string $accessToken, int $max);
-    public function toString();
+
+    /**
+     * Method used to keep the batch send process alive until all or $max number of Payloads are sent, which ever comes
+     * first.
+     *
+     * @param string $accessToken The project access token.
+     * @param int    $max         The maximum payloads to send before stopping the batch send process.
+     *
+     * @return void
+     */
+    public function wait(string $accessToken, int $max): void;
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -124,7 +124,7 @@ class ConfigTest extends BaseRollbarTest
                         );
         $senderMock = $this->getMockBuilder(SenderInterface::class)
                         ->getMock();
-        $senderMock->method('send')->willReturn(null);
+        $senderMock->method('send')->willReturn(new Response(200, 'Test'));
 
         $payload = new \Rollbar\Payload\EncodedPayload(array('data'=>array()));
         $payload->encode();


### PR DESCRIPTION
## Description of the change

This PR adds better typing and comments to the `SenderInterface` to make implementation less error prone. I also updated our three sender classes to properly implement the interface.

I removed the `SenderInterface::toString()` method from the interface as well as all the classes that implement it. As best I can tell have not used the `toString()` method since we removed the internal debug logger in `v1.6.3`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
