### PR TITLE
Fixed #463 PII can be leaked if nested query string keys are out of order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Query strings no longer forced strings to have percent encoding.
+### Fixed 
+* Fixed #463 PII can be leaked if nested query string keys are out of order.
 
 ## [4.1.4] - 2025-09-26
 ### Fixed


### PR DESCRIPTION
## Description of the change

This PR resolves an issue where out of order nested query string values could fail to be properly scrubbed.

The reason was we were parsing then rebuilding the query string to see if they matched. If they did we would decode and scrub the string as if it was a query string.

However, this caused issues because the nested keys would be order together, when the encoded string did not strictly require that. This solves that problem by partially decoding the string and comparing that with the decoded and rebuilt query string with a sorted key order.

As part of this change we also no longer encode all query strings that we send in the payload in the RFC3986 percent encoding sytanx. Instead we send the query string with the more human readable non-encoded characters.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

- Fixed #463 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
