### PR TITLE
Fixed PHP 8.4 deprecations.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -252,7 +252,7 @@ class Config
         }
 
         $levels = array(E_WARNING, E_NOTICE, E_USER_ERROR, E_USER_WARNING,
-            E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR);
+            E_USER_NOTICE, E_RECOVERABLE_ERROR);
         // PHP 5.3.0
         if (defined('E_DEPRECATED')) {
             $levels = array_merge($levels, array(E_DEPRECATED, E_USER_DEPRECATED));

--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -425,7 +425,7 @@ class DataBuilder implements DataBuilderInterface
      *
      * @return Trace|TraceChain
      */
-    public function getExceptionTrace(Throwable $exc, string|Stringable $message = null): Trace|TraceChain
+    public function getExceptionTrace(Throwable $exc, string|Stringable|null $message = null): Trace|TraceChain
     {
         $chain   = array();
         $chain[] = $this->makeTrace($exc, $this->includeExcCodeContext, message: $message);
@@ -460,7 +460,7 @@ class DataBuilder implements DataBuilderInterface
         Throwable $exception,
         bool $includeContext,
         ?string $classOverride = null,
-        string|Stringable $message = null,
+        string|Stringable|null $message = null,
     ): Trace {
         $frames = array();
         if ($this->captureErrorStacktraces) {

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -43,7 +43,6 @@ class Defaults
             E_USER_ERROR => "error",
             E_USER_WARNING => "warning",
             E_USER_NOTICE => "debug",
-            E_STRICT => "info",
             E_RECOVERABLE_ERROR => "error",
             E_DEPRECATED => "info",
             E_USER_DEPRECATED => "info"

--- a/src/ErrorWrapper.php
+++ b/src/ErrorWrapper.php
@@ -23,7 +23,6 @@ class ErrorWrapper extends \Exception
                 E_USER_ERROR => "E_USER_ERROR",
                 E_USER_WARNING => "E_USER_WARNING",
                 E_USER_NOTICE => "E_USER_NOTICE",
-                E_STRICT => "E_STRICT",
                 E_RECOVERABLE_ERROR => "E_RECOVERABLE_ERROR",
                 E_DEPRECATED => "E_DEPRECATED",
                 E_USER_DEPRECATED => "E_USER_DEPRECATED"

--- a/src/Rollbar.php
+++ b/src/Rollbar.php
@@ -421,7 +421,7 @@ class Rollbar
         string $type,
         string $level,
         array|TelemetryBody $metadata,
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         if (is_null(self::$logger)) {

--- a/src/RollbarLogger.php
+++ b/src/RollbarLogger.php
@@ -323,7 +323,7 @@ class RollbarLogger extends AbstractLogger
         string $type,
         string $level,
         array|TelemetryBody $metadata,
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         return Rollbar::getTelemeter()?->capture($type, $level, $metadata, $uuid, $timestamp);

--- a/src/Telemetry/Telemeter.php
+++ b/src/Telemetry/Telemeter.php
@@ -176,7 +176,7 @@ class Telemeter
         string $type,
         string $level,
         array|TelemetryBody $metadata,
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         if ($this->maxQueueSize === 0) {
@@ -213,7 +213,7 @@ class Telemeter
     public function captureError(
         array|string|ErrorWrapper|Throwable $error,
         string $level = 'error',
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         if (is_string($error)) {
@@ -253,7 +253,7 @@ class Telemeter
     public function captureLog(
         string $message,
         string $level = 'info',
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         return $this->capture('log', $level, new TelemetryBody(message: $message), $uuid, $timestamp);
@@ -278,7 +278,7 @@ class Telemeter
         string $url,
         string $status_code,
         string $level = 'info',
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         return $this->capture(
@@ -311,7 +311,7 @@ class Telemeter
         string $from,
         string $to,
         string $level = 'info',
-        string $uuid = null,
+        ?string $uuid = null,
         ?int $timestamp = null,
     ): ?TelemetryEvent {
         return $this->capture('log', $level, new TelemetryBody(from: $from, to: $to), $uuid, $timestamp);

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -78,14 +78,14 @@ final class Utilities
      * Serialize all, or the given keys, from the given object and store it
      * in this class's internal store (see self::$ObjectHashes).
      */
-    public static function serializeForRollbarInternal($obj, array $customKeys = null)
+    public static function serializeForRollbarInternal($obj, ?array $customKeys = null)
     {
         return self::serializeForRollbar($obj, $customKeys, self::$ObjectHashes);
     }
 
     public static function serializeForRollbar(
         $obj,
-        array $customKeys = null,
+        ?array $customKeys = null,
         &$objectHashes = array(),
         $maxDepth = -1,
         $depth = 0
@@ -141,7 +141,7 @@ final class Utilities
     
     private static function serializeObject(
         $obj,
-        array $customKeys = null,
+        ?array $customKeys = null,
         &$objectHashes = array(),
         $maxDepth = -1,
         $depth = 0

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -57,7 +57,6 @@ class DefaultsTest extends BaseRollbarTest
             E_USER_ERROR => "error",
             E_USER_WARNING => "warning",
             E_USER_NOTICE => "debug",
-            E_STRICT => "info",
             E_RECOVERABLE_ERROR => "error",
             E_DEPRECATED => "info",
             E_USER_DEPRECATED => "info"


### PR DESCRIPTION
## Description of the change

A few deprecation warnigns were raised as of PHP 8.4 in Rollbar. Namely the usage of `E_STRICT` (which was unused before 8.4) and implicitly marking nullable parameters as null. I've simply removed the usages of `E_STRICT` and added null types where they were missing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
