### PR TITLE
Fixed #648 TelemetryEvent cannot handle nested array as $body argument.

### DIFF
--- a/src/Payload/TelemetryBody.php
+++ b/src/Payload/TelemetryBody.php
@@ -71,6 +71,29 @@ class TelemetryBody implements SerializerInterface
     }
 
     /**
+     * Creates a {@see TelemetryBody} instance from an array of data.
+     *
+     * The data array may be loosely structured, as only the keys that match the defined keys will be used to create the
+     * instance. Any undefined keys in data will be stored in the {@see $extra} property.
+     *
+     * @param array $data The data to create the {@see TelemetryBody} instance from.
+     * @return self
+     *
+     * @since 4.1.1
+     */
+    public static function fromArray(array $data): self
+    {
+        // This filters out any keys that are not accepted by the constructor to prevent duplicate parameter errors from
+        // named and positional arguments.
+        $params = array_intersect_key($data, array_flip(self::DEFINED_KEYS));
+        // Generates an array of all the keys not used in the constructor.
+        $extra = array_diff_key($data, $params);
+        $instance = new self(...$params);
+        $instance->extra = $extra;
+        return $instance;
+    }
+
+    /**
      * Returns the array representation of the telemetry body.
      *
      * @return array

--- a/src/Payload/TelemetryEvent.php
+++ b/src/Payload/TelemetryEvent.php
@@ -47,7 +47,7 @@ class TelemetryEvent implements SerializerInterface
         if (is_null($this->timestamp)) {
             $this->timestamp = floor(microtime(true) * 1000);
         }
-        $this->body = is_array($body) ? new TelemetryBody(...$body): $body;
+        $this->body = is_array($body) ? TelemetryBody::fromArray($body): $body;
     }
 
     public function serialize(): array

--- a/tests/Payload/TelemetryBodyTest.php
+++ b/tests/Payload/TelemetryBodyTest.php
@@ -97,4 +97,55 @@ class TelemetryBodyTest extends BaseRollbarTest
 
         self::assertSame(['message' => 'foo'], $body->serialize());
     }
+
+    /**
+     * @since 4.1.1
+     */
+    public function testFromArray(): void
+    {
+        $body = TelemetryBody::fromArray([
+            'message' => 'message',
+            'method' => 'method',
+            'url' => 'url',
+            'status_code' => 'status',
+            'subtype' => 'sub',
+            'stack' => 'stack',
+            'from' => 'from',
+            'to' => 'to',
+            'start_timestamp_ms' => 42,
+            'end_timestamp_ms' => 43,
+            'extraOne' => 'foo',
+            'extraTwo' => 'bar',
+        ]);
+
+        self::assertSame('message', $body->message);
+        self::assertSame('method', $body->method);
+        self::assertSame('url', $body->url);
+        self::assertSame('status', $body->status_code);
+        self::assertSame('sub', $body->subtype);
+        self::assertSame('stack', $body->stack);
+        self::assertSame('from', $body->from);
+        self::assertSame('to', $body->to);
+        self::assertSame(42, $body->start_timestamp_ms);
+        self::assertSame(43, $body->end_timestamp_ms);
+        self::assertSame([
+            'extraOne' => 'foo',
+            'extraTwo' => 'bar',
+        ], $body->extra);
+    }
+
+    /**
+     * @since 4.1.1
+     */
+    public function testFromArrayNested(): void
+    {
+        // Assert that nested/non-standard arrays don't throw an error.
+        $body = TelemetryBody::fromArray([["data" => "some data"]]);
+        self::assertSame([["data" => "some data"]], $body->extra);
+
+        // Assert that positional arguments are not passed to named arguments on the constructor.
+        $body = TelemetryBody::fromArray(["0" => ["id" => "some id"], 'message' => 'test message']);
+        self::assertSame('test message', $body->message);
+        self::assertSame(["0" => ["id" => "some id"]], $body->extra);
+    }
 }

--- a/tests/Payload/TelemetryEventTest.php
+++ b/tests/Payload/TelemetryEventTest.php
@@ -20,4 +20,30 @@ class TelemetryEventTest extends BaseRollbarTest
         self::assertGreaterThanOrEqual($before, $event->timestamp);
         self::assertLessThanOrEqual($after, $event->timestamp);
     }
+
+    /**
+     * @since 4.1.1
+     */
+    public function testNestedArrayBody(): void
+    {
+        $event = new TelemetryEvent(EventType::Network, EventLevel::Info, [
+            'method' => 'GET',
+            'url' => 'https://example.com',
+            'status_code' => '200',
+            [
+                'unstructured' => 'data',
+                0 => 'foo',
+            ],
+        ]);
+
+        self::assertSame('GET', $event->body->method);
+        self::assertSame('https://example.com', $event->body->url);
+        self::assertSame('200', $event->body->status_code);
+        self::assertSame([
+            [
+                'unstructured' => 'data',
+                0 => 'foo',
+            ],
+        ], $event->body->extra);
+    }
 }


### PR DESCRIPTION
## Description of the change

This resolves an issue with the current creation of a `TelemetryBody` instance in `TelemetryEvent`. The core of the issue surrounds how the PHP spread operator (`...`) works when it is uesd to expand an array into a function's named arguments.

If an array has both string and numeric keys it can cause issues. The numeric keys are passed the the function as positional arguments. While the string keys are passed to the function as named arguments. If both a numeric key and a string key refer to the same argument PHP will throw and exception.

Consider the following example...

```php
$array = [
    0 => 'foo',
    'message' => 'bar',
];

function foo(string $message, string $other) {
    echo $message;
}

foo(...$array);
```

In this example both the `0` and `'message'` keys resolve to the first argument, which causes PHP to throw an exception.

Because we have been using the spread operator when the body of `TelemetryEvent` is an array we are experiancing the same issue. I am fixing this issue in this PR by adding a new `fromArray()` method on `TelemetryBody`. The new method is then used instead of the constructor for array bodys.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix #648
- SDK-455

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
