### PR TITLE
Fixed PHP 8.2 deprecated dynamic property creation 

### DIFF
--- a/src/ErrorWrapper.php
+++ b/src/ErrorWrapper.php
@@ -6,8 +6,6 @@ class ErrorWrapper extends \Exception
 {
     private static $constName;
 
-    public $isUncaught;
-
     private $utilities;
 
     private static function getConstName($const)

--- a/src/Handlers/ErrorHandler.php
+++ b/src/Handlers/ErrorHandler.php
@@ -42,9 +42,7 @@ class ErrorHandler extends AbstractHandler
         $exception = $this->logger()->
                             getDataBuilder()->
                             generateErrorWrapper($errno, $errstr, $errfile, $errline);
-        $exception->isUncaught = true;
-        $this->logger()->log(Level::ERROR, $exception, array());
-        unset($exception->isUncaught);
+        $this->logger()->report(Level::ERROR, $exception, isUncaught: true);
 
         return false;
     }

--- a/src/Handlers/ExceptionHandler.php
+++ b/src/Handlers/ExceptionHandler.php
@@ -24,10 +24,8 @@ class ExceptionHandler extends AbstractHandler
         }
         
         $exception = $args[0];
-        $exception->isUncaught = true;
-        $this->logger()->log(Level::ERROR, $exception, array());
-        unset($exception->isUncaught);
-        
+        $this->logger()->report(Level::ERROR, $exception, isUncaught: true);
+
         // if there was no prior handler, then we toss that exception
         if ($this->previousHandler === null) {
             throw $exception;

--- a/src/Handlers/FatalHandler.php
+++ b/src/Handlers/FatalHandler.php
@@ -38,9 +38,7 @@ class FatalHandler extends AbstractHandler
             $exception = $this->logger()->
                                 getDataBuilder()->
                                 generateErrorWrapper($errno, $errstr, $errfile, $errline);
-            $exception->isUncaught = true;
-            $this->logger()->log(Level::CRITICAL, $exception, array());
-            unset($exception->isUncaught);
+            $this->logger()->report(Level::CRITICAL, $exception, isUncaught: true);
         }
     }
     

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -249,13 +249,7 @@ class Rollbar
         if (is_null(self::$logger)) {
             return self::getNotInitializedResponse();
         }
-        $toLog->isUncaught = true;
-        try {
-            $result = self::$logger->report($level, $toLog, $context);
-        } finally {
-            unset($toLog->isUncaught);
-        }
-        return $result;
+        return self::$logger->report($level, $toLog, $context, isUncaught: true);
     }
 
     /**

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -14,6 +14,11 @@ class DefaultsTest extends BaseRollbarTest
      */
     private \Rollbar\Defaults $defaults;
 
+    /**
+     * @var string[]
+     */
+    private array $defaultPsrLevels;
+
     public function setUp(): void
     {
         $this->defaults = new Defaults;

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -57,11 +57,11 @@ class ErrorHandlerTest extends BaseRollbarTest
     {
         $logger = $this->getMockBuilder(RollbarLogger::class)
                         ->setConstructorArgs(array(self::$simpleConfig))
-                        ->setMethods(array('log'))
+                        ->setMethods(array('report'))
                         ->getMock();
         
         $logger->expects($this->once())
-                ->method('log');
+                ->method('report');
         
         /**
          * Disable PHPUnit's error handler as it would get triggered as the

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -73,11 +73,11 @@ class ExceptionHandlerTest extends BaseRollbarTest
         
         $logger = $this->getMockBuilder(RollbarLogger::class)
                         ->setConstructorArgs(array(self::$simpleConfig))
-                        ->setMethods(array('log'))
+                        ->setMethods(array('report'))
                         ->getMock();
         
         $logger->expects($this->once())
-                ->method('log');
+                ->method('report');
         
         $handler = new ExceptionHandler($logger);
         $handler->register();

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -99,7 +99,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
     {
         // Set error reporting level and error handler to capture deprecation
         // warnings.
-        error_reporting(E_ALL);
+        $prev = error_reporting(E_ALL);
         $errors = array();
         set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
             $errors[] = array(
@@ -114,6 +114,7 @@ class ExceptionHandlerTest extends BaseRollbarTest
 
         $handler->handle(new \Exception());
         restore_error_handler();
+        error_reporting($prev);
 
         // self::assertSame used instead of self::assertSame so the contents of
         // $errors are printed in the test output.

--- a/tests/Handlers/ExceptionHandlerTest.php
+++ b/tests/Handlers/ExceptionHandlerTest.php
@@ -87,4 +87,36 @@ class ExceptionHandlerTest extends BaseRollbarTest
         set_exception_handler(function () {
         });
     }
+
+    /**
+     * This test is specifically for the deprecated dynamic properties in PHP 8.2. We were setting a property named
+     * "isUncaught" on the exception object, which is now deprecated. This test ensures that we are no longer setting
+     * that property.
+     *
+     * @return void
+     */
+    public function testDeprecatedDynamicProperties(): void
+    {
+        // Set error reporting level and error handler to capture deprecation
+        // warnings.
+        error_reporting(E_ALL);
+        $errors = array();
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) use (&$errors) {
+            $errors[] = array(
+                'errno'   => $errno,
+                'errstr'  => $errstr,
+                'errfile' => $errfile,
+                'errline' => $errline,
+            );
+        });
+        $handler = new ExceptionHandler(new RollbarLogger(self::$simpleConfig));
+        $handler->register();
+
+        $handler->handle(new \Exception());
+        restore_error_handler();
+
+        // self::assertSame used instead of self::assertSame so the contents of
+        // $errors are printed in the test output.
+        self::assertSame([], $errors);
+    }
 }

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -782,8 +782,7 @@ class RollbarLoggerTest extends BaseRollbarTest
 
     public static function providesToLogEntityForUncaughtCheck(): array
     {
-        $uncaught = new Exception;
-        $uncaught->isUncaught = true;
+        $uncaught = new ExceptionWrapper(new Exception(), true);
         return [
             [ 'some string', false, 'String log data should not be seen as uncaught' ],
             [ [], false, 'Array log data should not be seen as uncaught' ],

--- a/tests/RollbarTest.php
+++ b/tests/RollbarTest.php
@@ -230,12 +230,14 @@ class RollbarTest extends BaseRollbarTest
 
     public function testLogUncaught(): void
     {
-        $sut = new Rollbar;
-        Rollbar::init(self::$simpleConfig);
-        $logger = Rollbar::logger();
-        $toLog = new \Exception;
+        $test = $this;
+        Rollbar::init(array_merge(self::$simpleConfig, [
+            'check_ignore' => function ($isUncaught) use ($test) {
+                $test::assertTrue($isUncaught);
+            },
+        ]));
+        $toLog  = new \Exception;
         $result = Rollbar::logUncaught(Level::ERROR, $toLog);
         $this->assertEquals(200, $result->getStatus());
-        $this->assertObjectNotHasAttribute('uncaught', $toLog);
     }
 }

--- a/tests/TestHelpers/MockPhpStream.php
+++ b/tests/TestHelpers/MockPhpStream.php
@@ -4,7 +4,7 @@ namespace Rollbar\TestHelpers;
 
 class MockPhpStream
 {
-    
+    public $context;
     protected static int $index = 0;
     protected static $length = null;
 

--- a/tests/Truncation/TruncationTest.php
+++ b/tests/Truncation/TruncationTest.php
@@ -9,7 +9,8 @@ use Rollbar\TestHelpers\CustomTruncation;
 
 class TruncationTest extends BaseRollbarTest
 {
-    
+    private Truncation $truncate;
+
     public function setUp(): void
     {
         $config = new Config(array('access_token' => $this->getTestAccessToken()));


### PR DESCRIPTION
This PR is an alternative to #604 and fixes the PHP 8.2 deprecated dynamic property creation warning issue #590.

## Description of the change

This adds a new optional argument to the `RollbarLogger::report()` method, `bool $isUncaught = false` as proposed by @anler https://github.com/rollbar/rollbar-php/pull/604#discussion_r1112973262. I created this as a new branch to keep our git history cleaner and then cherry picked the relevant commits from #604.

Because our internal `report()` method is not defined by the PSR log interface we are free to differ from the standard logging methods (as we already have done by returning a `Response` instance). Adding the argument removes the need to dynamically declare the `isUncaught` property as we had before.

A few things to note:

- The only reason this is considered a breaking change is because we are removing the public `RollbarLogger::isUncaughtLogData()` method since it is no longer needed.
- At every instance where we pass in the `$isUncaught` argument I use a named argument, so it is explicitly clear what the `true` is for.
- I did not add the `$isUncaught` argument to the `Rollbar::report()` method since we call `RollbarLogger::report()` directly, and the purpose of the argument is primarily for internal use. However, this does mean that the two `report()` methods are no longer the same. I am curious what the thoughts are on this.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fixes #590 
- Alternate to #604

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
