### PR TITLE
Fixed test helper method `ArrayLogger:log()` psr/log 1 compatability

### DIFF
--- a/tests/TestHelpers/ArrayLogger.php
+++ b/tests/TestHelpers/ArrayLogger.php
@@ -30,7 +30,7 @@ class ArrayLogger extends AbstractLogger
     /**
      * @inheritDoc
      */
-    public function log($level, Stringable|string $message, array $context = []): void
+    public function log($level, $message, array $context = []): void
     {
         $this->logs[] = self::stringify($level, $message);
     }


### PR DESCRIPTION
## Description of the change

This is a follow up PR to #623. It removes the type annotation conflict with the `Psr\Log\LoggerInterface::log()` method in version 1.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- #617 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
