### PR TITLE
Changed the `Telemeter::getLevelFromPsrLevel()` method from private to public.

### DIFF
--- a/src/Telemetry/Telemeter.php
+++ b/src/Telemetry/Telemeter.php
@@ -70,7 +70,7 @@ class Telemeter
      * @param string $level The PSR-3 log level.
      * @return EventLevel
      */
-    private static function getLevelFromPsrLevel(string $level): EventLevel
+    public static function getLevelFromPsrLevel(string $level): EventLevel
     {
         return match ($level) {
             Level::EMERGENCY, Level::ALERT, Level::CRITICAL => EventLevel::Critical,

--- a/tests/Telemetry/TelemeterTest.php
+++ b/tests/Telemetry/TelemeterTest.php
@@ -24,6 +24,18 @@ class TelemeterTest extends BaseRollbarTest
         self::assertSame(100, $telemeter->getMaxQueueSize());
     }
 
+    public function testGetLevelFromPsrLevel(): void
+    {
+        self::assertSame(EventLevel::Critical, Telemeter::getLevelFromPsrLevel(Level::EMERGENCY));
+        self::assertSame(EventLevel::Critical, Telemeter::getLevelFromPsrLevel(Level::ALERT));
+        self::assertSame(EventLevel::Critical, Telemeter::getLevelFromPsrLevel(Level::CRITICAL));
+        self::assertSame(EventLevel::Error, Telemeter::getLevelFromPsrLevel(Level::ERROR));
+        self::assertSame(EventLevel::Warning, Telemeter::getLevelFromPsrLevel(Level::WARNING));
+        self::assertSame(EventLevel::Info, Telemeter::getLevelFromPsrLevel(Level::NOTICE));
+        self::assertSame(EventLevel::Info, Telemeter::getLevelFromPsrLevel(Level::INFO));
+        self::assertSame(EventLevel::Debug, Telemeter::getLevelFromPsrLevel(Level::DEBUG));
+    }
+
     public function testScope(): void
     {
         $telemeter = new Telemeter();


### PR DESCRIPTION
## Description of the change

Changed the `Telemeter::getLevelFromPsrLevel()` method from private to public. This is needed for the Laravel service provider, and could be useful for anyone using the PSR log standard who wants to send logs to telemetry.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
