### PR TITLE
Removed the `Config::getAllowedCircularReferenceTypes()` method

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -580,11 +580,6 @@ class Config
         return $this->dataBuilder->getCustom();
     }
 
-    public function getAllowedCircularReferenceTypes()
-    {
-        return $this->allowedCircularReferenceTypes;
-    }
-
     /**
      * Sets the custom truncation strategy class for payloads.
      *


### PR DESCRIPTION
## Description of the change

In #417 some updates were made to how we handle circular references. However, a method that access a non-existent private property was accidentally left behind and was included in the final commit.

This PR simply removes it. I would not consider removing this public method a breaking change since calling it would throw an exception.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

Related to issue #416 and PR #417.

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
