### PR TITLE
Fixed #613 Added response status code to verbose log message.

### DIFF
--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -269,7 +269,7 @@ class RollbarLogger extends AbstractLogger
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
             $this->verboseLogger()->error(
-                'Occurrence rejected by the API: with status ' . $response->getStatus() . ' '
+                'Occurrence rejected by the API: with status ' . $response->getStatus() . ': '
                 . ($info['message'] ?? 'message not set')
             );
         } else {

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -269,7 +269,8 @@ class RollbarLogger extends AbstractLogger
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
             $this->verboseLogger()->error(
-                'Occurrence rejected by the API: ' . ($info['message'] ?? 'message not set')
+                'Occurrence rejected by the API: with status ' . $response->getStatus() . ' '
+                . ($info['message'] ?? 'message not set')
             );
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -227,13 +227,13 @@ class VerbosityTest extends BaseRollbarTest
     public function testRollbarLoggerResponseStatusError(): void
     {
         Rollbar::init([
-            'access_token'   => $this->getTestAccessToken(),
+            // Invalid access token should cause a 403 response.
+            'access_token'   => '00000000000000000000000000000000',
             'environment'    => 'testing-php',
             'verbose_logger' => $this->verboseLogger,
-            'endpoint'       => 'https://api.rollbar.com/api/foo/',
         ]);
         Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
-        $this->assertVerboseLogContains('Occurrence rejected by the API:', LogLevel::ERROR);
+        $this->assertVerboseLogContains('Occurrence rejected by the API: with status 403', LogLevel::ERROR);
     }
 
     /**

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -233,7 +233,7 @@ class VerbosityTest extends BaseRollbarTest
             'verbose_logger' => $this->verboseLogger,
         ]);
         Rollbar::log(LogLevel::INFO, "Testing PHP Notifier");
-        $this->assertVerboseLogContains('Occurrence rejected by the API: with status 403', LogLevel::ERROR);
+        $this->assertVerboseLogContains('Occurrence rejected by the API: with status 403: ', LogLevel::ERROR);
     }
 
     /**


### PR DESCRIPTION
## Description of the change

This resolves issue #613 by adding the response status code from the API to the verbose log, if there is an error response status.

I also updated the associated test. Instead of posting to a non-existent endpoint, I sent an invalid access token. This seems more deterministic since we don't just want an error, we want a specific status code.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #613

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
