### PR TITLE
Fixed #657 Param $len should not be implicitly nullable.

### DIFF
--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -29,7 +29,7 @@ final class Utilities
     public static function validateString(
         mixed $input,
         string $name = "?",
-        int|array $len = null,
+        int|array|null $len = null,
         bool $allowNull = true
     ): void {
         if (is_null($input)) {


### PR DESCRIPTION
## Description of the change

This PR resolves a deprecation in PHP 8.4 that requires paramaters to be explicitly nullable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fix #657
- SDK-475

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
