### PR TITLE
Added PHP 8.4 to CI tests and removed PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         # All the versions, OS, and dependency levels we want to support
         os: [ubuntu]         # TODO: windows, macos
-        php: [ '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
         dependency: [ stable ]
         # Our code has paths for with- and without- XDebug, and we want to test
         # both of them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,22 @@ jobs:
           key: ${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}-${{ matrix.dependency }}-
           restore-keys: ${{ matrix.os }}-composer-${{ matrix.dependency }}-
 
-      - name: Install dependencies
+      - name: Install dependencies PHP < 8.4
+        if: matrix.php != '8.4'
         run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction
 
-      - name: Execute tests
+      - name: Execute tests PHP < 8.4
+        if: matrix.php != '8.4'
         run: composer test
+
+      # This is a temporary workaround until vimeo/psalm is updated to support PHP 8.4.
+      # See https://github.com/vimeo/psalm/issues/11107
+      - name: Install dependencies PHP 8.4
+        if: matrix.php == '8.4'
+        run: composer update --prefer-${{ matrix.dependency }} --prefer-dist --no-interaction --ignore-platform-reqs
+
+      - name: Execute tests PHP 8.4
+        if: matrix.php == '8.4'
+        run: |
+          ./vendor/bin/phpcs --standard=PSR2 ./src ./tests
+          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         # @see https://xdebug.org/docs/all_settings#mode
         xdebug3-mode: ['develop,coverage', 'coverage']
         include:
-          - php: '8.0'
+          - php: '8.1'
             os: 'ubuntu'
             dependency: 'lowest'
             xdebug3-mode: 'develop,coverage'


### PR DESCRIPTION
## Description of the change

This PR adds PHP 8.4 to our test suite. However, it skips our static analysis with `vimeo/psalm` because a release that is compatible with PHP 8.4 has not been published yet. More details are here https://github.com/vimeo/psalm/issues/11107.

This PR also removes PHP 8.0 from our CI tests since we are dropping support for that version as it is no longer receiving any updates including security updates.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
