### PR TITLE
Added telemetry config filter to prevent invalid arguments.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -858,8 +858,18 @@ class Config
         if (null === $this->telemetry) {
             return null;
         }
+
         $config = $this->telemetry;
         $config['filter'] = $this->initTelemetryFilter($config['filter']);
+
+        // Filter out any invalid config options.
+        $config = array_intersect_key($config, [
+            'maxTelemetryEvents' => Telemeter::MAX_EVENTS,
+            'filter' => null,
+            'includeItemsInTelemetry' => false,
+            'includeIgnoredItemsInTelemetry' => false,
+        ]);
+
         if (null === $telemeter) {
             return new Telemeter(...$config);
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -853,7 +853,7 @@ class Config
      *
      * @since 4.1.0
      */
-    public function getTelemetry(?Telemeter $telemeter): ?Telemeter
+    public function getTelemetry(?Telemeter $telemeter = null): ?Telemeter
     {
         if (null === $this->telemetry) {
             return null;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,6 +12,7 @@ use Rollbar\Payload\Payload;
 use Rollbar\RollbarLogger;
 use Rollbar\Defaults;
 
+use Rollbar\Telemetry\Telemeter;
 use Rollbar\TestHelpers\CustomSerializable;
 use Rollbar\TestHelpers\DeprecatedSerializable;
 use Rollbar\TestHelpers\Exceptions\SilentExceptionSampleRate;
@@ -589,6 +590,34 @@ class ConfigTest extends BaseRollbarTest
         ));
         
         $this->assertTrue($config->getRaiseOnError());
+    }
+
+    public function testGetTelemetry(): void
+    {
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+        ));
+
+        $this->assertInstanceOf(Telemeter::class, $config->getTelemetry());
+
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "telemetry" => false,
+        ));
+
+        $this->assertNull($config->getTelemetry());
+
+        $config = new Config(array(
+            "access_token" => $this->getTestAccessToken(),
+            "environment" => $this->env,
+            "telemetry" => [
+                'invalidKey' => 'invalidValue'
+            ],
+        ));
+
+        $this->assertInstanceOf(Telemeter::class, $config->getTelemetry());
     }
 
     public function testSendMessageTrace(): void


### PR DESCRIPTION
## Description of the change

This adds a filter to ensure no invalid arguments are passed to the `Telemeter` constructor. In the case of a framework needing additional configuration options for telemetry, we need to keep those config options from being sent to the core `Telemeter` constructor

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
