### PR TITLE
Fixed #469 Added `requireAccessToken()` method to senders

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -291,13 +291,14 @@ class Config
         $this->setLogPayloadLogger($config);
         $this->setVerbose($config);
         $this->setVerboseLogger($config);
+        // The sender must be set before the access token, so we know if it is required.
+        $this->setSender($config);
         $this->setAccessToken($config);
         $this->setDataBuilder($config);
         $this->setTransformer($config);
         $this->setMinimumLevel($config);
         $this->setReportSuppressed($config);
         $this->setFilters($config);
-        $this->setSender($config);
         $this->setScrubber($config);
         $this->setBatched($config);
         $this->setBatchSize($config);
@@ -337,8 +338,14 @@ class Config
         if (isset($_ENV['ROLLBAR_ACCESS_TOKEN']) && !isset($config['access_token'])) {
             $config['access_token'] = $_ENV['ROLLBAR_ACCESS_TOKEN'];
         }
-        $this->utilities()->validateString($config['access_token'], "config['access_token']", 32, false);
-        $this->accessToken = $config['access_token'];
+        
+        $this->utilities()->validateString(
+            $config['access_token'],
+            "config['access_token']",
+            32,
+            !$this->sender->requireAccessToken(),
+        );
+        $this->accessToken = $config['access_token'] ?? '';
     }
 
     private function setEnabled(array $config): void

--- a/src/Senders/AgentSender.php
+++ b/src/Senders/AgentSender.php
@@ -60,9 +60,23 @@ class AgentSender implements SenderInterface
         return;
     }
 
+    /**
+     * Returns true if the access token is required by the sender to send the payload. The agent can be configured to
+     * provide its own access token. But may not have its own, so we are requiring it for now. See
+     * {@link https://github.com/rollbar/rollbar-php/issues/405} for more details.
+     *
+     * @since 4.0.0
+     *
+     * @return bool
+     */
+    public function requireAccessToken(): bool
+    {
+        return true;
+    }
+
     private function loadAgentFile()
     {
-        $filename = $this->agentLogLocation . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar';
+        $filename       = $this->agentLogLocation . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar';
         $this->agentLog = fopen($filename, 'a');
     }
 }

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -110,6 +110,18 @@ class CurlSender implements SenderInterface
         }
     }
 
+    /**
+     * Returns true if the access token is required by the sender to send the payload. The curl sender requires the
+     * access token since it is sending directly to the Rollbar service.
+     *
+     * @return bool
+     * @since 4.0.0
+     */
+    public function requireAccessToken(): bool
+    {
+        return false;
+    }
+
     private function maybeSendMoreBatchRequests(string $accessToken)
     {
         $max = $this->maxBatchRequests - count($this->inflightRequests);

--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -102,6 +102,18 @@ class FluentSender implements SenderInterface
     }
 
     /**
+     * Returns true if the access token is required by the sender to send the payload. The Fluentd service can provide
+     * its own access token.
+     *
+     * @return bool
+     * @since 4.0.0
+     */
+    public function requireAccessToken(): bool
+    {
+        return false;
+    }
+
+    /**
      * Loads the fluent logger
      */
     protected function loadFluentLogger()

--- a/src/Senders/SenderInterface.php
+++ b/src/Senders/SenderInterface.php
@@ -44,4 +44,13 @@ interface SenderInterface
      * @return void
      */
     public function wait(string $accessToken, int $max): void;
+
+    /**
+     * Returns true if the access token is required by the sender to send the payload. In cases where an intermediary
+     * sender is being used like Fluentd.
+     *
+     * @return bool
+     * @since 4.0.0
+     */
+    public function requireAccessToken(): bool;
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -428,9 +428,12 @@ class ConfigTest extends BaseRollbarTest
     public function testSender(): void
     {
         $p = m::mock(EncodedPayload::class);
-        $sender = m::mock(SenderInterface::class)
-            ->shouldReceive("send")
+        $sender = m::mock(SenderInterface::class);
+        $sender->shouldReceive("send")
             ->with($p, $this->getTestAccessToken())
+            ->once()
+            ->mock();
+        $sender->shouldReceive('requireAccessToken')
             ->once()
             ->mock();
         $c = new Config(array(

--- a/tests/FluentTest.php
+++ b/tests/FluentTest.php
@@ -28,7 +28,7 @@ class FluentTest extends BaseRollbarTest
             'fluent_port' => $port,
             'handler' => 'fluent'
         ));
-        $this->assertEquals(200, $logger->log(Level::INFO, 'this is a test', array())->getStatus());
+        $this->assertEquals(200, $logger->report(Level::INFO, 'this is a test', array())->getStatus());
 
         socket_close($socket);
     }


### PR DESCRIPTION
## Description of the change

We have three different built in payload senders that take a payload and send it to the Rollbar service. Some require that the payload include the access token. The `Rollbar\Senders\CurlSender` class is one of these. Our other two built in senders can use an external access token. The `Rollbar\Senders\FluentSender` is does not need the access token. And it was causing issues (see #469). 

This proposed change moves the requirement for knowing if the access token is required from the `Rollbar/Config` class to the configured sender. All senders must implement `Rollbar\Senders\SenderInterface`. So, I added a new `requireAccessToken()` method to the `SenderInterface`. The method returns a `boolean` indicating if the sender requires the access token. This method is called during the initialization process. If the access token is required and not valid an error is thrown.

The reason this is a breaking change is because it requires the `requireAccessToken()` method be added to all custom sender interfaces.

An argument could be made that the `Rollbar\Senders\AgentSender` does not require the access token. For now, I am going to stick with the conclusion from #405, and leave it the way it is.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #469

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
