### PR TITLE
Fixed #480 IP could not resolve IPv6

### DIFF
--- a/src/Senders/CurlSender.php
+++ b/src/Senders/CurlSender.php
@@ -26,6 +26,7 @@ class CurlSender implements SenderInterface
     private $maxBatchRequests = 75;
     private $batchRequests = array();
     private $inflightRequests = array();
+    private $ipResolve = CURL_IPRESOLVE_V4;
 
     public function __construct($opts)
     {
@@ -53,6 +54,10 @@ class CurlSender implements SenderInterface
         }
         if (array_key_exists('ca_cert_path', $opts)) {
             $this->caCertPath = $opts['ca_cert_path'];
+        }
+        if (array_key_exists('ip_resolve', $opts)
+            && in_array($opts['ip_resolve'], [CURL_IPRESOLVE_V4, CURL_IPRESOLVE_V6, CURL_IPRESOLVE_WHATEVER])) {
+            $this->ipResolve = $opts['ip_resolve'];
         }
     }
     
@@ -151,7 +156,7 @@ class CurlSender implements SenderInterface
         curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($handle, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($handle, CURLOPT_HTTPHEADER, array('X-Rollbar-Access-Token: ' . $accessToken));
-        curl_setopt($handle, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+        curl_setopt($handle, CURLOPT_IPRESOLVE, $this->ipResolve);
 
         if (!is_null($this->caCertPath)) {
             curl_setopt($handle, CURLOPT_CAINFO, $this->caCertPath);

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -2,7 +2,10 @@
 
 namespace Rollbar;
 
+use ReflectionClass;
+use ReflectionException;
 use Rollbar\Payload\Level;
+use Rollbar\Senders\CurlSender;
 
 class CurlSenderTest extends BaseRollbarTest
 {
@@ -25,5 +28,44 @@ class CurlSenderTest extends BaseRollbarTest
                 "Empty reply from server"
             )
         );
+    }
+
+    /**
+     * This test will fail if the {@see CurlSender::$ipResolve} property is renamed or removed.
+     */
+    public function testIPResolve(): void
+    {
+        $sender = new CurlSender([
+            'ip_resolve' => CURL_IPRESOLVE_V4,
+        ]);
+        self::assertSame(CURL_IPRESOLVE_V4, self::getPrivateProperty($sender, 'ipResolve'));
+
+        $sender = new CurlSender([]);
+        self::assertSame(CURL_IPRESOLVE_V4, self::getPrivateProperty($sender, 'ipResolve'));
+
+        $sender = new CurlSender([
+            'ip_resolve' => CURL_IPRESOLVE_V6,
+        ]);
+        self::assertSame(CURL_IPRESOLVE_V6, self::getPrivateProperty($sender, 'ipResolve'));
+
+        $sender = new CurlSender([
+            'ip_resolve' => CURL_IPRESOLVE_WHATEVER,
+        ]);
+        self::assertSame(CURL_IPRESOLVE_WHATEVER, self::getPrivateProperty($sender, 'ipResolve'));
+    }
+
+    /**
+     * Returns the value of a private property of an object.
+     *
+     * @param object $object   The object from which to get the private property.
+     * @param string $property The name of the private property to get.
+     * @return mixed
+     * @throws ReflectionException If the object or property does not exist.
+     */
+    private static function getPrivateProperty(object $object, string $property): mixed
+    {
+        $reflection = new ReflectionClass($object);
+        $property = $reflection->getProperty($property);
+        return $property->getValue($object);
     }
 }

--- a/tests/CurlSenderTest.php
+++ b/tests/CurlSenderTest.php
@@ -66,6 +66,7 @@ class CurlSenderTest extends BaseRollbarTest
     {
         $reflection = new ReflectionClass($object);
         $property = $reflection->getProperty($property);
+        $property->setAccessible(true);
         return $property->getValue($object);
     }
 }


### PR DESCRIPTION
## Description of the change

This fixes issue #480. It adds an optional config parameter `ip_resolve` that can be given one of the `CURL_IPRESOLVE_*` constants. Unless this config parameter is included the SDK will function entirely as before resolving with IPv4. This is not a breaking change.

_Note: Unfortunately, the PHP curl extension does not allow the retrieval of the value of this option once set. There is also no clear and consistently testable side effect that could be tested without introducing flaky tests. I tried a couple different methods but was unable to get consistent results. Because of that no new tests have been written._

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #480

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
