### PR TITLE
Fix: Body serialization should respect max_nesting_depth config

### DIFF
--- a/src/DataBuilder.php
+++ b/src/DataBuilder.php
@@ -59,6 +59,8 @@ class DataBuilder implements DataBuilderInterface
     protected $captureEmail;
     protected $captureUsername;
     
+    protected $maxNestingDepth;
+    
     /**
      * @var Utilities
      */
@@ -99,6 +101,7 @@ class DataBuilder implements DataBuilderInterface
         $this->setCustom($config);
         $this->setFingerprint($config);
         $this->setTitle($config);
+        $this->setMaxNestingDepth($config);
         $this->setNotifier($config);
         $this->setBaseException($config);
         $this->setIncludeCodeContext($config);
@@ -128,6 +131,12 @@ class DataBuilder implements DataBuilderInterface
     {
         $fromConfig = $config['capture_username'] ?? null;
         $this->captureUsername = self::$defaults->captureUsername($fromConfig);
+    }
+    
+    protected function setMaxNestingDepth($config)
+    {
+        $fromConfig = $config['max_nesting_depth'] ?? null;
+        $this->maxNestingDepth = self::$defaults->maxNestingDepth($fromConfig);
     }
 
     protected function setEnvironment($config)
@@ -411,7 +420,7 @@ class DataBuilder implements DataBuilderInterface
         } else {
             $content = $this->getMessage($toLog);
         }
-        return new Body($content, $context, $this->getTelemetry());
+        return new Body($content, $context, $this->getTelemetry(), $this->maxNestingDepth);
     }
 
     public function getErrorTrace(ErrorWrapper $error)

--- a/src/Payload/Body.php
+++ b/src/Payload/Body.php
@@ -23,7 +23,8 @@ class Body implements SerializerInterface
     public function __construct(
         private ContentInterface $value,
         private array $extra = [],
-        private ?array $telemetry = null
+        private ?array $telemetry = null,
+        private int $maxDepth = -1
     ) {
     }
 
@@ -122,6 +123,11 @@ class Body implements SerializerInterface
             $result['telemetry'] = $this->telemetry;
         }
 
-        return $this->utilities()->serializeForRollbarInternal($result, array('extra'));
+        if ($this->maxDepth === -1) {
+            return $this->utilities()->serializeForRollbarInternal($result, array('extra'));
+        } else {
+            $objectHashes = array();
+            return $this->utilities()->serializeForRollbar($result, array('extra'), $objectHashes, $this->maxDepth);
+        }
     }
 }

--- a/src/Payload/Body.php
+++ b/src/Payload/Body.php
@@ -125,9 +125,8 @@ class Body implements SerializerInterface
 
         if ($this->maxDepth === -1) {
             return $this->utilities()->serializeForRollbarInternal($result, array('extra'));
-        } else {
-            $objectHashes = array();
-            return $this->utilities()->serializeForRollbar($result, array('extra'), $objectHashes, $this->maxDepth);
         }
+        $objectHashes = array();
+        return $this->utilities()->serializeForRollbar($result, array('extra'), $objectHashes, $this->maxDepth);
     }
 }

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -59,7 +59,7 @@ class BodyTest extends BaseRollbarTest
         // Create deeply nested array that would cause memory issues
         $deepArray = array('level1' => array('level2' => array('level3' => array('level4' => 'deep_value'))));
         
-        // Test without depth limit - should serialize completely  
+        // Test without depth limit - should serialize completely
         $bodyNoLimit = new Body($value, array('deep' => $deepArray), null, -1);
         $resultNoLimit = $bodyNoLimit->serialize();
         

--- a/tests/BodyTest.php
+++ b/tests/BodyTest.php
@@ -46,4 +46,37 @@ class BodyTest extends BaseRollbarTest
             $encoded
         );
     }
+
+    public function testSerializeWithMaxNestingDepth(): void
+    {
+        $value = m::mock(ContentInterface::class)
+            ->shouldReceive("serialize")
+            ->andReturn("{CONTENT}")
+            ->shouldReceive("getKey")
+            ->andReturn("content_interface")
+            ->mock();
+        
+        // Create deeply nested array that would cause memory issues
+        $deepArray = array('level1' => array('level2' => array('level3' => array('level4' => 'deep_value'))));
+        
+        // Test without depth limit - should serialize completely  
+        $bodyNoLimit = new Body($value, array('deep' => $deepArray), null, -1);
+        $resultNoLimit = $bodyNoLimit->serialize();
+        
+        // Test with depth limit - should truncate deep nesting
+        $bodyWithLimit = new Body($value, array('deep' => $deepArray), null, 2);
+        $resultWithLimit = $bodyWithLimit->serialize();
+        
+        // Verify basic structure exists
+        $this->assertArrayHasKey('extra', $resultNoLimit);
+        $this->assertArrayHasKey('extra', $resultWithLimit);
+        
+        // Without limit should have all nested levels
+        $this->assertEquals('deep_value', $resultNoLimit['extra']['deep']['level1']['level2']['level3']['level4']);
+        
+        // With limit should truncate the 'deep' array due to depth constraint
+        // At depth 2: root -> extra -> deep (gets truncated to empty array)
+        $this->assertArrayHasKey('deep', $resultWithLimit['extra']);
+        $this->assertEmpty($resultWithLimit['extra']['deep']); // Truncated due to depth limit
+    }
 }


### PR DESCRIPTION
## Status
<img width="1562" height="452" alt="image" src="https://github.com/user-attachments/assets/532fa95e-f2a6-434b-92f1-d7d1c95121e2" />


- Add maxDepth parameter to Body constructor
- Update Body::serialize() to use maxDepth when calling serializeForRollbar
- Update DataBuilder to pass maxNestingDepth config to Body constructor
- Add test to verify deep nesting is properly truncated

This fixes memory exhaustion issues when logging errors with complex nested data structures (like Drupal form arrays) by respecting the configured max_nesting_depth limit during Body serialization.

Previously, Body::serialize() always used unlimited depth (-1) via serializeForRollbarInternal(), ignoring the max_nesting_depth config.

Fixes memory issues similar to those described in issue reports about Rollbar consuming excessive memory with deeply nested context data.

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
