### PR TITLE
Added deprecation notices to things that will be removed in v4.0.0.

### DIFF
--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -21,16 +21,16 @@ class Level implements SerializerInterface
     const DEBUG = 'debug';
     
     /**
-     * @deprecated 1.2.0
+     * @deprecated 1.2.0 and will be removed in 4.0.0.
      */
     const IGNORED = 'ignored';
     /**
-     * @deprecated 1.2.0
+     * @deprecated 1.2.0 and will be removed in 4.0.0.
      */
     const IGNORE = 'ignore';
 
     /**
-     * @deprecated 1.2.0
+     * @deprecated 1.2.0 and will be removed in 4.0.0.
      *
      * Usage of Level::error(), Level::warning(), Level::info(), Level::notice(),
      * Level::debug() is no longer supported. It has been replaced with matching

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -242,7 +242,8 @@ class Rollbar
      *
      * @return string uuid
      *
-     * @deprecated 1.0.0 This method has been replaced by ::log
+     * @deprecated 1.0.0 This method has been replaced by {@see Rollbar::log}.
+     *             This method will be removed in 4.0.0.
      */
     public static function report_exception($exc, $extra_data = null, $payload_data = null)
     {
@@ -260,7 +261,8 @@ class Rollbar
      *
      * @return string uuid
      *
-     * @deprecated 1.0.0 This method has been replaced by ::log
+     * @deprecated 1.0.0 This method has been replaced by {@see Rollbar::log}.
+     *             This method will be removed in 4.0.0.
      */
     public static function report_message($message, $level = null, $extra_data = null, $payload_data = null)
     {
@@ -273,7 +275,9 @@ class Rollbar
     /**
      * Catch any fatal errors that are causing the shutdown
      *
-     * @deprecated 1.0.0 This method has been replaced by ::fatalHandler
+     * @deprecated 1.0.0 This method has been replaced by
+     *             {@see Rollbar::fatalHandler} This method will be removed in
+     *             4.0.0.
      */
     public static function report_fatal_error()
     {
@@ -284,7 +288,8 @@ class Rollbar
     /**
      * This function must return false so that the default php error handler runs
      *
-     * @deprecated 1.0.0 This method has been replaced by ::log
+     * @deprecated 1.0.0 This method has been replaced by {@see Rollbar::log}.
+     *             This method will be removed in 4.0.0.
      */
     public static function report_php_error($errno, $errstr, $errfile, $errline)
     {

--- a/src/Senders/AgentSender.php
+++ b/src/Senders/AgentSender.php
@@ -65,7 +65,10 @@ class AgentSender implements SenderInterface
         $filename = $this->agentLogLocation . '/rollbar-relay.' . getmypid() . '.' . microtime(true) . '.rollbar';
         $this->agentLog = fopen($filename, 'a');
     }
-    
+
+    /**
+     * @deprecated 3.2.0 and will be removed in 4.0.0.
+     */
     public function toString()
     {
         return "agent log: " . $this->agentLogLocation;

--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -187,7 +187,10 @@ class CurlSender implements SenderInterface
         }
         $this->maybeSendMoreBatchRequests($accessToken);
     }
-    
+
+    /**
+     * @deprecated 3.2.0 and will be removed in 4.0.0.
+     */
     public function toString()
     {
         return "Rollbar API endpoint: " . $this->getEndpoint();

--- a/src/Senders/FluentSender.php
+++ b/src/Senders/FluentSender.php
@@ -108,7 +108,10 @@ class FluentSender implements SenderInterface
     {
         $this->fluentLogger = new FluentLogger($this->fluentHost, $this->fluentPort);
     }
-    
+
+    /**
+     * @deprecated 3.2.0 and will be removed in 4.0.0.
+     */
     public function toString()
     {
         return "fluentd " . $this->fluentHost . ":" . $this->fluentPort .

--- a/src/Senders/SenderInterface.php
+++ b/src/Senders/SenderInterface.php
@@ -10,5 +10,9 @@ interface SenderInterface
     public function send(EncodedPayload $payload, string $accessToken);
     public function sendBatch(array $batch, string $accessToken): void;
     public function wait(string $accessToken, int $max);
+
+    /**
+     * @deprecated 3.2.0 and will be removed in 4.0.0.
+     */
     public function toString();
 }

--- a/src/Truncation/IStrategy.php
+++ b/src/Truncation/IStrategy.php
@@ -4,6 +4,11 @@ namespace Rollbar\Truncation;
 
 use \Rollbar\Payload\EncodedPayload;
 
+/**
+ * @deprecated 3.2.0 and will be renamed in 4.0.0 to Rollbar\Truncation\StrategyInterface. All internal truncation
+ *             strategy classes that implement this interface (including {@see AbstractStrategy}) will use the new one
+ *             in 4.0.0.
+ */
 interface IStrategy
 {
     /**


### PR DESCRIPTION
## Description of the change

Making upgrading our existing v3 users to v4 as easy as possible is important. Because of that this commit is adding deprecation notices to anything that was removed in v4. It also updates any of the existing deprecation notices to identify that v4 is when the deprecated item will be removed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
