### PR TITLE
Fixed PHP 8.2 deprecated dynamic property creation warning

### DIFF
--- a/src/ErrorWrapper.php
+++ b/src/ErrorWrapper.php
@@ -6,7 +6,7 @@ class ErrorWrapper extends \Exception
 {
     private static $constName;
 
-    public $isUncaught;
+    public bool $isUncaught = false;
 
     private $utilities;
 

--- a/src/ExceptionWrapper.php
+++ b/src/ExceptionWrapper.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar;
+
+use Stringable;
+use Throwable;
+
+/**
+ * The exception wrapper class is used to annotate an exception with a caught/uncaught flag. This is used internally by
+ * our handlers when passing exceptions to the {@see RollbarLogger::log()} method, since it must conform to the PSR
+ * logger interface.
+ */
+class ExceptionWrapper implements Stringable
+{
+    /**
+     * Instantiates the exception wrapper.
+     *
+     * @param Throwable $exception  The exception to wrap.
+     * @param bool      $isUncaught Whether the exception was caught or not.
+     */
+    public function __construct(
+        private Throwable $exception,
+        public bool $isUncaught,
+    ) {
+    }
+
+    /**
+     * Returns the wrapped exception.
+     *
+     * @return Throwable
+     */
+    public function getException(): Throwable
+    {
+        return $this->exception;
+    }
+
+    /**
+     * This wrapper should be as transparent as possible, so we just pass through the exception
+     * {@see Throwable::__toString method.
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->exception->__toString();
+    }
+}

--- a/src/ExceptionWrapper.php
+++ b/src/ExceptionWrapper.php
@@ -20,7 +20,7 @@ class ExceptionWrapper implements Stringable
      */
     public function __construct(
         private Throwable $exception,
-        public bool $isUncaught,
+        public bool $isUncaught = false,
     ) {
     }
 

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar\Handlers;
 
+use Rollbar\ExceptionWrapper;
 use Rollbar\Rollbar;
 use Rollbar\RollbarLogger;
 use Rollbar\Payload\Level;
@@ -24,10 +25,9 @@ class ExceptionHandler extends AbstractHandler
         }
         
         $exception = $args[0];
-        $exception->isUncaught = true;
-        $this->logger()->log(Level::ERROR, $exception, array());
-        unset($exception->isUncaught);
-        
+        $wrapper = new ExceptionWrapper($exception, isUncaught: true);
+        $this->logger()->log(Level::ERROR, $wrapper, array());
+
         // if there was no prior handler, then we toss that exception
         if ($this->previousHandler === null) {
             throw $exception;

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -249,13 +249,8 @@ class Rollbar
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
-        $toLog->isUncaught = true;
-        try {
-            $result = self::$logger->report($level, $toLog, $context);
-        } finally {
-            unset($toLog->isUncaught);
-        }
-        return $result;
+        $wrapper = new ExceptionWrapper($toLog, isUncaught: true);
+        return self::$logger->report($level, $wrapper, $context);
     }
 
     /**

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -488,6 +488,9 @@ class RollbarLogger extends AbstractLogger
      */
     public function isUncaughtLogData(mixed $toLog): bool
     {
+        if ($toLog instanceof ExceptionWrapper || $toLog instanceof ErrorWrapper) {
+            return $toLog->isUncaught === true;
+        }
         if (! $toLog instanceof Throwable) {
             return false;
         }

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -217,6 +217,10 @@ class RollbarLogger extends AbstractLogger
             $this->verboseLogger()->notice('Rollbar is disabled');
             return new Response(0, "Disabled");
         }
+        $isUncaught = $this->isUncaughtLogData($message);
+        if ($message instanceof ExceptionWrapper) {
+            $message = $message->getException();
+        }
 
         // Convert a Level proper into a string proper, as the code paths that
         // follow have allowed both only by virtue that a Level downcasts to a
@@ -241,7 +245,6 @@ class RollbarLogger extends AbstractLogger
         $accessToken = $this->getAccessToken();
         $payload     = $this->getPayload($accessToken, $level, $message, $context);
 
-        $isUncaught = $this->isUncaughtLogData($message);
         if ($this->config->checkIgnored($payload, $message, $isUncaught)) {
             $this->verboseLogger()->info('Occurrence ignored');
             $response = new Response(0, "Ignored");

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -14,6 +14,11 @@ class DefaultsTest extends BaseRollbarTest
      */
     private \Rollbar\Defaults $defaults;
 
+    /**
+     * @var string[]
+     */
+    private array $defaultPsrLevels;
+
     public function setUp(): void
     {
         $this->defaults = new Defaults;

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -99,7 +99,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
     {
         // Set error reporting level and error handler to capture deprecation
         // warnings.
-        error_reporting(E_ALL);
+        $prev = error_reporting(E_ALL);
         $errors = array();
         set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
             $errors[] = array(
@@ -114,6 +114,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
 
         $handler->handle(new \Exception());
         restore_error_handler();
+        error_reporting($prev);
 
         // self::assertSame used instead of self::assertSame so the contents of
         // $errors are printed in the test output.

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -87,4 +87,36 @@ class ExceptionHandlerTest extends BaseRollbarTest
         set_exception_handler(function () {
         });
     }
+
+    /**
+     * This test is specifically for the deprecated dynamic properties in PHP 8.2. We were setting a property named
+     * "isUncaught" on the exception object, which is now deprecated. This test ensures that we are no longer setting
+     * that property.
+     *
+     * @return void
+     */
+    public function testDeprecatedDynamicProperties(): void
+    {
+        // Set error reporting level and error handler to capture deprecation
+        // warnings.
+        error_reporting(E_ALL);
+        $errors = array();
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
+            $errors[] = array(
+                'errno'   => $errno,
+                'errstr'  => $errstr,
+                'errfile' => $errfile,
+                'errline' => $errline,
+            );
+        });
+        $handler = new ExceptionHandler(new RollbarLogger(self::$simpleConfig));
+        $handler->register();
+
+        $handler->handle(new \Exception());
+        restore_error_handler();
+
+        // self::assertSame used instead of self::assertSame so the contents of
+        // $errors are printed in the test output.
+        self::assertSame([], $errors);
+    }
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -782,8 +782,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
     public static function providesToLogEntityForUncaughtCheck(): array
     {
-        $uncaught = new Exception;
-        $uncaught->isUncaught = true;
+        $uncaught = new ExceptionWrapper(new Exception(), true);
         return [
             [ 'some string', false, 'String log data should not be seen as uncaught' ],
             [ [], false, 'Array log data should not be seen as uncaught' ],

--- a/tests/TestHelpers/MockPhpStream.php
+++ b/tests/TestHelpers/MockPhpStream.php
@@ -4,7 +4,7 @@ namespace Rollbar\TestHelpers;
 
 class MockPhpStream
 {
-    
+    public $context;
     protected static int $index = 0;
     protected static $length = null;
 

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -9,7 +9,8 @@ use Rollbar\TestHelpers\CustomTruncation;
 
 class TruncationTest extends BaseRollbarTest
 {
-    
+    private Truncation $truncate;
+
     public function setUp(): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));


### PR DESCRIPTION
This PR fixes the PHP 8.2 deprecated dynamic property creation warning issue #590. 

## Description of the change

This adds a new class `ExceptionWrapper` to the SDK. It is used by the `ExceptionHandler::handle()` and `Rollbar::logUncaught()` methods. Both functions need to inform the `RollbarLogger::report()` method that the `Exception` instance we are passing it is on that was caught by the Rollbar SDK. To do that we had been setting the `isUncaught` property on the `Exception` instance. However, the `Exception` class does not have an `isUncaught` property. This means we were dynamically creating the property; something PHP allows. However, [in PHP 8.2 dynamic property creation has been deprecated.](https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties)

`ExceptionWrapper` let's us wrap the exception so that it can be passed to the `RollbarLogger::log()` method and include an `isUncaught` property while keeping the `log()` method compliant with the PSR logging interface.

For test review purposes I pushed the test to the branch first. [You can see the failed test in our CI](https://github.com/rollbar/rollbar-php/actions/runs/4226642287/jobs/7340297286#step:7:72) (while the test logs are retained). Also, note, that in the latest commit to this branch the test passes.

This also fixes all the dynamic properties I could find in the test suite.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix #590

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
