### PR TITLE
Backport of #614 Added response status code to verbose log message.

### DIFF
--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -142,7 +142,8 @@ class RollbarLogger extends AbstractLogger
         } elseif ($response->getStatus() >= 400) {
             $info = $response->getInfo();
             $this->verboseLogger()->error(
-                'Occurrence rejected by the API: ' . ($info['message'] ?? 'message not set')
+                'Occurrence rejected by the API: with status ' . $response->getStatus() . ': '
+                . ($info['message'] ?? 'message not set')
             );
         } else {
             $this->verboseLogger()->info('Occurrence successfully logged');

--- a/tests/VerbosityTest.php
+++ b/tests/VerbosityTest.php
@@ -310,15 +310,15 @@ class VerbosityTest extends BaseRollbarTest
         $unitTest = $this;
         $this->rollbarLogTest(
             array( // config
-                "access_token" => $this->getTestAccessToken(),
+                // Invalid access token should cause a 403 response.
+                "access_token" => '00000000000000000000000000000000',
                 "environment" => "testing-php",
-                "endpoint" => "https://api.rollbar.com/api/foo/"
             ),
             function () use ($unitTest) {
             // verbosity expectations
                 $unitTest->expectLog(
                     1,
-                    '/Occurrence rejected by the API: .*/',
+                    '/Occurrence rejected by the API: with status 403: .*/',
                     \Psr\Log\LogLevel::ERROR
                 );
             },


### PR DESCRIPTION
## Description of the change

This is a backport of #614 for v3. It adds the response status code to the verbose log when there is an error sending an item.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #613

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
