### PR TITLE
fix: correct version string

### DIFF
--- a/src/Payload/Notifier.php
+++ b/src/Payload/Notifier.php
@@ -8,7 +8,7 @@ use Rollbar\UtilitiesTrait;
 class Notifier implements SerializerInterface
 {
     const NAME = "rollbar-php";
-    const VERSION = "3.1.2";
+    const VERSION = "3.1.5";
 
     use UtilitiesTrait;
 


### PR DESCRIPTION
## Description of the change

Currently, the Rollbar PHP library is identifying itself with an older version string causing a notice to appear in the Rollbar UI.

> rollbar-php version 3.1.4 is now available. This project uses version 3.1.2. [View Release Notes](https://github.com/rollbar/rollbar-php/releases)

This change updates the version number to the latest one plus one to account for SemVer.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)