### PR TITLE
Fixed new 96 character access token fails validation.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -347,10 +347,10 @@ class Config
         }
 
         $this->utilities()->validateString(
-            $config['access_token'],
-            "config['access_token']",
-            32,
-            !$this->sender->requireAccessToken(),
+            input: $config['access_token'],
+            name: "config['access_token']",
+            len: [32, 96],
+            allowNull: !$this->sender->requireAccessToken(),
         );
         $this->accessToken = $config['access_token'] ?? '';
     }

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -13,12 +13,25 @@ final class Utilities
         return php_uname('s') == 'Windows NT';
     }
 
+    /**
+     * Validate that the given $input is a string or null if $allowNull is true and that it has as many characters as
+     * one of the given $len.
+     *
+     * @param mixed $input The value to validate.
+     * @param string $name The name of the variable being validated.
+     * @param int|int[]|null $len The length(s) to validate against. Can be a single integer or an array of integers.
+     * @param bool $allowNull Whether to allow null values.
+     * @return void
+     *
+     * @since 1.0.0
+     * @since 4.1.3 Added support for array of lengths.
+     */
     public static function validateString(
-        $input,
-        $name = "?",
-        $len = null,
-        $allowNull = true
-    ) {
+        mixed $input,
+        string $name = "?",
+        int|array $len = null,
+        bool $allowNull = true
+    ): void {
         if (is_null($input)) {
             if (!$allowNull) {
                 throw new \InvalidArgumentException("\$$name must not be null");
@@ -29,9 +42,19 @@ final class Utilities
         if (!is_string($input)) {
             throw new \InvalidArgumentException("\$$name must be a string");
         }
-        if (!is_null($len) && strlen($input) != $len) {
-            throw new \InvalidArgumentException("\$$name must be $len characters long, was '$input'");
+        if (null === $len) {
+            return;
         }
+        if (!is_array($len)) {
+            $len = [$len];
+        }
+        foreach ($len as $l) {
+            if (strlen($input) == $l) {
+                return;
+            }
+        }
+        $lens = implode(", ", $len);
+        throw new \InvalidArgumentException("\$$name must be $lens characters long, was '$input'");
     }
 
     public static function validateBoolean(

--- a/tests/UtilitiesTest.php
+++ b/tests/UtilitiesTest.php
@@ -38,6 +38,14 @@ class UtilitiesTest extends BaseRollbarTest
         } catch (\InvalidArgumentException $e) {
             $this->assertEquals("\$str must be 2 characters long, was '1'", $e->getMessage());
         }
+
+        try {
+            Utilities::validateString("foo", "str", [2, 4]);
+            $this->fail("Above should throw");
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals("\$str must be 2, 4 characters long, was 'foo'", $e->getMessage());
+        }
+        Utilities::validateString("four", "local", [2, 4]);
     }
 
     public function testValidateInteger(): void


### PR DESCRIPTION
## Description of the change

This resolves an issue with the validation of our new 96 character access tokens. We were previously requireing access tokens be 32 characters long. This PR fixes that by allowing either a 32 character or 96 character token.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix SDK-470

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
