### PR TITLE
Fixed #617 `RollbarLogger:log()` not compatible with psr/log 1

### DIFF
--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -191,7 +191,7 @@ class RollbarLogger extends AbstractLogger
      * @throws InvalidArgumentException If $level is not a valid level.
      * @throws Throwable Rethrown $message if it is {@see Throwable} and {@see Config::raiseOnError} is true.
      */
-    public function log($level, string|Stringable $message, array $context = array()): void
+    public function log($level, $message, array $context = array()): void
     {
         $this->report($level, $message, $context);
     }

--- a/tests/TestHelpers/StdOutLogger.php
+++ b/tests/TestHelpers/StdOutLogger.php
@@ -8,7 +8,7 @@ use Psr\Log\LoggerTrait;
 
 class StdOutLogger extends RollbarLogger
 {
-    public function log($level, string|Stringable $message, array $context = array()): void
+    public function log($level, $message, array $context = array()): void
     {
         echo '[' . get_class($this) . ': ' . $level . '] ' . $message;
     }


### PR DESCRIPTION
## Description of the change

This resolves the `psr/log` 1 compatibility issue in #617. Removing the type annotations does not break compatibility with `psr/log` 2 and 3, and seems like the best course of action. In the future if we remove support for `psr/log` 1 we can reinsert the type annotations.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #617

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
