### PR TITLE
Added support for monolog/monolog v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "php": ">=8.0.0 <9.0",
     "ext-curl": "*",
     "psr/log": "^1 || ^2 || ^3",
-    "monolog/monolog": "^2"
+    "monolog/monolog": "^2 || ^3"
   },
 
   "require-dev": {
@@ -42,7 +42,7 @@
     "mockery/mockery": "^1",
     "squizlabs/php_codesniffer": "^3.6 || 3.x-dev",
     "phpmd/phpmd" : "^2",
-    "vimeo/psalm": "^4.13"
+    "vimeo/psalm": "^5"
   },
 
   "suggest": {

--- a/src/Payload/Level.php
+++ b/src/Payload/Level.php
@@ -37,7 +37,7 @@ class Level implements SerializerInterface
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->level;
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -42,7 +42,7 @@ class Response
         return "https://rollbar.com/occurrence/uuid/?uuid=" . urlencode($this->uuid);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $url = $this->getOccurrenceUrl();
         return "Status: $this->status\n" .

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -1,6 +1,7 @@
 <?php namespace Rollbar;
 
 use Exception;
+use Monolog\Handler\NoopHandler;
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
 use Rollbar\TestHelpers\ArrayLogger;
@@ -190,21 +191,7 @@ class RollbarLoggerTest extends BaseRollbarTest
             "verbose" => \Rollbar\Config::VERBOSE_NONE
         ));
 
-        $verboseLogger = $logger->verboseLogger();
-        $originalHandler = $verboseLogger->getHandlers();
-        $originalHandler = $originalHandler[0];
-
-        $handlerMock = $this->getMockBuilder(ErrorLogHandler::class)
-            ->setMethods(array('handle'))
-            ->getMock();
-
-        $handlerMock->setLevel($originalHandler->getLevel());
-        
-        $handlerMock->expects($this->never())->method('handle');
-
-        $verboseLogger->setHandlers(array($handlerMock));
-
-        $logger->info('Internal message');
+        $this->assertInstanceOf(NoopHandler::class, $logger->verboseLogger()->getHandlers()[0]);
     }
 
     public function testVerbose(): void

--- a/tests/TestHelpers/ArrayLogger.php
+++ b/tests/TestHelpers/ArrayLogger.php
@@ -54,4 +54,66 @@ class ArrayLogger extends AbstractLogger
         }
         return $count;
     }
+
+    /**
+     * Returns the index of the first instance of a matching log in the logs. Returns -1 if no matching log is found.
+     *
+     * @param string            $level   The log level of the message to search for.
+     * @param Stringable|string $message The message body to search for.
+     *
+     * @return int
+     */
+    public function indexOf(string $level, Stringable|string $message): int
+    {
+        $str = self::stringify($level, $message);
+        foreach ($this->logs as $index => $log) {
+            if ($str === $log) {
+                return $index;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the index of the first instance of a matching level and message pattern in the logs. Returns -1 if no
+     * matching log is found.
+     *
+     * @param string $level   The log level of the message to search for. You can pass '.+' to match any level.
+     * @param string $pattern The regex pattern to search for.
+     *
+     * @return int
+     */
+    public function indexOfRegex(string $level, string $pattern): int
+    {
+        $pattern = '/\[' . $level . '\].*' . $pattern . '/';
+        foreach ($this->logs as $index => $log) {
+            if (preg_match($pattern, $log)) {
+                return $index;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Checks the log at the given index to see if it matches the given level and message pattern. Returns true if it
+     * matches, false otherwise.
+     *
+     * @param int    $index   The index of the log to check.
+     * @param string $level   The log level of the message to search for. You can pass '.+' to match any level.
+     * @param string $pattern The regex pattern to search for.
+     *
+     * @return bool
+     */
+    public function indexMatchesRegex(int $index, string $level, string $pattern): bool
+    {
+        if ($index < 0 || $index >= count($this->logs)) {
+            return false;
+        }
+        $log     = $this->logs[$index];
+        $pattern = '/\[' . $level . '\].*' . $pattern . '/';
+        if (preg_match($pattern, $log)) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -2,13 +2,11 @@
 
 namespace Rollbar;
 
+use Psr\Log\LogLevel;
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Payload;
-use Rollbar\Response;
-use Monolog\Handler\AbstractHandler;
-use Rollbar\ResponseHandlerInterface;
-use Rollbar\FilterInterface;
 use Rollbar\Payload\Data;
+use Rollbar\TestHelpers\ArrayLogger;
 
 /**
  * \Rollbar\VerboseTest tests the verbosity of the SDK.
@@ -26,6 +24,7 @@ use Rollbar\Payload\Data;
  */
 class VerbosityTest extends BaseRollbarTest
 {
+    private ArrayLogger|null $verboseLogger = null;
 
     /**
      * Prepare session
@@ -34,214 +33,154 @@ class VerbosityTest extends BaseRollbarTest
      */
     public function setUp(): void
     {
-        $_SESSION = array();
+        $_SESSION            = array();
+        $this->verboseLogger = new ArrayLogger();
         parent::setUp();
     }
-    
+
     /**
-     * Clean up Rollbar and the verbose logger handler mock for
-     * the next test
+     * Clean up Rollbar and the verbose logger handler mock for the next test
      *
      * @return void
      */
     public function tearDown(): void
     {
-        $this->verboseHandlerMock = null;
+        $this->verboseLogger = null;
         Rollbar::destroy();
         parent::tearDown();
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log with
-     * `enabled` == true.
+     * Test verbosity of \Rollbar\RollbarLogger::log with `enabled` == true.
      *
      * @return void
      */
     public function testRollbarLoggerEnabled(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "enabled" => true
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectConsecutiveLog([
-                    0,
-                    '/Attempting to log: \[warning\] Testing PHP Notifier/',
-                    \Psr\Log\LogLevel::INFO
-                ], [
-                    1,
-                    '/Occurrence/',
-                    \Psr\Log\LogLevel::INFO
-                ]);
-            }
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            "enabled"        => true,
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+
+        Rollbar::log(Level::WARNING, "Testing PHP Notifier");
+
+        $this->assertVerboseLogsConsecutive(
+            ['level' => LogLevel::INFO, 'messageRegEx' => 'Attempting to log: \[warning\] Testing PHP Notifier'],
+            ['level' => LogLevel::INFO, 'messageRegEx' => 'Occurrence'],
         );
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log with
-     * `enabled` == false.
+     * Test verbosity of \Rollbar\RollbarLogger::log with `enabled` == false.
      *
      * @return void
      */
     public function testRollbarLoggerDisabled(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "enabled" => false
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(0, '/Rollbar is disabled/', \Psr\Log\LogLevel::NOTICE);
-            }
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            "enabled"        => false,
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+
+        Rollbar::log(Level::WARNING, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Rollbar is disabled', LogLevel::NOTICE);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log with
-     * an invalid log level passed in the method call.
+     * Test verbosity of \Rollbar\RollbarLogger::log with an invalid log level passed in the method call.
      *
      * @return void
      */
     public function testRollbarLoggerInvalidLogLevel(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php"
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(0, '/Invalid log level \'nolevel\'\./', \Psr\Log\LogLevel::ERROR);
-            },
-            'nolevel', // rollbar message level
-            function () use ($unitTest) {
-                // We expect the logging library to throw this exception when
-                // given the bogus level, so we have to tell the test to expect
-                // it. We do so here in the "pre" test block because the
-                // "verbose expectations" block only applies to the scenario for
-                // verbose logging -- it would not catch the exception from
-                // the quiet scenario.
-                $unitTest->expectException(\Psr\Log\InvalidArgumentException::class);
-            }
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+
+        $this->expectException(\Psr\Log\InvalidArgumentException::class);
+        Rollbar::log('nolevel', "Testing PHP Notifier");
+
+        $this->assertVerboseLogContains('Invalid log level \'nolevel\'\.', LogLevel::ERROR);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log when an
-     * occurrence gets ignored for whatever reason.
+     * Test verbosity of \Rollbar\RollbarLogger::log when an occurrence gets ignored for whatever reason.
      *
      * @return void
      */
     public function testRollbarLoggerInternalCheckIgnored(): void
     {
-        $unitTest = $this;
         $errorReporting = \error_reporting();
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php"
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(2, '/Occurrence ignored/', \Psr\Log\LogLevel::INFO);
-            },
-            \Psr\Log\LogLevel::INFO, // rollbar message level
-            function () {
-            // test setup
-                \error_reporting(0);
-            },
-            function () use ($errorReporting) {
-            // test teardown
-                \error_reporting($errorReporting);
-            }
-        );
+        \error_reporting(0);
+
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Occurrence ignored', LogLevel::INFO);
+
+        \error_reporting($errorReporting);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log when an
-     * occurrence gets ignored due to check ignore
+     * Test verbosity of \Rollbar\RollbarLogger::log when an occurrence gets ignored due to check ignore
      *
      * @return void
      */
     public function testRollbarLoggerCheckIgnored(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "check_ignore" => function () {
-                    return true;
-                }
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(2, '/Occurrence ignored/', \Psr\Log\LogLevel::INFO);
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'check_ignore'   => function () {
+                return true;
             },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        ]);
+        Rollbar::log(LogLevel::WARNING, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Occurrence ignored', LogLevel::INFO);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log when
-     * `max_items` is reached.
+     * Test verbosity of \Rollbar\RollbarLogger::log when `max_items` is reached.
      *
      * @return void
      */
     public function testRollbarLoggerSendMaxItems(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "max_items" => 0
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    1,
-                    '/Maximum number of items per request has been reached.*/',
-                    \Psr\Log\LogLevel::WARNING
-                );
-            },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'max_items'      => 0,
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Maximum number of items per request has been reached.', LogLevel::WARNING);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log for adding
-     * occurrences to the queue when `batched` == true.
+     * Test verbosity of \Rollbar\RollbarLogger::log for adding occurrences to the queue when `batched` == true.
      *
      * @return void
      */
     public function testRollbarLoggerSendBatched(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "batched" => true
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    1,
-                    '/Added payload to the queue \(running in `batched` mode\)\./',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'batched'        => true,
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Added payload to the queue \(running in `batched` mode\)\.', LogLevel::DEBUG);
     }
 
     /**
@@ -251,921 +190,450 @@ class VerbosityTest extends BaseRollbarTest
      */
     public function testRollbarLoggerFlush(): void
     {
-        $unitTest = $this;
-        $rollbarLogger = $this->verboseRollbarLogger(array(
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php"
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $rollbarLogger,
-            function () use ($rollbarLogger) {
-            // logic under test
-                $rollbarLogger->flush();
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Queue flushed/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+        Rollbar::log(LogLevel::WARNING, "Testing PHP Notifier");
+        Rollbar::flush();
+        $this->assertVerboseLogContains('Queue flushed', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log for reports
-     * rejected by the SDK (response status == 0).
+     * Test verbosity of \Rollbar\RollbarLogger::log for reports rejected by the SDK (response status == 0).
      *
      * @return void
      */
     public function testRollbarLoggerResponseStatusZero(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "check_ignore" => function () {
-                    return true;
-                }
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    3,
-                    '/Occurrence rejected by the SDK: .*/',
-                    \Psr\Log\LogLevel::ERROR
-                );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'check_ignore'   => function () {
+                return true;
             },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Occurrence rejected by the SDK:', LogLevel::ERROR);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log for reports
-     * rejected by the API (response status >= 400).
+     * Test verbosity of \Rollbar\RollbarLogger::log for reports rejected by the API (response status >= 400).
      *
      * @return void
      */
     public function testRollbarLoggerResponseStatusError(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php",
-                "endpoint" => "https://api.rollbar.com/api/foo/"
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    1,
-                    '/Occurrence rejected by the API: .*/',
-                    \Psr\Log\LogLevel::ERROR
-                );
-            },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'endpoint'       => 'https://api.rollbar.com/api/foo/',
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Occurrence rejected by the API:', LogLevel::ERROR);
     }
 
     /**
-     * Test verbosity of \Rollbar\RollbarLogger::log for reports
-     * successfully processed.
+     * Test verbosity of \Rollbar\RollbarLogger::log for reports successfully processed.
      *
      * @return void
      */
     public function testRollbarLoggerResponseStatusSuccess(): void
     {
-        $unitTest = $this;
-        $this->rollbarLogTest(
-            array( // config
-                "access_token" => $this->getTestAccessToken(),
-                "environment" => "testing-php"
-            ),
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    1,
-                    '/Occurrence successfully logged/',
-                    \Psr\Log\LogLevel::INFO
-                );
-            },
-            \Psr\Log\LogLevel::INFO // rollbar message level
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+        Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Occurrence successfully logged', LogLevel::INFO);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::internalCheckIgnored
-     * when error_reporting === 0.
+     * Test verbosity of \Rollbar\Config::internalCheckIgnored when error_reporting === 0.
      *
      * @return void
      */
     public function testRollbarConfigInternalCheckIgnoredShouldSuppress(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php"
-        ));
         $errorReporting = \error_reporting();
+        \error_reporting(0);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->internalCheckIgnored(\Psr\Log\LogLevel::WARNING, "Some message");
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Ignoring \(error reporting has been disabled in PHP config\)/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            },
-            function () {
-            // test setup
-                \error_reporting(0);
-            },
-            function () use ($errorReporting) {
-            // test cleanup
-
-                \error_reporting($errorReporting);
-            }
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+        Rollbar::logger()->getConfig()->internalCheckIgnored(LogLevel::WARNING, "Some message");
+        $this->assertVerboseLogContains(
+            'Ignoring \(error reporting has been disabled in PHP config\)',
+            LogLevel::DEBUG,
         );
+
+        \error_reporting($errorReporting);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::internalCheckIgnored when an
-     * occurrence gets ignored due to occurrence level being
-     * too low (`minimum_level` < log_level).
+     * Test verbosity of \Rollbar\Config::internalCheckIgnored when an occurrence gets ignored due to occurrence level
+     * being too low (`minimum_level` < log_level).
      *
      * @return void
      */
     public function testRollbarConfigInternalCheckIgnoredLevelTooLow(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "minimum_level" => \Psr\Log\LogLevel::ERROR
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->internalCheckIgnored(\Psr\Log\LogLevel::WARNING, "Some message");
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Occurrence\'s level is too low/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'minimum_level'  => LogLevel::ERROR,
+        ]);
+        Rollbar::logger()->getConfig()->internalCheckIgnored(LogLevel::WARNING, "Some message");
+        $this->assertVerboseLogContains('Occurrence\'s level is too low', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::shouldIgnoreError when
-     * `use_error_reporting` == true and the error level is
+     * Test verbosity of \Rollbar\Config::shouldIgnoreError when `use_error_reporting` == true and the error level is
      * below allowed error_reporting() level.
      *
      * @return void
      */
     public function testRollbarConfigShouldIgnoreErrorErrorReporting(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "use_error_reporting" => true
-        ));
         $errorReporting = \error_reporting();
+        \error_reporting(\E_ERROR);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->shouldIgnoreError(\E_WARNING);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Ignore \(error below allowed error_reporting level\)/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            },
-            function () {
-            // test setup
-                \error_reporting(\E_ERROR);
-            },
-            function () use ($errorReporting) {
-            // test tear down
-                \error_reporting($errorReporting);
-            }
-        );
+        Rollbar::init([
+            'access_token'        => $this->getTestAccessToken(),
+            'environment'         => 'testing-php',
+            'verbose_logger'      => $this->verboseLogger,
+            'use_error_reporting' => true,
+        ]);
+        Rollbar::logger()->getConfig()->shouldIgnoreError(\E_WARNING);
+        $this->assertVerboseLogContains('Ignore \(error below allowed error_reporting level\)', LogLevel::DEBUG);
+
+        \error_reporting($errorReporting);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::shouldIgnoreError when
-     * `included_errno` is set.
+     * Test verbosity of \Rollbar\Config::shouldIgnoreError when `included_errno` is set.
      *
      * @return void
      */
     public function testRollbarConfigShouldIgnoreErrorIncludedErrno(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "included_errno" => \E_WARNING
-        ));
         $errorReporting = \error_reporting();
+        \error_reporting(0);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->shouldIgnoreError(\E_ERROR);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Ignore due to included_errno level/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            },
-            function () {
-            // test setup
-                \error_reporting(0);
-            },
-            function () use ($errorReporting) {
-            // test tear down
-                \error_reporting($errorReporting);
-            }
-        );
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'included_errno' => \E_WARNING,
+        ]);
+        Rollbar::logger()->getConfig()->shouldIgnoreError(\E_ERROR);
+        $this->assertVerboseLogContains('Ignore due to included_errno level', LogLevel::DEBUG);
+
+        \error_reporting($errorReporting);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::shouldIgnoreError when
-     * the error is skipped due to error sample rates.
+     * Test verbosity of \Rollbar\Config::shouldIgnoreError when the error is skipped due to error sample rates.
      *
      * @return void
      */
     public function testRollbarConfigShouldIgnoreErrorErrorSampleRates(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "error_sample_rates" => array(
-                \E_WARNING => 0
-            )
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->shouldIgnoreError(\E_WARNING);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Skip due to error sample rating/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        Rollbar::init([
+            'access_token'       => $this->getTestAccessToken(),
+            'environment'        => 'testing-php',
+            'verbose_logger'     => $this->verboseLogger,
+            'error_sample_rates' => array(
+                \E_WARNING => 0,
+            ),
+        ]);
+        Rollbar::logger()->getConfig()->shouldIgnoreError(\E_WARNING);
+        $this->assertVerboseLogContains('Skip due to error sample rating', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::shouldIgnoreException when
-     * the exception is skipped due to exception sample rates.
+     * Test verbosity of \Rollbar\Config::shouldIgnoreException when the exception is skipped due to exception sample
+     * rates.
      *
      * @return void
      */
     public function testRollbarConfigShouldIgnoreException(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "exception_sample_rates" => array(
-                'Exception' => 0
-            )
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $config->shouldIgnoreException(new \Exception());
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Skip exception due to exception sample rating/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        Rollbar::init([
+            'access_token'           => $this->getTestAccessToken(),
+            'environment'            => 'testing-php',
+            'verbose_logger'         => $this->verboseLogger,
+            'exception_sample_rates' => array(
+                'Exception' => 0,
+            ),
+        ]);
+        Rollbar::logger()->getConfig()->shouldIgnoreException(new \Exception());
+        $this->assertVerboseLogContains('Skip exception due to exception sample rating', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::checkIgnored due to custom
-     * `check_ignore` logic.
+     * Test verbosity of \Rollbar\Config::checkIgnored due to custom `check_ignore` logic.
      *
      * @return void
      */
     public function testRollbarConfigCheckIgnored(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "check_ignore" => function () {
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'check_ignore'   => function () {
                 return true;
-            }
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $dataMock = $unitTest->getMockBuilder(Data::class)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-                $dataMock->method('getLevel')->willReturn(\Rollbar\LevelFactory::fromName(Level::INFO));
-                $payloadMock = $unitTest->getMockBuilder(Payload::class)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-                $payloadMock->method('getData')->willReturn($dataMock);
-                $config->checkIgnored(
-                    $payloadMock,
-                    $payloadMock,
-                    false
-                );
             },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Occurrence ignored due to custom check_ignore logic/',
-                    \Psr\Log\LogLevel::INFO
-                );
-            }
-        );
+        ]);
+
+        $dataMock = $this->getMockBuilder(Data::class)->disableOriginalConstructor()->getMock();
+        $dataMock->method('getLevel')->willReturn(\Rollbar\LevelFactory::fromName(Level::INFO));
+
+        $payloadMock = $this->getMockBuilder(Payload::class)->disableOriginalConstructor()->getMock();
+        $payloadMock->method('getData')->willReturn($dataMock);
+
+        Rollbar::logger()->getConfig()->checkIgnored($payloadMock, $payloadMock, false);
+        $this->assertVerboseLogContains('Occurrence ignored due to custom check_ignore logic', LogLevel::INFO);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::checkIgnored due an exception
-     * in the custom check_ginore logic.
+     * Test verbosity of \Rollbar\Config::checkIgnored due an exception in the custom check_ginore logic.
      *
      * @return void
      */
     public function testRollbarConfigCheckIgnoredException(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "check_ignore" => function () {
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'check_ignore'   => function () {
                 throw new \Exception();
-            }
-        ));
-
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
-                $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, 'some message', false);
             },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Exception occurred in the custom checkIgnore logic:.*/',
-                    \Psr\Log\LogLevel::ERROR
-                );
-            }
-        );
+        ]);
+
+        Rollbar::log(LogLevel::WARNING, "Testing PHP Notifier");
+        $this->assertVerboseLogContains('Exception occurred in the custom checkIgnore logic:', LogLevel::ERROR);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::checkIgnored due the message
-     * being below `minimum_level`.
+     * Test verbosity of \Rollbar\Config::checkIgnored due the message being below `minimum_level`.
      *
      * @return void
      */
     public function testRollbarConfigCheckIgnoredPayloadLevelTooLow(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "minimum_level" => \Rollbar\Payload\Level::ERROR
-        ));
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'minimum_level'  => \Rollbar\Payload\Level::ERROR,
+        ]);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
-                $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, 'some message', false);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Occurrence\'s level is too low/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        $config  = Rollbar::logger()->getConfig();
+        $data    = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
+        $payload = new \Rollbar\Payload\Payload($data, $this->getTestAccessToken());
+        $config->checkIgnored($payload, 'some message', false);
+
+        $this->assertVerboseLogContains('Occurrence\'s level is too low', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::checkIgnored due the
-     * custom `filter`.
+     * Test verbosity of \Rollbar\Config::checkIgnored due the custom `filter`.
      *
      * @return void
      */
     public function testRollbarConfigCheckIgnoredFilter(): void
     {
-        $unitTest = $this;
         $filterMock = $this->getMockBuilder(FilterInterface::class)->getMock();
         $filterMock->method('shouldSend')->willReturn(true);
 
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "filter" => $filterMock
-        ));
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'filter'         => $filterMock,
+        ]);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $data = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
-                $payload = new \Rollbar\Payload\Payload($data, $unitTest->getTestAccessToken());
-                $config->checkIgnored($payload, 'some message', false);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Custom filter result: true/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        $config  = Rollbar::logger()->getConfig();
+        $data    = $config->getRollbarData(\Rollbar\Payload\Level::INFO, 'some message', array());
+        $payload = new \Rollbar\Payload\Payload($data, $this->getTestAccessToken());
+        $config->checkIgnored($payload, 'some message', false);
+
+        $unitTest   = $this;
+        $filterMock = $this->getMockBuilder(FilterInterface::class)->getMock();
+        $filterMock->method('shouldSend')->willReturn(true);
+
+        $this->assertVerboseLogContains('Custom filter result: true', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::send due the
-     * custom `transmit` == false.
+     * Test verbosity of \Rollbar\Config::send due the custom `transmit` == false.
      *
      * @return void
      */
     public function testRollbarConfigSendTransmit(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "transmit" => false
-        ));
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'transmit'       => false,
+        ]);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $encoded = new \Rollbar\Payload\EncodedPayload(array());
-                $config->send($encoded, $unitTest->getTestAccessToken());
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Not transmitting \(transmitting disabled in configuration\)/',
-                    \Psr\Log\LogLevel::WARNING
-                );
-            }
+        $config  = Rollbar::logger()->getConfig();
+        $encoded = new \Rollbar\Payload\EncodedPayload(array());
+        $config->send($encoded, $this->getTestAccessToken());
+
+        $this->assertVerboseLogContains(
+            'Not transmitting \(transmitting disabled in configuration\)',
+            LogLevel::WARNING,
         );
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::sendBatch due the
-     * custom `transmit` == false.
+     * Test verbosity of \Rollbar\Config::sendBatch due the custom `transmit` == false.
      *
      * @return void
      */
     public function testRollbarConfigSendBatchTransmit(): void
     {
-        $unitTest = $this;
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "transmit" => false,
-            "batched" => true
-        ));
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+            'transmit'       => false,
+            'batched'        => true,
+        ]);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config) {
-            // logic under test
-                $batch = array();
-                $config->sendBatch($batch, 'access-token');
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Not transmitting \(transmitting disabled in configuration\)/',
-                    \Psr\Log\LogLevel::WARNING
-                );
-            }
+        $config = Rollbar::logger()->getConfig();
+        $config->sendBatch(array(), $this->getTestAccessToken());
+
+        $this->assertVerboseLogContains(
+            'Not transmitting \(transmitting disabled in configuration\)',
+            LogLevel::WARNING,
         );
     }
 
     /**
-     * Test verbosity of \Rollbar\Config::handleResponse with
-     * custom `responseHandler`.
+     * Test verbosity of \Rollbar\Config::handleResponse with custom `responseHandler`.
      *
      * @return void
      */
     public function testRollbarConfigHandleResponse(): void
     {
-        $unitTest = $this;
         $responseHandlerMock = $this->getMockBuilder(ResponseHandlerInterface::class)->getMock();
-        $config = $this->verboseRollbarConfig(array( // config
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php",
-            "responseHandler" => $responseHandlerMock
-        ));
+        Rollbar::init([
+            'access_token'    => $this->getTestAccessToken(),
+            'environment'     => 'testing-php',
+            'verbose_logger'  => $this->verboseLogger,
+            'responseHandler' => $responseHandlerMock,
+        ]);
 
-        $this->configurableObjectVerbosityTest(
-            $config,
-            function () use ($config, $unitTest) {
-            // logic under test
-                $payloadMock = $unitTest->getMockBuilder(Payload::class)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-                $responseMock = $unitTest->getMockBuilder(Response::class)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-                $config->handleResponse($payloadMock, $responseMock);
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    0,
-                    '/Applying custom response handler: .*/',
-                    \Psr\Log\LogLevel::DEBUG
-                );
-            }
-        );
+        $config       = Rollbar::logger()->getConfig();
+        $payloadMock  = $this->getMockBuilder(Payload::class)->disableOriginalConstructor()->getMock();
+        $responseMock = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();
+        $config->handleResponse($payloadMock, $responseMock);
+
+        $this->assertVerboseLogContains('Applying custom response handler:', LogLevel::DEBUG);
     }
 
     /**
-     * Test verbosity of \Rollbar\Truncation\Truncation::registerStrategy
-     * in truncate method.
+     * Test verbosity of \Rollbar\Truncation\Truncation::registerStrategy in truncate method.
      *
      * @return void
      */
     public function testRollbarTruncation(): void
     {
-        $unitTest = $this;
-        $rollbarLogger = $this->verboseRollbarLogger(array(
-            "access_token" => $this->getTestAccessToken(),
-            "environment" => "testing-php"
-        ));
+        Rollbar::init([
+            'access_token'   => $this->getTestAccessToken(),
+            'environment'    => 'testing-php',
+            'verbose_logger' => $this->verboseLogger,
+        ]);
+        Rollbar::logger()->log(
+            \Rollbar\Payload\Level::INFO,
+            \str_repeat("x", \Rollbar\Truncation\Truncation::MAX_PAYLOAD_SIZE),
+        );
 
-        $this->configurableObjectVerbosityTest(
-            $rollbarLogger,
-            function () use ($rollbarLogger) {
-            // logic under test
-                $rollbarLogger->log(
-                    \Rollbar\Payload\Level::INFO,
-                    \str_repeat("x", \Rollbar\Truncation\Truncation::MAX_PAYLOAD_SIZE),
-                    array()
-                );
-            },
-            function () use ($unitTest) {
-            // verbosity expectations
-                $unitTest->expectLog(
-                    1,
-                    '/Applying truncation strategy .*/',
-                    \Psr\Log\LogLevel::DEBUG
+        $this->assertVerboseLogContains('Applying truncation strategy', LogLevel::DEBUG);
+    }
+
+    /**
+     * Asserts that the {@see $this->verboseLogger} contains the given message at the given level.
+     *
+     * @param string $messageRegEx The message regular expression to match.
+     * @param string $level        The level to match.
+     *
+     * @return void
+     */
+    private function assertVerboseLogContains(string $messageRegEx, string $level): void
+    {
+        self::assertGreaterThanOrEqual(
+            0,
+            $this->verboseLogger->indexOfRegex($level, $messageRegEx),
+            'Verbose log does not contain expected message: "' . $messageRegEx . '" at level "' . $level . '"',
+        );
+    }
+
+    /**
+     * Asserts that the {@see $this->verboseLogger} contains the given logs in the given order, and that they are
+     * consecutive.
+     *
+     * This function loops over all the logs until it finds a match for the first constraint. Then it checks the next
+     * log messages to see if they match the next constraint, and so on, until it reaches the end of the constraints or
+     * the end of the logs.
+     *
+     * If every constraint is matched in order, the test passes.
+     *
+     * @param array{level: string, messageRegEx: string} ...$constraints The constraints to match. The array must
+     *                                                                   contain two keys: `level` and `messageRegEx`.
+     *                                                                   The `level` key must contain the log level to
+     *                                                                   match, and the `messageRegEx` key must contain
+     *                                                                   the regular expression to match the log
+     *                                                                   message.
+     *
+     * @return void
+     */
+    private function assertVerboseLogsConsecutive(array ...$constraints): void
+    {
+        $matchCount      = 0;
+        $constraintIndex = 0;
+        $consecutive     = false;
+        for ($i = 0; $i < count($this->verboseLogger->logs); $i++) {
+            // If this is past the last constraint, we're done.
+            if ($constraintIndex >= count($constraints)) {
+                break;
+            }
+            $message = $constraints[$constraintIndex]['messageRegEx'];
+            $level   = $constraints[$constraintIndex]['level'];
+            $matches    = $this->verboseLogger->indexMatchesRegex($i, $level, $message);
+            if ($consecutive && !$matches) {
+                // If we are expecting consecutive matches, and the current log message does not match the current
+                // constraint, then we can fail early.
+                $this->fail(
+                    'Expected log message at index "' . $i . '" to match "' . $message . '" at level "' . $level . '"'
                 );
             }
-        );
-    }
-
-    /**
-     * @var mock $verboseHandlerMock The verboser log handler used for
-     * verbose logging in tests.
-     */
-    private $verboseHandlerMock;
-
-    /**
-     * Test helper for creating \Rollbar\RollbarLogger or
-     * \Rollbar\Config objects. It also sets up
-     * the $this->verboseHandlerMock to the one used in
-     * the created object.
-     *
-     * @param array $config Config array used to configure
-     * the $object.
-     * @param \Rollbar\Config|\Rollbar\RollbarLogger $object
-     * Object to be set up for the test.
-     */
-    private function prepareForLogMocking(array $config, Config|RollbarLogger $object): Config|RollbarLogger
-    {
-        $verboseLogger = new \Monolog\Logger('rollbar.verbose.test');
-
-        $object->configure(array_merge($config, array(
-            'verbose_logger' => $verboseLogger
-        )));
-
-        $verbose = $config['verbose'] ?? \Rollbar\Config::VERBOSE_NONE;
-
-        if ($verbose == \Rollbar\Config::VERBOSE_NONE) {
-            $verbose = \Rollbar\Config::VERBOSE_NONE_INT;
-        } else {
-            $verbose = \Monolog\Logger::toMonologLevel($verbose);
-        }
-
-        $handlerMock = $this->getMockBuilder(AbstractHandler::class)
-            ->setMethods(array('handle'))
-            ->getMock();
-        $handlerMock->setLevel($verbose);
-
-        $verboseLogger->setHandlers(array($handlerMock));
-
-        $this->verboseHandlerMock = $handlerMock;
-
-        return $object;
-    }
-
-    /**
-     * This is a convenience method for creating properly configured
-     * Rollbar config objects for testing verbosity. It also sets up
-     * the $this->verboseHandlerMock to the one used in the created
-     * Rollbar logger.
-     *
-     * @param array $config Configuration options for Rollbar
-     * @return \Rollbar\Config
-     */
-    private function verboseRollbarConfig(array $config): Config|RollbarLogger
-    {
-        return $this->prepareForLogMocking(
-            $config,
-            new \Rollbar\Config($config)
-        );
-    }
-
-    /**
-     * This is a convenience method for creating properly configured
-     * Rollbar logger objects for testing verbosity. It also sets up
-     * the $this->verboseHandlerMock to the one used in the created
-     * Rollbar logger.
-     *
-     * @param array $config Configuration options for Rollbar
-     * @return \Rollbar\RollbarLogger
-     */
-    private function verboseRollbarLogger(array $config): Config|RollbarLogger
-    {
-        return $this->prepareForLogMocking(
-            $config,
-            new \Rollbar\RollbarLogger($config)
-        );
-    }
-
-    /**
-     * Convenience method for asserting verbose logging calls on the
-     * handler mock.
-     *
-     * @param string $messageRegEx Regular expression against which the
-     * log message will be asserted.
-     * @param string $level The level of the log recorded which will
-     * be asserted.
-     */
-    private function withLogParams(string $messageRegEx, string $level): \PHPUnit\Framework\Constraint\Callback
-    {
-        return $this->callback(function ($record) use ($messageRegEx, $level) {
-            return
-                \preg_match($messageRegEx, $record['message']) &&
-                strtolower($record['level_name']) == strtolower($level);
-        });
-    }
-
-    /**
-     * Convenience method for asserting a log record is in a valid format.
-     */
-    private function withLog(): \PHPUnit\Framework\Constraint\Callback
-    {
-        return $this->callback(function ($record) {
-            return is_array($record);
-        });
-    }
-
-    /**
-     * Convenience method to expect verbose log messages in a certain order
-     * on the verbose log handler mock.
-     */
-    public function expectConsecutiveLog(array ...$constraints): void
-    {
-        // We need an ordered array of expectations. The constraints we are
-        // given may not be ordered or contiguous. First step is to build a
-        // (potentially) sparse array of the given expectations, and then fill
-        // the gaps in the array with generic expectations. Finally, we'll
-        // sort it to ensure a total ordering.
-
-        // ... Create a sparse array of custom expectations.
-        $matchers = [];
-        foreach ($constraints as [ $at, $messageRegEx, $level ]) {
-            assert(0 <= $at, 'Cannot expect a message at negative index in the log stack');
-            assert(! array_key_exists($at, $matchers), 'Cannot override an already set expectation');
-            // ensure the message at this index matches the given regex and verbosity level
-            $matchers[$at] = [ $this->withLogParams($messageRegEx, $level) ];
-        }
-
-        // ... Fill in the gaps
-        for ($i = 0; $i < max(array_keys($matchers)); $i++) {
-            if (! array_key_exists($i, $matchers)) {
-                // ensure the message at this index has the right format, regardless of content
-                $matchers[$i] = [ $this->withLog() ];
+            if ($matches) {
+                // Since we have found a match for the current constraint, we can now expect all future matches to be
+                // consecutive.
+                $consecutive = true;
+                $matchCount++;
+                $constraintIndex++;
             }
         }
-
-        // ... Order the now-filled array.
-        ksort($matchers);
-
-        // Finally, wire up the mock with those ordered expectations.
-        $this->verboseHandlerMock
-            ->expects($this->atLeast(count($matchers)))
-            ->method('handle')
-            ->withConsecutive(...$matchers)
-            ->willReturn(true)
-        ;
-    }
-
-    /**
-     * Convenience method to expect verbose log messages
-     * on the verbose log handler mock.
-     *
-     * @param integer $at The incrementing number indicating the order
-     * of the log message.
-     * @param string $messageRegEx Regex against which the log message
-     * will be asserted.
-     * @param string $level The log level against which the log will
-     * be asserted.
-     * @param mock|null $handlerMock (optional) The handler mock on which to set the
-     * expectations.
-     */
-    public function expectLog(int $at, string $messageRegEx, string $level, mock $handlerMock = null): void
-    {
-        $this->expectConsecutiveLog([ $at, $messageRegEx, $level ]);
-    }
-
-    /**
-     * Convenience method to expect a quiet verbose log handler mock.
-     *
-     * @param mock|null $handlerMock (optional) The handler mock on which to set the
-     * expectations.
-     */
-    public function expectQuiet(mock $handlerMock = null): void
-    {
-        if ($handlerMock === null) {
-            $handlerMock = $this->verboseHandlerMock;
-        }
-
-        $handlerMock
-            ->expects($this->never())
-            ->method('handle');
-    }
-
-    /**
-     * Test helper providing a quiet and verbose scenario testing
-     * for given functionality. Passing `verbose` config option
-     * to the initial config is not needed as the method takes
-     * care of performing assertions in both quiet and verbose scenarios.
-     *
-     * @param \Rollbar\Config|\Rollbar\RollbarLogger $object Object under test.
-     * @param callback $test Logic under test
-     * @param callback $verboseExpectations A callback with
-     * expectations to be set on the verbose logger handler mock
-     * in the verbose scenario.
-     * @param callback|null $pre (optional) Logic to be executed before test.
-     * @param callback|null $post (optional) Logic to be executed after the test
-     */
-    private function configurableObjectVerbosityTest(
-        Config|RollbarLogger $object,
-        callable             $test,
-        callable             $verboseExpectations,
-        callable             $pre = null,
-        callable             $post = null
-    ): void {
-        $unitTest = $this;
-        // Quiet scenario
-        $this->prepareForLogMocking(
-            array('verbose' => \Rollbar\Config::VERBOSE_NONE),
-            $object
-        );
-        $this->withTestLambdas(
-            $test,
-            function () use ($unitTest) {
-                $unitTest->expectQuiet();
-            },
-            $pre,
-            $post
-        );
-
-        // Verbose scenario
-        $this->prepareForLogMocking(
-            array('verbose' => \Psr\Log\LogLevel::DEBUG),
-            $object
-        );
-        $this->withTestLambdas(
-            $test,
-            $verboseExpectations,
-            $pre,
-            $post
-        );
-    }
-
-    /**
-     * Test helper for performing verbosity tests
-     *
-     * @param callback $test Logic under test.
-     * @param callback $expectations Logic with expectations.
-     * @param callback|null $pre (optional) Test set up.
-     * @param callback|null $post (optional) Test tear down.
-     */
-    private function withTestLambdas(
-        callable $test,
-        callable $expectations,
-        callable $pre = null,
-        callable $post = null
-    ): void {
-        if ($pre !== null) {
-            $pre();
-        }
-
-        $expectations();
-
-        $test();
-
-        if ($post !== null) {
-            $post();
-        }
-    }
-
-    /**
-     * Convenience test helper for a Rollbar logger log test with
-     * a verbose logger handler mock. Passing `verbose` config option
-     * to the initial config is not needed as
-     * `configurableObjectVerbosityTest` takes care of performing
-     * assertions in both quiet and verbose scenarios.
-     *
-     * @param array $config Configuration for Rollbar logger.
-     * @param callback $expectations A callback with expectations to be
-     * set on the verbose logger handler mock.
-     * @param string $messageLevel (optional) The level of the Rollbar log
-     * message invoked.
-     * @param callback|null $pre (optional) Logic to be executed before test.
-     * @param callback|null $post (optional) Logic to be executed after the test
-     */
-    private function rollbarLogTest(
-        array    $config,
-        callable $expectations,
-        string   $messageLevel = Level::WARNING,
-        callable $pre = null,
-        callable $post = null
-    ): void {
-        $rollbarLogger = $this->verboseRollbarLogger($config);
-
-        $this->configurableObjectVerbosityTest(
-            $rollbarLogger,
-            function () use ($rollbarLogger, $messageLevel) {
-                $rollbarLogger->log($messageLevel, "Testing PHP Notifier", array());
-            },
-            $expectations,
-            $pre,
-            $post
+        self::assertSame(
+            count($constraints),
+            $matchCount,
+            'Expected ' . count($constraints) . ' log messages, but found ' . $matchCount,
         );
     }
 }


### PR DESCRIPTION
This PR adds support for Monolog v3. [This is required to be compatible with Laravel v10](https://github.com/laravel/framework/blob/3a46fa307c73c8371ea6c72129f7c23a2f52c7f3/composer.json#L36). This was done without removing support for Monolog v2. I believe it is important to provide compatibility with existing packages that don't yet support Monolog v3.

## Description of the change

The biggest changes are in the `Rollbar\Config` class. Monolog v3 changes the log level to an `enum`. Enums are new in PHP 8.1. Previously, the log level was an integer. This may seem like a small issue. However, it has a number of implications.

1. To be compatible with PHP 8.0 we must support Monolog v2.
2. In Monolog v3 our custom `none` verbose log level with an integer value of `1000` will not work.

To resolve the first issue a number of checks were added so that Monolog v2 and v3 return types are both supported. 

To resolve the second issue if the `'verbose'` config option is set to `'none'` we set the verbose log hander to the `NoopHandler` instead of trying to set the log level as `1000` like we did previously.

Lastly, we bumped the version of `vimeo/psalm` to v5 to support some of the new PHP 8.1 features from Monolog.

## Test Changes

There were some minor updates to the `ConfigTest` and `RollbarLoggerTest classes to support the above changes.

The biggest changes in the tests were in the `VerbosityTest` class. It previously used a sophisticated series of mocks and lambda functions to validate that the right verbose messages were logged. The changes to support Monolog v3 caused all of these tests to fail. I believe it had something to do with the `NoopHandler` in some of the cases, but I really don't know. After trying to debug the `VerbosityTest` test suite for way too long (like an hour) I decided to remove the mocks and the anonymous functions and write more declarative test with the existing `ArrayLogger` test helper as the verbose logger. I added a few new methods to `ArrayLogger` and updated all the test. The `VerbosityTest` class is now about half the size, retains all the previous test cases, and last but most important to me I can read and understand it.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix #575 
- This is an alternative to #600 and #601.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
