### PR TITLE
Added support for the Telemetry feature.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,6 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
          colors="true"
-         cacheDirectory=".phpunit.cache"
          defaultTestSuite="Rollbar Test Suite"
 >
   <testsuites>
@@ -26,11 +25,4 @@
   <php>
     <env name="ROLLBAR_TEST_TOKEN" value="ad865e76e7fb496fab096ac07b1dbabb"/>
   </php>
-
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
-
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,21 +3,21 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
          colors="true"
-         defaultTestSuite="Rollbar Test Suite"
->
+         cacheDirectory=".phpunit.cache"
+         defaultTestSuite="Rollbar Test Suite">
   <testsuites>
     <testsuite name="Rollbar Test Suite">
       <directory suffix=".php">./tests/</directory>
-      <exclude>./tests/Performance/</exclude>
-      <exclude>./tests/TestHelpers/</exclude>
-      <exclude>./tests/FakeDataBuilder.php</exclude>
-      <exclude>./tests/bootstrap.php</exclude>
-      <exclude>./tests/BaseRollbarTest.php</exclude>
+        <exclude>./tests/Performance/</exclude>
+        <exclude>./tests/TestHelpers/</exclude>
+        <exclude>./tests/FakeDataBuilder.php</exclude>
+        <exclude>./tests/bootstrap.php</exclude>
+        <exclude>./tests/BaseRollbarTest.php</exclude>
     </testsuite>
 
-    <testsuite name="Rollbar Performance Test Suite">
-      <directory suffix=".php">./tests/Performance/</directory>
-    </testsuite>
+      <testsuite name="Rollbar Performance Test Suite">
+          <directory suffix=".php">./tests/Performance/</directory>
+      </testsuite>
   </testsuites>
 
   <coverage/>
@@ -25,4 +25,10 @@
   <php>
     <env name="ROLLBAR_TEST_TOKEN" value="ad865e76e7fb496fab096ac07b1dbabb"/>
   </php>
+
+    <source restrictDeprecations="true" restrictNotices="true" restrictWarnings="true">
+      <include>
+        <directory>src</directory>
+      </include>
+    </source>
 </phpunit>

--- a/src/Config.php
+++ b/src/Config.php
@@ -1139,7 +1139,7 @@ class Config
         // > the value E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR |
         // > E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE.
         // https://www.php.net/manual/en/language.operators.errorcontrol.php
-        if (version_compare(PHP_VERSION, '8.0', 'ge') && $errorReporting === (
+        if ($errorReporting === (
                 E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE
             )) {
             return true;

--- a/src/Config.php
+++ b/src/Config.php
@@ -2,6 +2,7 @@
 
 namespace Rollbar;
 
+use InvalidArgumentException;
 use Monolog\Handler\ErrorLogHandler;
 use Monolog\Handler\NoopHandler;
 use Monolog\Logger;
@@ -12,6 +13,8 @@ use Rollbar\Payload\EncodedPayload;
 use Rollbar\Senders\AgentSender;
 use Rollbar\Senders\CurlSender;
 use Rollbar\Senders\SenderInterface;
+use Rollbar\Telemetry\Telemeter;
+use Rollbar\Telemetry\TelemetryFilterInterface;
 use Throwable;
 use Rollbar\Senders\FluentSender;
 
@@ -60,6 +63,7 @@ class Config
         'scrub_safelist',
         'timeout',
         'transmit',
+        'telemetry',
         'custom_truncation',
         'report_suppressed',
         'use_error_reporting',
@@ -219,6 +223,13 @@ class Config
     private bool $raiseOnError = false;
 
     /**
+     * @var null|array The telemetry config. If null, telemetry is disabled.
+     *
+     * @since 4.1.0
+     */
+    private ?array $telemetry;
+
+    /**
      * @var int The maximum number of items reported to Rollbar within one
      * request.
      */
@@ -303,6 +314,7 @@ class Config
         $this->setCheckIgnoreFunction($config);
         $this->setSendMessageTrace($config);
         $this->setRaiseOnError($config);
+        $this->setTelemetry($config);
 
         if (isset($config['included_errno'])) {
             $this->includedErrno = $config['included_errno'];
@@ -333,7 +345,7 @@ class Config
         if (isset($_ENV['ROLLBAR_ACCESS_TOKEN']) && !isset($config['access_token'])) {
             $config['access_token'] = $_ENV['ROLLBAR_ACCESS_TOKEN'];
         }
-        
+
         $this->utilities()->validateString(
             $config['access_token'],
             "config['access_token']",
@@ -443,7 +455,7 @@ class Config
 
     private function setMinimumLevel(array $config): void
     {
-        $this->minimumLevel = \Rollbar\Defaults::get()->minimumLevel();
+        $this->minimumLevel = Defaults::get()->minimumLevel();
 
         $override = $config['minimum_level'] ?? null;
         $override = array_key_exists('minimumLevel', $config) ? $config['minimumLevel'] : $override;
@@ -468,7 +480,7 @@ class Config
         }
 
         if (!$this->reportSuppressed) {
-            $this->reportSuppressed = \Rollbar\Defaults::get()->reportSuppressed();
+            $this->reportSuppressed = Defaults::get()->reportSuppressed();
         }
     }
 
@@ -508,8 +520,22 @@ class Config
         if (array_key_exists('raise_on_error', $config)) {
             $this->raiseOnError = $config['raise_on_error'];
         } else {
-            $this->raiseOnError = \Rollbar\Defaults::get()->raiseOnError();
+            $this->raiseOnError = Defaults::get()->raiseOnError();
         }
+    }
+
+    /**
+     * Sets and cleans the telemetry config.
+     *
+     * @param array $config The config array.
+     * @return void
+     *
+     * @since 4.1.0
+     */
+    private function setTelemetry(array $config): void
+    {
+        $telemetry = key_exists('telemetry', $config) ? $config['telemetry']: true;
+        $this->telemetry = Defaults::get()->telemetry($telemetry);
     }
 
     private function setBatchSize(array $config): void
@@ -746,7 +772,7 @@ class Config
         }
 
         if (!$this->$keyName instanceof $expectedType) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 "$keyName must be a $expectedType"
             );
         }
@@ -815,6 +841,61 @@ class Config
     public function getRaiseOnError(): bool
     {
         return $this->raiseOnError;
+    }
+
+    /**
+     * Returns the telemetry instance or null if telemetry is disabled.
+     *
+     * @param Telemeter|null $telemeter An optional telemeter instance to scope the telemetry to. This allows us to
+     *                                  keep the same telemeter instance when mutating the config. Otherwise, we would
+     *                                  destroy the telemetry queue when mutating the config.
+     * @return Telemeter|null The telemetry instance or null if telemetry is disabled.
+     *
+     * @since 4.1.0
+     */
+    public function getTelemetry(?Telemeter $telemeter): ?Telemeter
+    {
+        if (null === $this->telemetry) {
+            return null;
+        }
+        $config = $this->telemetry;
+        $config['filter'] = $this->initTelemetryFilter($config['filter']);
+        if (null === $telemeter) {
+            return new Telemeter(...$config);
+        }
+        $telemeter->scope(...$config);
+        return $telemeter;
+    }
+
+    /**
+     * Returns the telemetry filter instance or null if no filter is configured.
+     *
+     * @param string|null $filterClass The fully qualified class name of the telemetry filter class or null if no
+     *                                 filter is configured.
+     * @return TelemetryFilterInterface|null
+     *
+     * @throws InvalidArgumentException if the configured filter class does not exist or does not implement
+     *                                  {@see TelemetryFilterInterface}.
+     *
+     * @since 4.1.0
+     */
+    private function initTelemetryFilter(?string $filterClass): ?TelemetryFilterInterface
+    {
+        if (null === $filterClass) {
+            return null;
+        }
+        if (!class_exists($filterClass)) {
+            throw new InvalidArgumentException(
+                "Telemetry filter class $filterClass does not exist"
+            );
+        }
+        $filter = new $filterClass($this->telemetry);
+        if (!$filter instanceof TelemetryFilterInterface) {
+            throw new InvalidArgumentException(
+                "Telemetry filter class $filterClass must implement TelemetryFilterInterface"
+            );
+        }
+        return $filter;
     }
 
     public function transform(
@@ -1059,8 +1140,8 @@ class Config
         // > E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE.
         // https://www.php.net/manual/en/language.operators.errorcontrol.php
         if (version_compare(PHP_VERSION, '8.0', 'ge') && $errorReporting === (
-            E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE
-        )) {
+                E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR | E_RECOVERABLE_ERROR | E_PARSE
+            )) {
             return true;
         }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -5,6 +5,7 @@ namespace Rollbar;
 use Monolog\Logger;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
+use Rollbar\Telemetry\Telemeter;
 use Throwable;
 
 class Defaults
@@ -328,10 +329,31 @@ class Defaults
     {
         return $value ?? $this->minimumLevel;
     }
-    
+
     public function raiseOnError($value = null)
     {
         return $value ?? $this->raiseOnError;
+    }
+
+    /**
+     * Returns the telemetry configuration array or null if telemetry should be disabled.
+     *
+     * @param bool|array|null $value If true or null returns the default telemetry configuration. If false returns null.
+     *
+     * @return array|null The telemetry configuration.
+     *
+     * @since 4.1.0
+     */
+    public function telemetry(bool|array|null $value = null): ?array
+    {
+        if (true === $value) {
+            return $this->telemetry;
+        }
+        if (is_array($value)) {
+            // Ensure that the telemetry array contains only the keys we expect and includes all the required keys.
+            return array_merge($this->telemetry, array_intersect_key($value, $this->telemetry));
+        }
+        return null;
     }
 
     private $psrLevels;
@@ -384,4 +406,16 @@ class Defaults
     private $maxItems = 10;
     private $minimumLevel = 0;
     private $raiseOnError = false;
+
+    /**
+     * @var array $telemetry The default telemetry configuration.
+     *
+     * @since 4.1.0
+     */
+    private array $telemetry = [
+        'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+        'filter' => null,
+        'includeItemsInTelemetry' => true,
+        'includeIgnoredItemsInTelemetry' => false,
+    ];
 }

--- a/src/Payload/Body.php
+++ b/src/Payload/Body.php
@@ -9,43 +9,119 @@ class Body implements SerializerInterface
 {
     use UtilitiesTrait;
 
+    /**
+     * Creates a new instance of the Body class.
+     *
+     * @param ContentInterface      $value     The value to assign to the content property.
+     * @param array                 $extra     An array to assign to the extra property. Default value is an empty
+     *                                         array.
+     * @param TelemetryEvent[]|null $telemetry An optional array of telemetry events. Default value is null.
+     * @return void
+     *
+     * @since 4.1.0 The $telemetry property was added.
+     */
     public function __construct(
         private ContentInterface $value,
-        private array $extra = array()
+        private array $extra = [],
+        private ?array $telemetry = null
     ) {
     }
 
+    /**
+     * Returns the main content of the payload body.
+     *
+     * @return ContentInterface
+     */
     public function getValue(): ContentInterface
     {
         return $this->value;
     }
 
+    /**
+     * Sets the main content of the payload body.
+     *
+     * @param ContentInterface $value The value to assign to the content of the payload body.
+     *
+     * @return self
+     */
     public function setValue(ContentInterface $value): self
     {
         $this->value = $value;
         return $this;
     }
-    
+
+    /**
+     * Sets the array of extra data.
+     *
+     * @param array $extra The array of extra data.
+     *
+     * @return self
+     */
     public function setExtra(array $extra): self
     {
         $this->extra = $extra;
         return $this;
     }
-    
+
+    /**
+     * Returns the array of extra data.
+     *
+     * @return array
+     */
     public function getExtra(): array
     {
         return $this->extra;
     }
 
+    /**
+     * Returns the array of telemetry events or null if there were none.
+     *
+     * @return TelemetryEvent[]|null
+     *
+     * @since 4.1.0
+     */
+    public function getTelemetry(): ?array
+    {
+        if (empty($this->telemetry)) {
+            return null;
+        }
+        return $this->telemetry;
+    }
+
+    /**
+     * Sets the list of telemetry events for this payload body.
+     *
+     * @param array|null $telemetry The list of telemetry events or null if there were none.
+     *
+     * @return void
+     *
+     * @since 4.1.0
+     */
+    public function setTelemetry(?array $telemetry): void
+    {
+        $this->telemetry = $telemetry;
+    }
+
+    /**
+     * Returns the JSON serializable representation of the payload body.
+     *
+     * @return array
+     *
+     * @since 4.1.0 Includes the 'telemetry' key, if it is not empty.
+     */
     public function serialize()
     {
         $result = array();
         $result[$this->value->getKey()] = $this->value;
-        
+
         if (!empty($this->extra)) {
             $result['extra'] = $this->extra;
         }
-        
+
+        if (!empty($this->telemetry)) {
+            $result['telemetry'] = $this->telemetry;
+        }
+
         return $this->utilities()->serializeForRollbarInternal($result, array('extra'));
     }
 }

--- a/src/Payload/TelemetryBody.php
+++ b/src/Payload/TelemetryBody.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar\Payload;
+
+use Rollbar\SerializerInterface;
+use Rollbar\UtilitiesTrait;
+
+/**
+ * The body of a telemetry event.
+ *
+ * @since 4.1.0
+ */
+class TelemetryBody implements SerializerInterface
+{
+    use UtilitiesTrait;
+
+    public const DEFINED_KEYS = [
+        'message',
+        'method',
+        'url',
+        'status_code',
+        'subtype',
+        'stack',
+        'element',
+        'from',
+        'to',
+        'start_timestamp_ms',
+        'end_timestamp_ms',
+    ];
+
+    /**
+     * @var array $extra Any extra data to include in the telemetry body.
+     */
+    public array $extra = [];
+
+    /**
+     * Creates the telemetry body.
+     *
+     * The `element` property is not included in the constructor because it intended for browser DOM events.
+     *
+     * @param string      $message            This should be included for errors and log events.
+     * @param string      $method             This should be included for network events. The HTTP method. E.g. GET,
+     *                                        POST, etc.
+     * @param string      $url                This should be included for network events. The URL of the request.
+     * @param string      $status_code        This should be included for network events. The HTTP status code.
+     * @param string      $subtype            This can be used to further classify the event. Internally, we use this to
+     *                                        distinguish between errors and exceptions for error events.
+     * @param string|null $stack              The stack trace of the error or exception. This should be included for
+     *                                        error events.
+     * @param string      $from               This should be included for navigation events. The URL of the previous
+     *                                        page.
+     * @param string      $to                 This should be included for navigation events. The URL of the next page.
+     * @param int|null    $start_timestamp_ms The start time of the event in milliseconds since the Unix epoch.
+     * @param int|null    $end_timestamp_ms   The end time of the event in milliseconds since the Unix epoch.
+     * @param mixed       ...$extra           Any extra data to include in the telemetry body.
+     */
+    public function __construct(
+        public string $message = '',
+        public string $method = '',
+        public string $url = '',
+        public string $status_code = '',
+        public string $subtype = '',
+        public ?string $stack = null,
+        public string $from = '',
+        public string $to = '',
+        public ?int $start_timestamp_ms = null,
+        public ?int $end_timestamp_ms = null,
+        mixed ...$extra,
+    ) {
+        $this->extra = $extra;
+    }
+
+    /**
+     * Returns the array representation of the telemetry body.
+     *
+     * @return array
+     */
+    public function serialize(): array
+    {
+        // This filters out any null or empty values.
+        $result = array_filter([
+            'message' => $this->message,
+            'method' => $this->method,
+            'url' => $this->url,
+            'status_code' => $this->status_code,
+            'subtype' => $this->subtype,
+            'stack' => $this->stack,
+            'from' => $this->from,
+            'to' => $this->to,
+            'start_timestamp_ms' => $this->start_timestamp_ms,
+            'end_timestamp_ms' => $this->end_timestamp_ms,
+        ]);
+
+        if (empty($this->extra)) {
+            return $result;
+        }
+
+        // This keeps the extra data from overwriting the defined keys when the extra data is merged into the result.
+        $extra = array_diff_key($this->extra, array_fill_keys(self::DEFINED_KEYS, null));
+
+        return $this->utilities()->serializeForRollbarInternal(array_merge($result, $extra));
+    }
+}

--- a/src/Payload/TelemetryEvent.php
+++ b/src/Payload/TelemetryEvent.php
@@ -33,8 +33,8 @@ class TelemetryEvent implements SerializerInterface
      * @param string              $type      The type of telemetry data. One of: {@see DataType}.
      * @param string              $level     The severity level of the telemetry data. One of: "critical", "error",
      *                                       "warning", "info", or "debug".
-     * @param array|TelemetryBody $body      Additional data for the telemetry event. If an array is provided, it will be
-     *                                       converted to a {@see TelemetryBody} object.
+     * @param array|TelemetryBody $body      Additional data for the telemetry event. If an array is provided, it will
+     *                                       be converted to a {@see TelemetryBody} object.
      * @param float|null          $timestamp When this occurred, as a unix timestamp in milliseconds. If not provided,
      *                                       Rollbar will use the current time.
      */

--- a/src/Payload/TelemetryEvent.php
+++ b/src/Payload/TelemetryEvent.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar\Payload;
+
+use Rollbar\SerializerInterface;
+use Rollbar\Telemetry\DataType;
+use Rollbar\UtilitiesTrait;
+
+/**
+ * A telemetry event.
+ *
+ * @since 4.1.0
+ */
+class TelemetryEvent implements SerializerInterface
+{
+    use UtilitiesTrait;
+
+    public ?string $uuid = null;
+    public ?string $source = 'server';
+
+    public TelemetryBody $body;
+
+    /**
+     * Creates a telemetry event.
+     *
+     * Some types should be accompanied by specific data in the body.
+     *
+     * - If $type is {@see DataType::LOG}, the body should contain "message" key.
+     * - If $type is {@see DataType::NETWORK}, the body should contain "method", "url", and "status_code" keys.
+     * - If $type is {@see DataType::NAVIGATION}, the body should contain "from" and "to" keys.
+     * - If $type is {@see DataType::ERROR}, the body should contain "message" key.
+     *
+     * @param string              $type      The type of telemetry data. One of: {@see DataType}.
+     * @param string              $level     The severity level of the telemetry data. One of: "critical", "error",
+     *                                       "warning", "info", or "debug".
+     * @param array|TelemetryBody $body      Additional data for the telemetry event. If an array is provided, it will be
+     *                                       converted to a {@see TelemetryBody} object.
+     * @param float|null          $timestamp When this occurred, as a unix timestamp in milliseconds. If not provided,
+     *                                       Rollbar will use the current time.
+     */
+    public function __construct(
+        public string $type,
+        public string $level,
+        array|TelemetryBody $body,
+        public ?float $timestamp = null,
+    ) {
+        if (is_null($this->timestamp)) {
+            $this->timestamp = floor(microtime(true) * 1000);
+        }
+        $this->body = is_array($body) ? new TelemetryBody(...$body): $body;
+    }
+
+    public function serialize(): array
+    {
+        $result = array_filter([
+            'uuid' => $this->uuid,
+            'source' => $this->source,
+            'level' => $this->level,
+            'type' => $this->type,
+            'body' => $this->body->serialize(),
+            'timestamp_ms' => $this->timestamp,
+        ]);
+
+        return $this->utilities()->serializeForRollbarInternal($result);
+    }
+}

--- a/src/Telemetry/DataType.php
+++ b/src/Telemetry/DataType.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar\Telemetry;
+
+/**
+ * The type of the telemetry event.
+ *
+ * This should be replaced by an enum when we only support PHP >= 8.1.
+ *
+ * @since 4.1.0
+ */
+class DataType
+{
+    const LOG = 'log';
+
+    const NETWORK = 'network';
+
+    /**
+     * This is intended for use with browsers, and is only included here for API completeness. Generally, this should
+     * not be used in a PHP context.
+     */
+    const DOM = 'dom';
+
+    const NAVIGATION = 'navigation';
+
+    const ERROR = 'error';
+
+    const MANUAL = 'manual';
+}

--- a/src/Telemetry/Telemeter.php
+++ b/src/Telemetry/Telemeter.php
@@ -1,0 +1,548 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar\Telemetry;
+
+use Rollbar\ErrorWrapper;
+use Rollbar\Payload\Level;
+use Rollbar\Payload\TelemetryBody;
+use Rollbar\Payload\TelemetryEvent;
+use Stringable;
+use Throwable;
+
+/**
+ * The Telemeter collects telemetry events and queues them for sending to Rollbar.
+ *
+ * @since 4.1.0
+ */
+class Telemeter
+{
+    public const MAX_EVENTS = 100;
+
+    /**
+     * @var TelemetryEvent[] $queue The queue of telemetry events.
+     */
+    private array $queue = [];
+
+    private int $maxQueueSize;
+
+    /**
+     * Initialize a new Telemeter.
+     *
+     * @param int                           $maxTelemetryEvents      The maximum number of telemetry events to queue
+     *                                                               before discarding. Must be between 0 and 100. If,
+     *                                                               a value outside the range is given it will be
+     *                                                               changed to be within the range. Defaults to 100.
+     * @param TelemetryFilterInterface|null $filter                  A filter to apply to telemetry items before they
+     *                                                               are added to the queue. If null, no filter will be
+     *                                                               applied. Defaults to null.
+     * @param bool                          $includeItemsInTelemetry If true, the items caught by Rollbar will be
+     *                                                               included in the telemetry of future items sent to
+     *                                                               Rollbar.
+     * @param bool                          $includeIgnoredItemsInTelemetry
+     */
+    public function __construct(
+        int $maxTelemetryEvents = self::MAX_EVENTS,
+        private ?TelemetryFilterInterface $filter = null,
+        private bool $includeItemsInTelemetry = true,
+        private bool $includeIgnoredItemsInTelemetry = false
+    ) {
+        $this->maxQueueSize = max(0, min($maxTelemetryEvents, self::MAX_EVENTS));
+    }
+
+    /**
+     * Returns the Rollbar telemetry type that corresponds to the given PSR-3 log level.
+     *
+     * @param string $level The PSR-3 log level.
+     * @return string
+     */
+    private static function getTypeFromLevel(string $level): string
+    {
+        return match ($level) {
+            Level::EMERGENCY, Level::ALERT, Level::CRITICAL, Level::ERROR, Level::WARNING => DataType::ERROR,
+            Level::NOTICE, Level::INFO => DataType::LOG,
+            default => DataType::MANUAL,
+        };
+    }
+
+    /**
+     * Returns the Rollbar telemetry level that corresponds to the given PSR-3 log level.
+     *
+     * @param string $level The PSR-3 log level.
+     * @return string
+     */
+    private static function getLevelFromLevel(string $level): string
+    {
+        return match ($level) {
+            Level::EMERGENCY, Level::ALERT, Level::CRITICAL => 'critical',
+            Level::ERROR => 'error',
+            Level::WARNING => 'warning',
+            Level::DEBUG => 'debug',
+            default => 'info',
+        };
+    }
+
+    /**
+     * Reconfigures the Telemeter with the given options. See the constructor for a description of the options.
+     *
+     * @param int                           $maxTelemetryEvents
+     * @param TelemetryFilterInterface|null $filter
+     * @param bool                          $includeItemsInTelemetry
+     * @param bool                          $includeIgnoredItemsInTelemetry
+     * @return void
+     */
+    public function scope(
+        int $maxTelemetryEvents = self::MAX_EVENTS,
+        ?TelemetryFilterInterface $filter = null,
+        bool $includeItemsInTelemetry = true,
+        bool $includeIgnoredItemsInTelemetry = false
+    ): void {
+        if ($maxTelemetryEvents !== $this->maxQueueSize) {
+            // We call this method so that the queue is truncated if necessary.
+            $this->setMaxQueueSize($maxTelemetryEvents);
+        }
+        if ($filter !== $this->filter) {
+            $this->filter = $filter;
+        }
+        if ($includeItemsInTelemetry !== $this->includeItemsInTelemetry) {
+            $this->includeItemsInTelemetry = $includeItemsInTelemetry;
+        }
+        if ($includeIgnoredItemsInTelemetry !== $this->includeIgnoredItemsInTelemetry) {
+            $this->includeIgnoredItemsInTelemetry = $includeIgnoredItemsInTelemetry;
+        }
+    }
+
+    /**
+     * Returns the current queue of telemetry events.
+     *
+     * Note: this method returns a copy of the queue array, but the TelemetryEvent objects are not cloned, so modifying
+     * the events in the returned array will modify the events in the queue.
+     *
+     * @return TelemetryEvent[]
+     */
+    public function copyEvents(): array
+    {
+        if (null === $this->filter || !$this->filter->filterOnRead()) {
+            return $this->queue;
+        }
+        $queue = [];
+        $filtered = 0;
+        foreach ($this->queue as $event) {
+            // The queue size needs to be calculated as the number of events in the queue minus the number of events
+            // that have already been filtered.
+            if (!$this->filter->include($event, count($this->queue) - $filtered)) {
+                $filtered++;
+                continue;
+            }
+            $queue[] = $event;
+        }
+        return $queue;
+    }
+
+    /**
+     * Appends a telemetry event to the queue. If the queue is full, the oldest event will be discarded.
+     *
+     * Note: using this method directly will bypass any filters that have been set on the Telemeter.
+     *
+     * @param TelemetryEvent $event The telemetry event to add to the queue.
+     *
+     * @return void
+     */
+    public function push(TelemetryEvent $event): void
+    {
+        if ($this->maxQueueSize === 0) {
+            return;
+        }
+        $this->queue[] = $event;
+        if (count($this->queue) > $this->maxQueueSize) {
+            array_shift($this->queue);
+        }
+    }
+
+    /**
+     * Captures a telemetry event and adds it to the queue.
+     *
+     * @param string              $type      The type of telemetry data. One of: "log", "network", "dom", "navigation",
+     *                                       "error", or "manual".
+     * @param string              $level     The severity level of the telemetry data. One of: "critical", "error",
+     *                                       "warning", "info", or "debug".
+     * @param array|TelemetryBody $metadata  Additional data about the telemetry event.
+     * @param string|null         $uuid      The Rollbar UUID to associate with this telemetry event.
+     * @param int|null            $timestamp When this occurred, as a unix timestamp in milliseconds. If not provided,
+     *                                       the current time will be used.
+     *
+     * @return TelemetryEvent|null
+     */
+    public function capture(
+        string $type,
+        string $level,
+        array|TelemetryBody $metadata,
+        string $uuid = null,
+        ?int $timestamp = null,
+    ): ?TelemetryEvent {
+        if ($this->maxQueueSize === 0) {
+            return null;
+        }
+        $event = new TelemetryEvent($type, $level, $metadata, $timestamp);
+        if (null !== $uuid) {
+            $event->uuid = $uuid;
+        }
+        if (null !== $this->filter && !$this->filter->include($event, count($this->queue))) {
+            return null;
+        }
+        $this->push($event);
+        return $event;
+    }
+
+    /**
+     * Captures an error as a telemetry event and adds it to the queue.
+     *
+     * @param array|string|ErrorWrapper|Throwable $error     The error to capture. If a string is given, it will be used
+     *                                                       as the message. If an array is given, it will be used as
+     *                                                       the metadata body. If an ErrorWrapper is given, it will be
+     *                                                       parsed for the message and stack trace.
+     * @param string                              $level     The severity level of the telemetry data. One of:
+     *                                                       "critical", "error", "warning", "info", or "debug".
+     *                                                       Defaults to "error".
+     * @param string|null                         $uuid      The Rollbar UUID to associate with this telemetry event.
+     * @param int|null                            $timestamp When this occurred, as a unix timestamp in milliseconds. If
+     *                                                       not provided, the current time will be used.
+     *
+     * @return TelemetryEvent|null Returns the {@see TelemetryEvent} that was added to the queue, or null if the event
+     *                             was filtered out.
+     */
+    public function captureError(
+        array|string|ErrorWrapper|Throwable $error,
+        string $level = 'error',
+        string $uuid = null,
+        ?int $timestamp = null,
+    ): ?TelemetryEvent {
+        if (is_string($error)) {
+            return $this->capture('error', $level, new TelemetryBody(message: $error), $uuid, $timestamp);
+        }
+        if ($error instanceof ErrorWrapper) {
+            $metadata = new TelemetryBody(
+                message: $error->getMessage(),
+                subtype: 'error',
+                stack: $this->stringifyBacktrace($error->getBacktrace()),
+            );
+            return $this->capture('error', $level, $metadata, $uuid, $timestamp);
+        }
+        if ($error instanceof Throwable) {
+            $metadata = new TelemetryBody(
+                message: $error->getMessage(),
+                subtype: 'exception',
+                stack: $this->stringifyBacktrace($error->getTrace())
+            );
+            return $this->capture('error', $level, $metadata, $uuid, $timestamp);
+        }
+        return $this->capture('error', $level, $error, $uuid, $timestamp);
+    }
+
+    /**
+     * Captures a log message as a telemetry event and adds it to the queue.
+     *
+     * @param string      $message   The log message to capture.
+     * @param string      $level     The severity level of the telemetry data. One of: "critical", "error", "warning",
+     *                               "info", or "debug". Defaults to "info".
+     * @param string|null $uuid      The Rollbar UUID to associate with this telemetry event.
+     * @param int|null    $timestamp When this occurred, as a unix timestamp in milliseconds. If not provided, the
+     *                               current time will be used.
+     *
+     * @return TelemetryEvent|null
+     */
+    public function captureLog(
+        string $message,
+        string $level = 'info',
+        string $uuid = null,
+        ?int $timestamp = null,
+    ): ?TelemetryEvent {
+        return $this->capture('log', $level, new TelemetryBody(message: $message), $uuid, $timestamp);
+    }
+
+    /**
+     * Captures a network event as a telemetry event and adds it to the queue.
+     *
+     * @param string      $method      The HTTP method. E.g. GET, POST, etc.
+     * @param string      $url         The URL of the request.
+     * @param string      $status_code The HTTP status code.
+     * @param string      $level       The severity level of the telemetry data. One of: "critical", "error", "warning",
+     *                                 "info", or "debug". Defaults to "info".
+     * @param string|null $uuid        The Rollbar UUID to associate with this telemetry event.
+     * @param int|null    $timestamp   When this occurred, as a unix timestamp in milliseconds. If not provided, the
+     *                                 current time will be used.
+     *
+     * @return TelemetryEvent|null
+     */
+    public function captureNetwork(
+        string $method,
+        string $url,
+        string $status_code,
+        string $level = 'info',
+        string $uuid = null,
+        ?int $timestamp = null,
+    ): ?TelemetryEvent {
+        return $this->capture(
+            type: 'log',
+            level: $level,
+            metadata: new TelemetryBody(
+                method: $method,
+                url: $url,
+                status_code: $status_code,
+            ),
+            uuid: $uuid,
+            timestamp: $timestamp,
+        );
+    }
+
+    /**
+     * Captures a navigation event as a telemetry event and adds it to the queue.
+     *
+     * @param string      $from      The URL of the previous page.
+     * @param string      $to        The URL of the next page.
+     * @param string      $level     The severity level of the telemetry data. One of: "critical", "error", "warning",
+     *                               "info", or "debug". Defaults to "info".
+     * @param string|null $uuid      The Rollbar UUID to associate with this telemetry event.
+     * @param int|null    $timestamp When this occurred, as a unix timestamp in milliseconds. If not provided, the
+     *                               current time will be used.
+     *
+     * @return TelemetryEvent|null
+     */
+    public function captureNavigation(
+        string $from,
+        string $to,
+        string $level = 'info',
+        string $uuid = null,
+        ?int $timestamp = null,
+    ): ?TelemetryEvent {
+        return $this->capture('log', $level, new TelemetryBody(from: $from, to: $to), $uuid, $timestamp);
+    }
+
+    /**
+     * Add a Rollbar captured item to the telemetry queue.
+     *
+     * @param string                      $level   The PSR-3 log level.
+     * @param string|Stringable|Throwable $message The message to log.
+     * @param array                       $context The context.
+     * @param bool                        $ignored Whether the item was ignored.
+     * @param string|null                 $uuid    The Rollbar item UUID.
+     *
+     * @return TelemetryEvent|null
+     *
+     * @internal This method is for internal use only and may change without warning.
+     */
+    public function captureRollbarItem(
+        string $level,
+        string|Stringable|Throwable $message,
+        array $context = [],
+        bool $ignored = false,
+        ?string $uuid = null,
+    ): ?TelemetryEvent {
+        if (!$this->includeItemsInTelemetry) {
+            return null;
+        }
+        if (!$this->includeIgnoredItemsInTelemetry && $ignored) {
+            return null;
+        }
+        if (null !== $this->filter && !$this->filter->includeRollbarItem($level, $message, $context, $ignored)) {
+            return null;
+        }
+        // Make sure to respect the PSR exception context. See https://www.php-fig.org/psr/psr-3/#13-context.
+        if (($context['exception'] ?? null) instanceof Throwable) {
+            $event = $this->captureError($context['exception'], self::getLevelFromLevel($level), $uuid);
+            if (null === $event) {
+                return null;
+            }
+            // We have both a message from the exception instance and a message. So we will use the message as the
+            // primary body message, and the exception message will be saved to a custom "error_message" property on
+            // the posted telemetry event body.
+            $event->body->extra['error_message'] = $event->body->message;
+            $event->body->message = $this->getRollbarItemMessage($message);
+            return $event;
+        }
+        // If the rollbar item is an exception, we should capture it as an error event.
+        if ($message instanceof Throwable) {
+            return $this->captureError($message, self::getLevelFromLevel($level), $uuid);
+        }
+        // Otherwise, we will capture it based on the level.
+        return $this->capture(
+            type: self::getTypeFromLevel($level),
+            level: self::getLevelFromLevel($level),
+            metadata: new TelemetryBody(message: $this->getRollbarItemMessage($message)),
+            uuid: $uuid,
+        );
+    }
+
+    /**
+     * Returns the maximum number of telemetry events that can be queued before discarding prior events.
+     *
+     * @return int
+     */
+    public function getMaxQueueSize(): int
+    {
+        return $this->maxQueueSize;
+    }
+
+    /**
+     * Update the maximum number of telemetry events that can be queued before discarding. NOTE: If the new max is less
+     * than the current number of queued events, the oldest events will be discarded.
+     *
+     * @param int $maxQueueSize The maximum number of telemetry events to queue before discarding. Must be between 0
+     *                          and 100.
+     */
+    public function setMaxQueueSize(int $maxQueueSize): void
+    {
+        $newMax = max(0, min($maxQueueSize, self::MAX_EVENTS));
+        $queueSize = count($this->queue);
+        if ($queueSize > $newMax) {
+            array_splice($this->queue, 0, $queueSize - $newMax);
+        }
+        $this->maxQueueSize = $newMax;
+    }
+
+    /**
+     * Returns the current number of telemetry events in the queue.
+     *
+     * @return int
+     */
+    public function getQueueSize(): int
+    {
+        return count($this->queue);
+    }
+
+    /**
+     * Clears the queue of all telemetry events.
+     *
+     * @return void
+     */
+    public function clearQueue(): void
+    {
+        $this->queue = [];
+    }
+
+    /**
+     * If true, the items caught by Rollbar will be included in the telemetry of future items sent to Rollbar.
+     *
+     * @return bool
+     */
+    public function shouldIncludeItemsInTelemetry(): bool
+    {
+        return $this->includeItemsInTelemetry;
+    }
+
+    /**
+     * Change whether Rollbar items should be included in the telemetry queue.
+     *
+     * @param bool $include True to include Rollbar items in the telemetry data.
+     */
+    public function setIncludeItemsInTelemetry(bool $include): void
+    {
+        $this->includeItemsInTelemetry = $include;
+    }
+
+    /**
+     * Returns the filter instance that is applied to telemetry items before they are added to the queue.
+     *
+     * @return TelemetryFilterInterface|null
+     */
+    public function getFilter(): ?TelemetryFilterInterface
+    {
+        return $this->filter;
+    }
+
+    /**
+     * Sets the filter to apply to telemetry items before they are added to the queue. This will also apply the new
+     * filter to any items already in the queue if $apply is true.
+     *
+     * @param TelemetryFilterInterface|null $filter A filter to apply to telemetry items before they are added to the
+     *                                              queue. If null, no filter will be applied.
+     * @param bool                          $apply  If true, the new filter will be applied to any items already in
+     *                                              the queue.
+     */
+    public function setFilter(?TelemetryFilterInterface $filter, bool $apply = true): void
+    {
+        $this->filter = $filter;
+        if (null === $filter || !$apply) {
+            return;
+        }
+        $tempQueue = [];
+        $filtered = 0;
+        foreach ($this->queue as $event) {
+            // The queue size needs to be calculated as the number of events in the queue minus the number of events
+            // that have already been filtered.
+            if (!$this->filter->include($event, count($this->queue) - $filtered)) {
+                $filtered++;
+                continue;
+            }
+            $tempQueue[] = $event;
+        }
+        $this->queue = $tempQueue;
+    }
+
+    /**
+     * Returns true if a Rollbar captured item that has been ignored should still be included in the telemetry data.
+     *
+     * @return bool
+     */
+    public function shouldIncludeIgnoredItemsInTelemetry(): bool
+    {
+        return $this->includeIgnoredItemsInTelemetry;
+    }
+
+    /**
+     * Sets whether items captured by Rollbar should be included in the telemetry data even if they are ignored.
+     *
+     * @param bool $include True to include ignored items in the telemetry data.
+     * @return void
+     */
+    public function setIncludeIgnoredItemsInTelemetry(bool $include): void
+    {
+        $this->includeIgnoredItemsInTelemetry = $include;
+    }
+
+    /**
+     * Returns the message from a Rollbar reported item.
+     *
+     * @param string|Stringable|Throwable $message The message to log.
+     *
+     * @return string
+     */
+    private function getRollbarItemMessage(string|Stringable|Throwable $message): string
+    {
+        if (is_string($message)) {
+            return $message;
+        }
+        if ($message instanceof Throwable) {
+            return $message->getMessage();
+        }
+        // else $message is a Stringable instance
+        return $message->__toString();
+    }
+
+    /**
+     * Given a standard PHP backtrace array, returns a string representation of the backtrace.
+     *
+     * @param array $backtrace The backtrace array.
+     * @return string
+     */
+    private function stringifyBacktrace(array $backtrace): string
+    {
+        $result = '';
+        foreach ($backtrace as $i => $frame) {
+            $result .= '#' . $i . ' ';
+            $result .= $frame['class'] ?? '';
+            $result .= $frame['type'] ?? '';
+            $result .= $frame['function'] ?? '';
+            if (isset($frame['args'])) {
+                $result .= '(';
+                $result .= implode(', ', array_map(fn($arg) => is_string($arg) ? $arg : gettype($arg), $frame['args']));
+                $result .= ')';
+            }
+            $result .= ' at ';
+            $result .= $frame['file'] ?? '';
+            $result .= ':';
+            $result .= $frame['line'] ?? '';
+            $result .= "\n";
+        }
+        return $result;
+    }
+}

--- a/src/Telemetry/TelemetryFilterInterface.php
+++ b/src/Telemetry/TelemetryFilterInterface.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Rollbar\Telemetry;
+
+use Rollbar\Payload\TelemetryEvent;
+use Stringable;
+
+/**
+ * The TelemetryFilterInterface allows you to filter telemetry events from the reporting events sent to Rollbar.
+ *
+ * An optional constructor can be included in the implementing class. The constructor should accept a single array
+ * argument. The value of the argument will be the value of `telemetry` from the configs array, or an empty array if
+ * the `telemetry` key does not exist.
+ *
+ * A new instance of the filter will be created any time the configuration is changed.
+ *
+ * @since 4.1.0
+ */
+interface TelemetryFilterInterface
+{
+    /**
+     * Filter the given telemetry event.
+     *
+     * This method may be called multiple times for the same event, so it should be idempotent. It also may be called
+     * before an event is added to the queue, and then again before the event is sent to Rollbar.
+     *
+     * @param TelemetryEvent $event     The telemetry event to include or exclude from the telemetry data.
+     * @param int            $queueSize The current size of the telemetry queue.
+     *
+     * @return bool True if the event should be included in the telemetry queue, false if it should be excluded.
+     */
+    public function include(TelemetryEvent $event, int $queueSize): bool;
+
+    /**
+     * Filter if a Rollbar captured or reported item should be included in the telemetry data.
+     *
+     * This method will be called prior to the {@see include()} method for captured or reported items. If this method
+     * returns `false`, then the item will not be included in the telemetry data. However, it may still be sent to
+     * Rollbar as the main reported item. To prevent the item from being sent to Rollbar at all, you should also
+     * implement the {@see \Rollbar\FilterInterface} and return `false` from the
+     * {@see \Rollbar\FilterInterface::shouldSend()} method.
+     *
+     * This method is called before {@see \Rollbar\FilterInterface::shouldSend()} and so the `$ignored` parameter will
+     * only reflect the internal filtering based on the minimum log level and PHP error reporting level.
+     *
+     * This method will not be called in two scenarios:
+     *
+     * 1. Rollbar items in telemetry data are disabled by setting the `telemetry => includeItemsInTelemetry` config
+     *    option to `false`.
+     * 2. Ignored Rollbar items are not included in the telemetry data by changing the default value of the
+     *    `telemetry => includeIgnoredItemsInTelemetry` config option to `true`. And the reported item is ignored
+     *    because of its log level or PHP error reporting level.
+     *
+     * @param string            $level   The PSR-3 log level.
+     * @param string|Stringable $message The message to log.
+     * @param array             $context The context.
+     * @param bool              $ignored Whether the item was ignored as a result of the configuration. If false, then
+     *                                   the item will not be sent to Rollbar. However, you may still want to include
+     *                                   it in the telemetry data.
+     *
+     * @return bool True if the item should be included in the telemetry queue, false if it should be excluded.
+     */
+    public function includeRollbarItem(
+        string $level,
+        string|Stringable $message,
+        array $context = [],
+        bool $ignored = false,
+    ): bool;
+
+    /**
+     * Returns `true` if the {@see include()} method should be called not only before the event is added to the queue,
+     * but also before the event is sent to Rollbar. This means the {@see include()} method will be called twice for
+     * each event.
+     *
+     * If this method returns `false`, then the {@see include()} method will only be called before the event is added to
+     * the queue.
+     *
+     * @return bool
+     */
+    public function filterOnRead(): bool;
+}

--- a/src/Truncation/TelemetryStrategy.php
+++ b/src/Truncation/TelemetryStrategy.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Rollbar\Truncation;
+
+use Exception;
+use Rollbar\Payload\EncodedPayload;
+use Rollbar\Rollbar;
+
+/**
+ * Truncation strategy for telemetry in payloads.
+ *
+ * @since 4.1.0
+ */
+class TelemetryStrategy extends AbstractStrategy
+{
+    /**
+     * The number of telemetry events to keep at the beginning and end of the telemetry array.
+     */
+    const TELEMETRY_OPTIMIZATION_RANGE = 5;
+
+    /**
+     * Removes telemetry events from the middle of the telemetry array. Will keep the number of telemetry events
+     * specified by $range at the start and end of the array.
+     *
+     * @param array $telemetry The list of telemetry events.
+     * @param int   $range     The number of telemetry events to keep on each end of the telemetry array.
+     * @return array
+     *
+     * @since 4.1.0
+     */
+    public static function selectTelemetry(array $telemetry, int $range = self::TELEMETRY_OPTIMIZATION_RANGE): array
+    {
+        if (count($telemetry) <= $range * 2) {
+            return $telemetry;
+        }
+
+        return array_merge(
+            array_slice($telemetry, 0, $range),
+            array_slice($telemetry, -$range)
+        );
+    }
+
+    /**
+     * Truncates the data in the payload by removing excess telemetry events from the middle of the telemetry array.
+     *
+     * @param EncodedPayload $payload The payload to truncate.
+     * @return EncodedPayload
+     *
+     * @throws Exception If the payload encoding fails.
+     *
+     * @since 4.1.0
+     */
+    public function execute(EncodedPayload $payload): EncodedPayload
+    {
+        $data = $payload->data();
+
+        // If telemetry is not enabled, then remove the telemetry data from the payload entirely.
+        if (null === Rollbar::getTelemeter()) {
+            unset($data['data']['body']['telemetry']);
+            $payload->encode($data);
+            return $payload;
+        }
+
+        if (!isset($data['data']['body']['telemetry'])) {
+            return $payload;
+        }
+
+        $data['data']['body']['telemetry'] = self::selectTelemetry($data['data']['body']['telemetry']);
+        $payload->encode($data);
+
+        return $payload;
+    }
+
+    /**
+     * Returns true if the given payload contains telemetry data. This is irrespective of whether the telemetry is
+     * enabled or not.
+     *
+     * @param EncodedPayload $payload The payload to truncate.
+     *
+     * @return bool
+     *
+     * @since 4.1.0
+     */
+    public function applies(EncodedPayload $payload): bool
+    {
+        // If the payload does not telemetry data, then this strategy does not apply.
+        return isset($payload->data()['data']['body']['telemetry']);
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -404,12 +404,18 @@ class ConfigTest extends BaseRollbarTest
 
     public function testReportSuppressedActuallySuppressed()
     {
+        // To make sure that the suppression actually works, we need to reset the error_reporting.
+        $oldErrorReporting = error_reporting(E_ALL);
+
         $config = new Config(array(
             'report_suppressed' => false,
             "access_token" => $this->getTestAccessToken()
         ));
         $this->assertFalse($config->shouldSuppress());
         $this->assertTrue(@$config->shouldSuppress());
+
+        // Reset the error_reporting to its original value.
+        error_reporting($oldErrorReporting);
     }
 
     public function testFilter(): void

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -5,6 +5,7 @@ use Rollbar\Defaults;
 use Rollbar\Payload\Level;
 use Rollbar\Payload\Notifier;
 use Psr\Log\LogLevel;
+use Rollbar\Telemetry\Telemeter;
 use Throwable;
 
 class DefaultsTest extends BaseRollbarTest
@@ -282,6 +283,50 @@ class DefaultsTest extends BaseRollbarTest
     public function testRaiseOnError(): void
     {
         $this->assertEquals(false, $this->defaults->raiseOnError());
+    }
+
+    public function testTelemetry(): void
+    {
+        $this->assertSame([
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => null,
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => false,
+        ], $this->defaults->telemetry(true));
+
+        $this->assertSame([
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => null,
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => false,
+        ], $this->defaults->telemetry([]));
+
+        $this->assertNull($this->defaults->telemetry(null));
+        $this->assertNull($this->defaults->telemetry(false));
+
+        $this->assertSame([
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => null,
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => false,
+        ], $this->defaults->telemetry(['foo' => 'bar']));
+
+        $this->assertSame([
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => null,
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => true,
+        ], $this->defaults->telemetry([
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => true,
+        ]));
+
+        $this->assertSame([
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => 'foo',
+            'includeItemsInTelemetry' => true,
+            'includeIgnoredItemsInTelemetry' => false,
+        ], $this->defaults->telemetry(['filter' => 'foo']));
     }
 
     /**

--- a/tests/Payload/TelemetryBodyTest.php
+++ b/tests/Payload/TelemetryBodyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Payload;
+
+use Rollbar\BaseRollbarTest;
+use Rollbar\Payload\TelemetryBody;
+
+class TelemetryBodyTest extends BaseRollbarTest
+{
+    public function testConstruct(): void
+    {
+        $body = new TelemetryBody(
+            message: 'message',
+            method: 'method',
+            url: 'url',
+            status_code: 'status',
+            subtype: 'sub',
+            stack: 'stack',
+            from: 'from',
+            to: 'to',
+            start_timestamp_ms: 42,
+            end_timestamp_ms: 43,
+            extraOne: 'foo',
+            extraTwo: 'bar',
+        );
+
+        self::assertSame('message', $body->message);
+        self::assertSame('method', $body->method);
+        self::assertSame('url', $body->url);
+        self::assertSame('status', $body->status_code);
+        self::assertSame('sub', $body->subtype);
+        self::assertSame('stack', $body->stack);
+        self::assertSame('from', $body->from);
+        self::assertSame('to', $body->to);
+        self::assertSame(42, $body->start_timestamp_ms);
+        self::assertSame(43, $body->end_timestamp_ms);
+        self::assertSame([
+            'extraOne' => 'foo',
+            'extraTwo' => 'bar',
+        ], $body->extra);
+
+        // Assert array order does not matter.
+        $body = new TelemetryBody(...[
+            'message' => 'message',
+            'extraOne' => 'foo',
+            'stack' => 'stack',
+        ]);
+
+        self::assertSame('message', $body->message);
+        self::assertSame('foo', $body->extra['extraOne']);
+        self::assertSame('stack', $body->stack);
+    }
+
+    public function testSerialize(): void
+    {
+        $body = new TelemetryBody(
+            message: 'message',
+            method: 'method',
+            url: 'url',
+            status_code: 'status',
+            subtype: 'sub',
+            stack: 'stack',
+            from: 'from',
+            to: 'to',
+            start_timestamp_ms: 42,
+            end_timestamp_ms: 43,
+            extraOne: 'foo',
+            extraTwo: 'bar',
+        );
+
+        self::assertSame([
+            'message' => 'message',
+            'method' => 'method',
+            'url' => 'url',
+            'status_code' => 'status',
+            'subtype' => 'sub',
+            'stack' => 'stack',
+            'from' => 'from',
+            'to' => 'to',
+            'start_timestamp_ms' => 42,
+            'end_timestamp_ms' => 43,
+            'extraOne' => 'foo',
+            'extraTwo' => 'bar',
+        ], $body->serialize());
+    }
+
+    public function testEmptyProperties(): void
+    {
+        $body = new TelemetryBody();
+        self::assertEmpty($body->serialize());
+    }
+
+    public function testExtraDoesNotOverrideProperty(): void
+    {
+        $body = new TelemetryBody(message: 'foo');
+        $body->extra['message'] = 'bar';
+
+        self::assertSame(['message' => 'foo'], $body->serialize());
+    }
+}

--- a/tests/Payload/TelemetryEventTest.php
+++ b/tests/Payload/TelemetryEventTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Payload;
+
+use Rollbar\BaseRollbarTest;
+use Rollbar\Payload\TelemetryEvent;
+use Rollbar\Telemetry\DataType;
+
+class TelemetryEventTest extends BaseRollbarTest
+{
+    public function testConstruct(): void
+    {
+        // Make sure the timestamp is automatically created if it is null.
+        $before = floor(microtime(true) * 1000);
+        $event = new TelemetryEvent(DataType::LOG, 'info', ['message' => 'foo']);
+        $after = floor(microtime(true) * 1000);
+
+        self::assertNotNull($event->timestamp);
+        self::assertGreaterThanOrEqual($before, $event->timestamp);
+        self::assertLessThanOrEqual($after, $event->timestamp);
+    }
+}

--- a/tests/RollbarLoggerTest.php
+++ b/tests/RollbarLoggerTest.php
@@ -193,6 +193,22 @@ class RollbarLoggerTest extends BaseRollbarTest
         $this->assertEquals(200, $response->getStatus());
     }
 
+    public function testReportTelemetry(): void
+    {
+        // Init used so that the telemeter is initialized.
+        Rollbar::init([
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => "testing-php",
+        ]);
+
+        Rollbar::logger()->report(Level::WARNING, "Testing PHP Notifier", isUncaught: true);
+        $events = Rollbar::getTelemeter()->copyEvents();
+        $this->assertCount(1, $events);
+        $this->assertSame($events[0]->type, 'error');
+        $this->assertSame($events[0]->level, 'warning');
+        $this->assertSame($events[0]->body->message, 'Testing PHP Notifier');
+    }
+
     public function testDefaultVerbose(): void
     {
         $this->testNotVerbose();

--- a/tests/Telemetry/TelemeterTest.php
+++ b/tests/Telemetry/TelemeterTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Rollbar\Telemetry;
+
+use Closure;
+use Exception;
+use Rollbar\BaseRollbarTest;
+use Rollbar\Payload\Level;
+use Rollbar\Payload\TelemetryBody;
+use Rollbar\Payload\TelemetryEvent;
+use Rollbar\TestHelpers\TestTelemetryFilter;
+
+class TelemeterTest extends BaseRollbarTest
+{
+    public function testMaxEventConstrains(): void
+    {
+        $telemeter = new Telemeter(-5);
+        self::assertSame(0, $telemeter->getMaxQueueSize());
+
+        $telemeter = new Telemeter(42);
+        self::assertSame(42, $telemeter->getMaxQueueSize());
+
+        $telemeter = new Telemeter(105);
+        self::assertSame(100, $telemeter->getMaxQueueSize());
+    }
+
+    public function testScope(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertSame(100, $telemeter->getMaxQueueSize());
+        self::assertNull($telemeter->getFilter());
+        self::assertTrue($telemeter->shouldIncludeItemsInTelemetry());
+        self::assertFalse($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+
+        $telemeter->scope(42, new TestTelemetryFilter(), false, true);
+        self::assertSame(42, $telemeter->getMaxQueueSize());
+        self::assertInstanceOf(TestTelemetryFilter::class, $telemeter->getFilter());
+        self::assertFalse($telemeter->shouldIncludeItemsInTelemetry());
+        self::assertTrue($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+    }
+
+    public function testPush(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertSame(100, $telemeter->getMaxQueueSize());
+        self::assertSame(0, $telemeter->getQueueSize());
+
+        $telemeter->push(new TelemetryEvent(DataType::LOG, 'info', ['message' => 'foo']));
+        self::assertSame(1, $telemeter->getQueueSize());
+
+        $telemeter->push(new TelemetryEvent(DataType::LOG, 'info', new TelemetryBody('bar')));
+        self::assertSame(2, $telemeter->getQueueSize());
+    }
+
+    public function testCopyEvents(): void
+    {
+        $telemeter = new Telemeter();
+
+        $event1 = new TelemetryEvent(DataType::LOG, 'info', ['message' => 'foo']);
+        $event2 = new TelemetryEvent(DataType::LOG, 'info', new TelemetryBody('bar'));
+
+        $telemeter->push($event1);
+        $telemeter->push($event2);
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(2, count($events));
+        self::assertSame($event1, $events[0]);
+        self::assertSame($event2, $events[1]);
+    }
+
+    public function testCopyEventsFilter(): void
+    {
+        $filter = new TestTelemetryFilter();
+        $filter->includeFunction = Closure::fromCallable(function (TelemetryEvent $event, int $queueSize): bool {
+            return $event->body->message !== 'foo';
+        });
+
+        $telemeter = new Telemeter(filter: $filter);
+
+        $event1 = new TelemetryEvent(DataType::LOG, 'info', ['message' => 'foo']);
+        $event2 = new TelemetryEvent(DataType::LOG, 'info', new TelemetryBody('bar'));
+
+        $telemeter->push($event1);
+        $telemeter->push($event2);
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame($event2, $events[0]);
+    }
+
+    public function testCapture(): void
+    {
+        $telemeter = new Telemeter();
+        $telemeter->capture(DataType::LOG, 'info', ['message' => 'foo']);
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame('foo', $events[0]->body->message);
+        self::assertSame('info', $events[0]->level);
+        self::assertSame(DataType::LOG, $events[0]->type);
+        self::assertNotNull($events[0]->timestamp);
+    }
+
+    public function testCaptureFilter(): void
+    {
+        $filter = new TestTelemetryFilter();
+        $filter->includeFunction = Closure::fromCallable(function (TelemetryEvent $event, int $queueSize): bool {
+            return $event->body->message !== 'foo';
+        });
+
+        $telemeter = new Telemeter(filter: $filter);
+        $telemeter->capture(DataType::LOG, 'info', ['message' => 'foo']);
+        $telemeter->capture(DataType::LOG, 'info', ['message' => 'bar']);
+
+        // Because the filter is also applied on the copyEvents() call, we want to make sure that the 'foo' event is
+        // filtered out, but the 'bar' event is not.
+        self::assertSame(1, $telemeter->getQueueSize());
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame('bar', $events[0]->body->message);
+    }
+
+    public function testCaptureError(): void
+    {
+        $telemeter = new Telemeter();
+        $telemeter->captureError('foo');
+        $telemeter->captureError(['message' => 'bar'], 'warning');
+        $telemeter->captureError(['message' => 'baz'], 'critical');
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(3, count($events));
+        self::assertSame('foo', $events[0]->body->message);
+        self::assertSame('error', $events[0]->type);
+        self::assertSame('error', $events[0]->level);
+
+        self::assertSame('bar', $events[1]->body->message);
+        self::assertSame('error', $events[1]->type);
+        self::assertSame('warning', $events[1]->level);
+
+        self::assertSame('baz', $events[2]->body->message);
+        self::assertSame('error', $events[2]->type);
+        self::assertSame('critical', $events[2]->level);
+    }
+
+    public function testCaptureLog(): void
+    {
+        $telemeter = new Telemeter();
+        $telemeter->captureLog('foo');
+        $telemeter->captureLog('bar', 'debug');
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(2, count($events));
+        self::assertSame('foo', $events[0]->body->message);
+        self::assertSame('log', $events[0]->type);
+        self::assertSame('info', $events[0]->level);
+
+        self::assertSame('bar', $events[1]->body->message);
+        self::assertSame('log', $events[1]->type);
+        self::assertSame('debug', $events[1]->level);
+    }
+
+    public function testCaptureNetwork(): void
+    {
+        $telemeter = new Telemeter();
+        $telemeter->captureNetwork('POST', 'https://example.com', '200');
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame('POST', $events[0]->body->method);
+        self::assertSame('https://example.com', $events[0]->body->url);
+        self::assertSame('200', $events[0]->body->status_code);
+    }
+
+    public function testCaptureNavigation(): void {
+        $telemeter = new Telemeter();
+        $telemeter->captureNavigation('https://example.com/foo', 'https://example.com/bar');
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame('https://example.com/foo', $events[0]->body->from);
+        self::assertSame('https://example.com/bar', $events[0]->body->to);
+    }
+
+    public function testCaptureRollbarItem(): void
+    {
+        // Test exclude Rollbar captured item.
+        $telemeter = new Telemeter(includeItemsInTelemetry: false);
+        self::assertNull($telemeter->captureRollbarItem(Level::INFO, 'foo'));
+
+        // Test exclude ignored Rollbar item.
+        $telemeter = new Telemeter(includeIgnoredItemsInTelemetry: false);
+        self::assertNull($telemeter->captureRollbarItem(Level::INFO, 'foo', ignored: true));
+
+        // Test non-ignored Rollbar item not excluded.
+        $event = $telemeter->captureRollbarItem(Level::INFO, 'bar');
+        self::assertSame($event->body->message, 'bar');
+
+        // Test a Throwable in the $context['exception'] is treated as an error.
+        $telemeter = new Telemeter();
+        $error = new Exception('oops');
+        $event = $telemeter->captureRollbarItem(Level::DEBUG, 'baz', context: ['exception' => $error]);
+        self::assertSame(DataType::ERROR, $event->type);
+        self::assertSame('oops', $event->body->extra['error_message']);
+        self::assertSame('baz', $event->body->message);
+
+        // Test a Throwable $message is treated as an error
+        $event = $telemeter->captureRollbarItem(Level::DEBUG, $error);
+        self::assertSame(DataType::ERROR, $event->type);
+        self::assertSame('oops', $event->body->message);
+
+        // Test telemetry type dynamically determined from the Rollbar level.
+        self::assertSame(DataType::ERROR, $telemeter->captureRollbarItem(Level::EMERGENCY, 'foo')->type);
+        self::assertSame(DataType::ERROR, $telemeter->captureRollbarItem(Level::ALERT, 'foo')->type);
+        self::assertSame(DataType::ERROR, $telemeter->captureRollbarItem(Level::CRITICAL, 'foo')->type);
+        self::assertSame(DataType::ERROR, $telemeter->captureRollbarItem(Level::ERROR, 'foo')->type);
+        self::assertSame(DataType::ERROR, $telemeter->captureRollbarItem(Level::WARNING, 'foo')->type);
+        self::assertSame(DataType::LOG, $telemeter->captureRollbarItem(Level::NOTICE, 'foo')->type);
+        self::assertSame(DataType::LOG, $telemeter->captureRollbarItem(Level::INFO, 'foo')->type);
+        self::assertSame(DataType::MANUAL, $telemeter->captureRollbarItem(Level::DEBUG, 'foo')->type);
+        self::assertSame(DataType::MANUAL, $telemeter->captureRollbarItem('bar', 'foo')->type);
+
+        // Test telemetry level dynamically determined from the Rollbar level.
+        self::assertSame('critical', $telemeter->captureRollbarItem(Level::EMERGENCY, 'foo')->level);
+        self::assertSame('critical', $telemeter->captureRollbarItem(Level::ALERT, 'foo')->level);
+        self::assertSame('critical', $telemeter->captureRollbarItem(Level::CRITICAL, 'foo')->level);
+        self::assertSame('error', $telemeter->captureRollbarItem(Level::ERROR, 'foo')->level);
+        self::assertSame('warning', $telemeter->captureRollbarItem(Level::WARNING, 'foo')->level);
+        self::assertSame('info', $telemeter->captureRollbarItem(Level::NOTICE, 'foo')->level);
+        self::assertSame('info', $telemeter->captureRollbarItem(Level::INFO, 'foo')->level);
+        self::assertSame('debug', $telemeter->captureRollbarItem(Level::DEBUG, 'foo')->level);
+        self::assertSame('info', $telemeter->captureRollbarItem('bar', 'foo')->level);
+    }
+
+    public function testGetMaxQueueSize(): void
+    {
+        $telemeter = new Telemeter(42);
+        self::assertSame(42, $telemeter->getMaxQueueSize());
+    }
+
+    public function testSetMaxQueueSize(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertSame(100, $telemeter->getMaxQueueSize());
+
+        $telemeter->setMaxQueueSize(10);
+        self::assertSame(10, $telemeter->getMaxQueueSize());
+
+        foreach (range(1, 10) as $i) {
+            $telemeter->captureLog('foo' . $i);
+        }
+
+        self::assertSame(10, $telemeter->getQueueSize());
+
+        $telemeter->setMaxQueueSize(5);
+        self::assertSame(5, $telemeter->getMaxQueueSize());
+        self::assertSame(5, $telemeter->getQueueSize());
+    }
+
+    public function testGetQueueSize(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertSame(0, $telemeter->getQueueSize());
+
+        $telemeter->captureLog('foo');
+        self::assertSame(1, $telemeter->getQueueSize());
+
+        $telemeter->captureLog('bar');
+        self::assertSame(2, $telemeter->getQueueSize());
+    }
+
+    public function testClearQueue(): void
+    {
+        $telemeter = new Telemeter();
+        $telemeter->captureLog('foo');
+        $telemeter->captureLog('bar');
+
+        self::assertSame(2, $telemeter->getQueueSize());
+        $telemeter->clearQueue();
+        self::assertSame(0, $telemeter->getQueueSize());
+    }
+
+    public function testShouldIncludeItemsInTelemetry(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertTrue($telemeter->shouldIncludeItemsInTelemetry());
+
+        $telemeter = new Telemeter(includeItemsInTelemetry: false);
+        self::assertFalse($telemeter->shouldIncludeItemsInTelemetry());
+    }
+
+    public function testSetIncludeItemsInTelemetry(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertTrue($telemeter->shouldIncludeItemsInTelemetry());
+
+        $telemeter->setIncludeItemsInTelemetry(false);
+        self::assertFalse($telemeter->shouldIncludeItemsInTelemetry());
+
+        $telemeter->setIncludeItemsInTelemetry(true);
+        self::assertTrue($telemeter->shouldIncludeItemsInTelemetry());
+    }
+
+    public function testGetFilter(): void
+    {
+        $filter = new TestTelemetryFilter();
+        $filter->includeFunction = Closure::fromCallable(function (TelemetryEvent $event, int $queueSize): bool {
+            return $event->body->message !== 'foo';
+        });
+        $telemeter = new Telemeter(filter: $filter);
+        self::assertSame($filter, $telemeter->getFilter());
+    }
+
+    public function testSetFilter(): void
+    {
+        $filter = new TestTelemetryFilter();
+        $filter->includeFunction = Closure::fromCallable(function (TelemetryEvent $event, int $queueSize): bool {
+            return $event->body->message !== 'foo';
+        });
+        $telemeter = new Telemeter();
+        self::assertNull($telemeter->getFilter());
+
+        $telemeter->setFilter($filter);
+        self::assertSame($filter, $telemeter->getFilter());
+    }
+
+    public function testShouldIncludeIgnoredItemsInTelemetry(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertFalse($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+
+        $telemeter = new Telemeter(includeIgnoredItemsInTelemetry: false);
+        self::assertFalse($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+
+        $telemeter = new Telemeter(includeIgnoredItemsInTelemetry: true);
+        self::assertTrue($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+    }
+
+    public function testSetIncludeIgnoredItemsInTelemetry(): void
+    {
+        $telemeter = new Telemeter();
+        self::assertFalse($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+
+        $telemeter->setIncludeIgnoredItemsInTelemetry(true);
+        self::assertTrue($telemeter->shouldIncludeIgnoredItemsInTelemetry());
+    }
+
+    public function testSetFilterWithFilterableEvents(): void
+    {
+        $filter = new TestTelemetryFilter();
+        $filter->includeFunction = Closure::fromCallable(function (TelemetryEvent $event, int $queueSize): bool {
+            return $event->body->message !== 'foo';
+        });
+        $telemeter = new Telemeter();
+
+        $event1 = new TelemetryEvent(DataType::LOG, 'info', ['message' => 'foo']);
+        $event2 = new TelemetryEvent(DataType::LOG, 'info', new TelemetryBody('bar'));
+
+        $telemeter->push($event1);
+        $telemeter->push($event2);
+
+        $telemeter->setFilter($filter);
+
+        $events = $telemeter->copyEvents();
+        self::assertSame(1, count($events));
+        self::assertSame($event2, $events[0]);
+    }
+}

--- a/tests/Telemetry/TelemeterTest.php
+++ b/tests/Telemetry/TelemeterTest.php
@@ -172,7 +172,8 @@ class TelemeterTest extends BaseRollbarTest
         self::assertSame('200', $events[0]->body->status_code);
     }
 
-    public function testCaptureNavigation(): void {
+    public function testCaptureNavigation(): void
+    {
         $telemeter = new Telemeter();
         $telemeter->captureNavigation('https://example.com/foo', 'https://example.com/bar');
 

--- a/tests/TestHelpers/TestTelemetryFilter.php
+++ b/tests/TestHelpers/TestTelemetryFilter.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Rollbar\TestHelpers;
+
+use Closure;
+use Rollbar\Payload\TelemetryEvent;
+use Rollbar\Telemetry\TelemetryFilterInterface;
+use Stringable;
+
+class TestTelemetryFilter implements TelemetryFilterInterface
+{
+    public array $config;
+    public ?Closure $includeFunction = null;
+
+    public ?Closure $includeRollbarItemFunction = null;
+
+    public bool $filterOnRead = true;
+
+    /**
+     * @param array $config The telemetry config.
+     */
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function include(TelemetryEvent $event, int $queueSize): bool
+    {
+        return $this->includeFunction?->call($this, $event, $queueSize) ?? false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function includeRollbarItem(
+        string $level,
+        Stringable|string $message,
+        array $context = [],
+        bool $ignored = false,
+    ): bool {
+        return $this->includeRollbarItemFunction?->call($this, $level, $message, $context, $ignored) ?? false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function filterOnRead(): bool
+    {
+        return $this->filterOnRead;
+    }
+}

--- a/tests/Truncation/TelemetryStrategyTest.php
+++ b/tests/Truncation/TelemetryStrategyTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Rollbar\Truncation;
+
+use Rollbar\BaseRollbarTest;
+use Rollbar\Config;
+use Rollbar\Payload\EncodedPayload;
+use Rollbar\Rollbar;
+
+class TelemetryStrategyTest extends BaseRollbarTest
+{
+
+    public function setUp(): void
+    {
+        Rollbar::init([
+            'access_token' => $this->getTestAccessToken(),
+            'environment' => 'test',
+        ]);
+    }
+
+    /**
+     * @dataProvider executeProvider
+     */
+    public function testExecute(array $data, array $expected): void
+    {
+        $config = new Config(['access_token' => $this->getTestAccessToken()]);
+        $truncation = new Truncation($config);
+
+        $strategy = new TelemetryStrategy($truncation);
+
+        $data = new EncodedPayload($data);
+        $data->encode();
+
+        $result = $strategy->execute($data);
+
+        $this->assertEquals($expected, $result->data());
+    }
+
+    /**
+     * @return array
+     */
+    public static function executeProvider(): array
+    {
+        return [
+            'nothing to truncate: no telemetry data' => [
+                [
+                    'data' => [
+                        'body' => [],
+                    ],
+                ],
+                [
+                    'data' => [
+                        'body' => [],
+                    ],
+                ],
+            ],
+            'nothing to truncate: telemetry in range' => [
+                [
+                    'data' => [
+                        'body' => [
+                            'telemetry' => range(1, 6),
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        'body' => [
+                            'telemetry' => range(1, 6),
+                        ],
+                    ],
+                ],
+            ],
+            'truncate middle: telemetry too long' => [
+                [
+                    'data' => [
+                        'body' => [
+                            'telemetry' => range(1, TelemetryStrategy::TELEMETRY_OPTIMIZATION_RANGE * 2 + 1),
+                        ],
+                    ],
+                ],
+                [
+                    'data' => [
+                        'body' => [
+                            'telemetry' => array_merge(
+                                range(1, TelemetryStrategy::TELEMETRY_OPTIMIZATION_RANGE),
+                                range(
+                                    TelemetryStrategy::TELEMETRY_OPTIMIZATION_RANGE + 2,
+                                    TelemetryStrategy::TELEMETRY_OPTIMIZATION_RANGE * 2 + 1
+                                ),
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Description of the change

This is adds support for the Telemetry feature.

### Design decisions and overview of the change.

1. **Rollbar Items:** Occurrences and log items that are captured by the SDK's error monitoring or manually reported may be included in the telemetry data of subsequently reported items.
2. Telemetry is enabled by default.
3. The only telemetry events captured by the core SDK are the errors/logs reported or captured by the SDK prior to the current report. This means that if a non-fatal error occurs it will be included in the telemetry data a subsequent error as long as they both share the same process. Our packages for frameworks like Laravel or Symfony may choose to have some default telemetry events that are tailored for those frameworks, but there are none included in the core SDK by default.
   **Note:** some of our other programing language SDKs capture things like log messages and other items in the telemetry data as part of an auto instrumentation setup. Trying to do this in PHP would require messing with things that could break logging for end user applications. Since most projects will have some sort of logging built in this could easily be wired to the telemeter to capture debug logs etc. 
4. A custom filter can be created to reduce noise in the telemetry data if logs are being included.
5. To help reduce the size of large payloads being sent to the Rollbar backend an optional `TelemetryStrategy` truncation strategy has been included. This is not enabled by default but can be added if large telemetry sets are reducing the quality of the stack frame data.
6. The `Telemeter` instance is statically attached to the `Rollbar` class so that the telemetry data is preserved on reconfiguration of the SDK.
7. The telemetry data can be manually cleared if needed.
8. Setting the telemetry configuration to `null` or `false` or calling `Rollbar::destroy()` will remove the telemeter and all the events in the queue.

There are probably more details that are important. Feel free to ask questions in the comments.

### New configs

The `telemetry` key is now supported in the configs array. It can have any of the following values:

1. `null` or `false` will disable capturing and reporting of telemetry events.
2. `true` or `[]` will result in telemetry being enabled with the default settings.
3. An array of further configs can be provided.
   ```php
   Rollbar::init([
       // other configs
       'telemetry' => [
           'maxTelemetryEvents' => 100,
           'filter' => null,
           'includeItemsInTelemetry' => true,
           'includeIgnoredItemsInTelemetry' => false,
       ],
   ]);
   ```

`'maxTelemetryEvents'` `int` Should be the most events that will be retained or reported at any given time. If more events are captured they will be removed in a FIFO order. This defaults to `100`.

`'filter'` `null|string` This is a custom filter FQCN for a telemetry filter class that implements the `Rollbar\Telemetry\TelemetryFilterInterface` interface. See the extensive comments on `TelemetryFilterInterface` for implementation details. This defaults to `null`.

`'includeItemsInTelemetry'` `bool` Set to `true` to include errors, logs, and other items captured/reported to the SDK in the telemetry data of subsequent reports. If `false` they will not be included. This defaults to `true`.

`'includeIgnoredItemsInTelemetry'` `bool` Set to `true` to include items that have been ignored by the SDK in the telemetry data. This defaults to `false`.


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #349

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
