### PR TITLE
Fixed #631 Set log message as primary

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -462,18 +462,25 @@ class DataBuilder implements DataBuilderInterface
         ?string $classOverride = null,
         string|Stringable $message = null,
     ): Trace {
+        $frames = array();
         if ($this->captureErrorStacktraces) {
             $frames = $this->makeFrames($exception, $includeContext);
-        } else {
-            $frames = array();
+        }
+        
+        $exceptionMessage = $exception->getMessage();
+        $description = $message;
+
+        // If a message is explicitly set when calling the logger, use that. Otherwise, use the exception's message.
+        if (null !== $message) {
+            $exceptionMessage = $message;
+            $description = $exception->getMessage();
         }
 
-        $excInfo = new ExceptionInfo(
+        return new Trace($frames, new ExceptionInfo(
             $classOverride ?: get_class($exception),
-            $message,
-            $exception->getMessage()
-        );
-        return new Trace($frames, $excInfo);
+            $exceptionMessage,
+            $description,
+        ));
     }
 
     public function makeFrames($exception, $includeContext)

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -470,8 +470,8 @@ class DataBuilder implements DataBuilderInterface
 
         $excInfo = new ExceptionInfo(
             $classOverride ?: get_class($exception),
-            $exception->getMessage(),
-            $message
+            $message,
+            $exception->getMessage()
         );
         return new Trace($frames, $excInfo);
     }

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -706,8 +706,8 @@ class DataBuilderTest extends BaseRollbarTest
         $this->assertSame(
             array(
                 'class'       => 'Exception',
-                'message'     => 'testing exception',
-                'description' => 'testing',
+                'message'     => 'testing',
+                'description' => 'testing exception',
             ),
             $output['body']['trace']['exception'],
         );


### PR DESCRIPTION
## Description of the change

This resolves #631. When we added support for both a log message and the exception in the log context, it caused the primary log message to be the exception message instead of the log message set when calling the log method. This is backward of what it should be. This PR fixes that issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #631

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
